### PR TITLE
Allow phpunit to resolve the default config

### DIFF
--- a/spec/GrumPHP/Task/PhpunitSpec.php
+++ b/spec/GrumPHP/Task/PhpunitSpec.php
@@ -37,7 +37,6 @@ class PhpunitSpec extends ObjectBehavior
     function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process)
     {
         $processBuilder->setArguments(Argument::type('array'))->shouldBeCalled();
-        $processBuilder->add('-cphpunit.xml')->shouldBeCalled();
         $processBuilder->getProcess()->willReturn($process);
 
         $process->run()->shouldBeCalled();
@@ -52,7 +51,6 @@ class PhpunitSpec extends ObjectBehavior
     function it_throws_exception_if_the_process_fails(ProcessBuilder $processBuilder, Process $process)
     {
         $processBuilder->setArguments(Argument::type('array'))->shouldBeCalled();
-        $processBuilder->add('-cphpunit.xml')->shouldBeCalled();
         $processBuilder->getProcess()->willReturn($process);
 
         $process->run()->shouldBeCalled();

--- a/src/GrumPHP/Task/Phpunit.php
+++ b/src/GrumPHP/Task/Phpunit.php
@@ -26,7 +26,7 @@ class Phpunit extends AbstractExternalTask
     public function getDefaultConfiguration()
     {
         return array(
-            'config_file' => 'phpunit.xml',
+            'config_file' => null,
         );
     }
 


### PR DESCRIPTION
First of great tool!

I wanted to use this with a library not containing a `phpunit.xml` file. It does however have a `phpunit.xml.dist` file to which phpunit would resolve if the first was not found. ([documentation](https://phpunit.de/manual/current/en/textui.html#textui.examples.filter-shortcuts)). 

Removing the default setting allows packages to ship with a more basic config.