### PR TITLE
Added documentation for auto install via composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,25 @@ parameters:
 ### Set up basic configuration
 GrumPHP comes shipped with a configuration tool. Run following command to create a configuration file:
 ```
-php ./vendor/bin configure
+php ./vendor/bin/grumphp configure
 ```
 
 This command is also invoked during installation. 
 It wil not ask you for anything, but it will try to guess the best possible configuration.
+
+### Auto config via composer
+
+* Install GrumPHP as a composer dependency
+* Add `grumphp.yml` in your project
+* Add setup script to composer.json in `post-install-cmd` section
+
+```
+"scripts": {
+    "post-install-cmd": [
+        "php ./vendor/bin/grumphp git:init"
+    ]
+}
+```
 
 ### Parameters
 


### PR DESCRIPTION
It is hard to add `pre-commit` hook for each developer manually. I added to README how to install GrumPHP checks for each developer via `composer install` command.