### PR TITLE
HHVM nightly is no longer supported on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,10 @@ matrix:
     - php: 5.4
     - php: 5.5
     - php: 5.6
-    - php: hhvm
-    - php: hhvm-nightly
     - php: 7.0
+    - php: hhvm
+    
   allow_failures:
-    - php: hhvm-nightly
     - php: 7.0
   fast_finish: true
 


### PR DESCRIPTION
HHVM nightly is no longer supported on Ubuntu Precise. See travis-ci/travis-ci#3788 and facebook/hhvm#5220