### PR TITLE
Refactoring for running the tasks in different contexts

### DIFF
--- a/spec/GrumPHP/Collection/TasksCollectionSpec.php
+++ b/spec/GrumPHP/Collection/TasksCollectionSpec.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace spec\GrumPHP\Collection;
+
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\TaskInterface;
+use phpDocumentor\Reflection\DocBlock\Context;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class TasksCollectionSpec extends ObjectBehavior
+{
+    public function let(TaskInterface $task1, TaskInterface $task2)
+    {
+        $this->beConstructedWith(array($task1, $task2));
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Collection\TasksCollection');
+    }
+
+    function it_is_an_array_collection()
+    {
+        $this->shouldHaveType('Doctrine\Common\Collections\ArrayCollection');
+    }
+
+    function it_should_filter_by_context(TaskInterface $task1, TaskInterface $task2, ContextInterface $context)
+    {
+        $task1->canRunInContext($context)->willReturn(true);
+        $task2->canRunInContext($context)->willReturn(false);
+
+        $result = $this->filterByContext($context);
+        $result->shouldBeAnInstanceOf('GrumPHP\Collection\TasksCollection');
+        $result->count()->shouldBe(1);
+        $tasks = $result->toArray();
+        $tasks[0]->shouldBe($task1);
+    }
+
+}

--- a/spec/GrumPHP/Console/Helper/TaskRunnerHelperSpec.php
+++ b/spec/GrumPHP/Console/Helper/TaskRunnerHelperSpec.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace spec\GrumPHP\Console\Helper;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Console\Helper\PathsHelper;
+use GrumPHP\Console\Helper\TaskRunnerHelper;
+use GrumPHP\Exception\FailureException;
+use GrumPHP\Runner\TaskRunner;
+use GrumPHP\Task\Context\ContextInterface;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class TaskRunnerHelperSpec extends ObjectBehavior
+{
+    function let(TaskRunner $taskRunner, HelperSet $helperSet, PathsHelper $pathsHelper)
+    {
+        $this->beConstructedWith($taskRunner);
+
+        $helperSet->get(PathsHelper::HELPER_NAME)->willreturn($pathsHelper);
+        $this->setHelperSet($helperSet);
+    }
+
+    function it_should_return_error_code_during_exceptions(OutputInterface $output, TaskRunner $taskRunner, ContextInterface $context)
+    {
+        $taskRunner->run($context)->willThrow(new FailureException());
+        $this->run($output, $context)->shouldReturn(TaskRunnerHelper::CODE_ERROR);
+    }
+
+    function it_should_return_success_code_during_exceptions(OutputInterface $output, TaskRunner $taskRunner, ContextInterface $context)
+    {
+        $taskRunner->run($context)->shouldBeCalled();
+        $this->run($output, $context)->shouldReturn(TaskRunnerHelper::CODE_SUCCESS);
+    }
+}

--- a/spec/GrumPHP/Task/BehatSpec.php
+++ b/spec/GrumPHP/Task/BehatSpec.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
 use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -33,6 +34,11 @@ class BehatSpec extends ObjectBehavior
     {
         $externalCommandLocator->locate('behat')->shouldBeCalled();
         $this->getCommandLocation();
+    }
+
+    function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
     }
 
     function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder, ContextInterface $context)

--- a/spec/GrumPHP/Task/BlacklistSpec.php
+++ b/spec/GrumPHP/Task/BlacklistSpec.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
 use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -34,6 +35,11 @@ class BlacklistSpec extends ObjectBehavior
     {
         $externalCommandLocator->locate('git')->shouldBeCalled();
         $this->getCommandLocation();
+    }
+
+    function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
     }
 
     function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder, ContextInterface $context)

--- a/spec/GrumPHP/Task/BlacklistSpec.php
+++ b/spec/GrumPHP/Task/BlacklistSpec.php
@@ -5,6 +5,7 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
+use GrumPHP\Task\Context\ContextInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -35,31 +36,36 @@ class BlacklistSpec extends ObjectBehavior
         $this->getCommandLocation();
     }
 
-    function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder)
+    function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder, ContextInterface $context)
     {
         $processBuilder->add(Argument::any())->shouldNotBeCalled();
         $processBuilder->setArguments(Argument::any())->shouldNotBeCalled();
         $processBuilder->getProcess()->shouldNotBeCalled();
 
-        $files = new FilesCollection();
-        $this->run($files)->shouldBeNull();
+        $context->getFiles()->willReturn(new FilesCollection());
+        $this->run($context)->shouldBeNull();
     }
 
-    function it_does_not_do_anything_if_there_are_no_keywords(ProcessBuilder $processBuilder)
+    function it_does_not_do_anything_if_there_are_no_keywords(ProcessBuilder $processBuilder, ContextInterface $context)
     {
         $processBuilder->add(Argument::any())->shouldNotBeCalled();
         $processBuilder->setArguments(Argument::any())->shouldNotBeCalled();
         $processBuilder->getProcess()->shouldNotBeCalled();
 
-        $files = new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('file1.php'),
-        ));
+        )));
 
-        $this->run($files)->shouldBeNull();
+        $this->run($context)->shouldBeNull();
     }
 
-    function it_runs_the_suite(GrumPHP $grumPHP, LocatorInterface $externalCommandLocator, ProcessBuilder $processBuilder, Process $process)
-    {
+    function it_runs_the_suite(
+        GrumPHP $grumPHP,
+        LocatorInterface $externalCommandLocator,
+        ProcessBuilder $processBuilder,
+        Process $process,
+        ContextInterface $context
+    ) {
         $this->beConstructedWith($grumPHP, array('keywords'=>array('var_dump(', 'die(')), $externalCommandLocator, $processBuilder);
 
         $processBuilder->setArguments(Argument::type('array'))->shouldBeCalled();
@@ -73,14 +79,19 @@ class BlacklistSpec extends ObjectBehavior
         // Assume that blacklisted keywords was not found by `git grep` process
         $process->isSuccessful()->willReturn(false); 
 
-        $files = new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('file1.php'),
-        ));
-        $this->run($files);
+        )));
+        $this->run($context);
     }
 
-    function it_throws_exception_if_the_process_is_successfull(GrumPHP $grumPHP, LocatorInterface $externalCommandLocator, ProcessBuilder $processBuilder, Process $process)
-    {
+    function it_throws_exception_if_the_process_is_successfull(
+        GrumPHP $grumPHP,
+        LocatorInterface $externalCommandLocator,
+        ProcessBuilder $processBuilder,
+        Process $process,
+        ContextInterface $context
+    ) {
         $this->beConstructedWith($grumPHP, array('keywords'=>array('var_dump(')), $externalCommandLocator, $processBuilder);
 
         $processBuilder->setArguments(Argument::type('array'))->shouldBeCalled();
@@ -92,9 +103,9 @@ class BlacklistSpec extends ObjectBehavior
         $process->isSuccessful()->willReturn(true);
         $process->getOutput()->shouldBeCalled();
 
-        $files = new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('file1.php'),
-        ));
-        $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringRun($files);
+        )));
+        $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringRun($context);
     }
 }

--- a/spec/GrumPHP/Task/Context/GitPreCommitContextSpec.php
+++ b/spec/GrumPHP/Task/Context/GitPreCommitContextSpec.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace spec\GrumPHP\Task\Context;
+
+use GrumPHP\Collection\FilesCollection;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class GitPreCommitContextSpec extends ObjectBehavior
+{
+    function let(FilesCollection $files)
+    {
+        $this->beConstructedWith($files);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Task\Context\GitPreCommitContext');
+    }
+
+    function it_should_be_a_task_context()
+    {
+        $this->shouldImplement('GrumPHP\Task\Context\ContextInterface');
+    }
+
+    function it_should_have_files(FilesCollection $files)
+    {
+        $this->getFiles()->shouldBe($files);
+    }
+}

--- a/spec/GrumPHP/Task/PhpcsSpec.php
+++ b/spec/GrumPHP/Task/PhpcsSpec.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
 use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -34,6 +35,11 @@ class PhpcsSpec extends ObjectBehavior
     {
         $externalCommandLocator->locate('phpcs')->shouldBeCalled();
         $this->getCommandLocation();
+    }
+
+    function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
     }
 
     function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder, ContextInterface $context)

--- a/spec/GrumPHP/Task/PhpcsSpec.php
+++ b/spec/GrumPHP/Task/PhpcsSpec.php
@@ -5,6 +5,7 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
+use GrumPHP\Task\Context\ContextInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -35,17 +36,17 @@ class PhpcsSpec extends ObjectBehavior
         $this->getCommandLocation();
     }
 
-    function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder)
+    function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder, ContextInterface $context)
     {
         $processBuilder->add(Argument::any())->shouldNotBeCalled();
         $processBuilder->setArguments(Argument::any())->shouldNotBeCalled();
         $processBuilder->getProcess()->shouldNotBeCalled();
 
-        $files = new FilesCollection();
-        $this->run($files)->shouldBeNull();
+        $context->getFiles()->willReturn(new FilesCollection());
+        $this->run($context)->shouldBeNull();
     }
 
-    function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process)
+    function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
     {
         $processBuilder->add('file1.php')->shouldBeCalled();
         $processBuilder->add('file2.php')->shouldBeCalled();
@@ -55,15 +56,18 @@ class PhpcsSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $files = new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('file1.php'),
             new SplFileInfo('file2.php'),
-        ));
-        $this->run($files);
+        )));
+        $this->run($context);
     }
 
-    function it_throws_exception_if_the_process_fails(ProcessBuilder $processBuilder, Process $process)
-    {
+    function it_throws_exception_if_the_process_fails(
+        ProcessBuilder $processBuilder,
+        Process $process,
+        ContextInterface $context
+    ) {
         $processBuilder->add('file1.php')->shouldBeCalled();
         $processBuilder->setArguments(Argument::type('array'))->shouldBeCalled();
         $processBuilder->getProcess()->willReturn($process);
@@ -72,9 +76,9 @@ class PhpcsSpec extends ObjectBehavior
         $process->isSuccessful()->willReturn(false);
         $process->getOutput()->shouldBeCalled();
 
-        $files = new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('file1.php'),
-        ));
-        $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringRun($files);
+        )));
+        $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringRun($context);
     }
 }

--- a/spec/GrumPHP/Task/PhpcsfixerSpec.php
+++ b/spec/GrumPHP/Task/PhpcsfixerSpec.php
@@ -5,6 +5,7 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
+use GrumPHP\Task\Context\ContextInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -35,17 +36,17 @@ class PhpcsfixerSpec extends ObjectBehavior
         $this->getCommandLocation();
     }
 
-    function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder)
+    function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder, ContextInterface $context)
     {
         $processBuilder->add(Argument::any())->shouldNotBeCalled();
         $processBuilder->setArguments(Argument::any())->shouldNotBeCalled();
         $processBuilder->getProcess()->shouldNotBeCalled();
 
-        $files = new FilesCollection();
-        $this->run($files)->shouldBeNull();
+        $context->getFiles()->willReturn(new FilesCollection());
+        $this->run($context)->shouldBeNull();
     }
 
-    function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process)
+    function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
     {
         $processBuilder->add('--config=default')->shouldBeCalled();
         $processBuilder->add('--verbose')->shouldBeCalled();
@@ -58,15 +59,18 @@ class PhpcsfixerSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $files = new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('file1.php'),
             new SplFileInfo('file2.php'),
-        ));
-        $this->run($files);
+        )));
+        $this->run($context);
     }
 
-    function it_throws_exception_if_the_process_fails(ProcessBuilder $processBuilder, Process $process)
-    {
+    function it_throws_exception_if_the_process_fails(
+        ProcessBuilder $processBuilder,
+        Process $process,
+        ContextInterface $context
+    ) {
         $processBuilder->add('--config=default')->shouldBeCalled();
         $processBuilder->add('--verbose')->shouldBeCalled();
         $processBuilder->add('fix')->shouldBeCalled();
@@ -78,9 +82,9 @@ class PhpcsfixerSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $files = new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('file1.php'),
-        ));
-        $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringRun($files);
+        )));
+        $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringRun($context);
     }
 }

--- a/spec/GrumPHP/Task/PhpcsfixerSpec.php
+++ b/spec/GrumPHP/Task/PhpcsfixerSpec.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
 use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -44,6 +45,11 @@ class PhpcsfixerSpec extends ObjectBehavior
 
         $context->getFiles()->willReturn(new FilesCollection());
         $this->run($context)->shouldBeNull();
+    }
+
+    function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
     }
 
     function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)

--- a/spec/GrumPHP/Task/PhpspecSpec.php
+++ b/spec/GrumPHP/Task/PhpspecSpec.php
@@ -5,6 +5,7 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
+use GrumPHP\Task\Context\ContextInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -35,7 +36,7 @@ class PhpspecSpec extends ObjectBehavior
         $this->getCommandLocation();
     }
 
-    function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process)
+    function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
     {
         $processBuilder->setArguments(Argument::type('array'))->shouldBeCalled();
         $processBuilder->getProcess()->willReturn($process);
@@ -43,13 +44,13 @@ class PhpspecSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $files = new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.php')
-        ));
-        $this->run($files);
+        )));
+        $this->run($context);
     }
 
-    function it_throws_exception_if_the_process_fails(ProcessBuilder $processBuilder, Process $process)
+    function it_throws_exception_if_the_process_fails(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
     {
         $processBuilder->setArguments(Argument::type('array'))->shouldBeCalled();
         $processBuilder->getProcess()->willReturn($process);
@@ -58,9 +59,9 @@ class PhpspecSpec extends ObjectBehavior
         $process->isSuccessful()->willReturn(false);
         $process->getOutput()->shouldBeCalled();
 
-        $files = new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.php')
-        ));
-        $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringRun($files);
+        )));
+        $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringRun($context);
     }
 }

--- a/spec/GrumPHP/Task/PhpspecSpec.php
+++ b/spec/GrumPHP/Task/PhpspecSpec.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
 use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -34,6 +35,11 @@ class PhpspecSpec extends ObjectBehavior
     {
         $externalCommandLocator->locate('phpspec')->shouldBeCalled();
         $this->getCommandLocation();
+    }
+
+    function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
     }
 
     function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)

--- a/spec/GrumPHP/Task/PhpunitSpec.php
+++ b/spec/GrumPHP/Task/PhpunitSpec.php
@@ -5,6 +5,7 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
+use GrumPHP\Task\Context\ContextInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -34,7 +35,7 @@ class PhpunitSpec extends ObjectBehavior
         $this->getCommandLocation();
     }
 
-    function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process)
+    function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
     {
         $processBuilder->setArguments(Argument::type('array'))->shouldBeCalled();
         $processBuilder->getProcess()->willReturn($process);
@@ -42,13 +43,13 @@ class PhpunitSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $files = new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.php')
-        ));
-        $this->run($files);
+        )));
+        $this->run($context);
     }
 
-    function it_throws_exception_if_the_process_fails(ProcessBuilder $processBuilder, Process $process)
+    function it_throws_exception_if_the_process_fails(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
     {
         $processBuilder->setArguments(Argument::type('array'))->shouldBeCalled();
         $processBuilder->getProcess()->willReturn($process);
@@ -57,9 +58,9 @@ class PhpunitSpec extends ObjectBehavior
         $process->isSuccessful()->willReturn(false);
         $process->getOutput()->shouldBeCalled();
 
-        $files = new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.php')
-        ));
-        $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringRun($files);
+        )));
+        $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringRun($context);
     }
 }

--- a/spec/GrumPHP/Task/PhpunitSpec.php
+++ b/spec/GrumPHP/Task/PhpunitSpec.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
 use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -33,6 +34,11 @@ class PhpunitSpec extends ObjectBehavior
     {
         $externalCommandLocator->locate('phpunit')->shouldBeCalled();
         $this->getCommandLocation();
+    }
+
+    function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
     }
 
     function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)

--- a/src/GrumPHP/Collection/TasksCollection.php
+++ b/src/GrumPHP/Collection/TasksCollection.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace GrumPHP\Collection;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\TaskInterface;
+
+/**
+ * Class TasksCollection
+ *
+ * @package GrumPHP\Collection
+ */
+class TasksCollection extends ArrayCollection
+{
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return TasksCollection
+     */
+    public function filterByContext(ContextInterface $context)
+    {
+        return $this->filter(function (TaskInterface $task) use ($context) {
+            return $task->canRunInContext($context);
+        });
+    }
+}

--- a/src/GrumPHP/Console/Application.php
+++ b/src/GrumPHP/Console/Application.php
@@ -98,10 +98,7 @@ class Application extends SymfonyConsole
         );
         $commands[] = new Command\Git\PreCommitCommand(
             $container->get('config'),
-            $container->get('task_runner'),
-            $container->get('locator.changed_files'),
-            $container->get('locator.external_command'),
-            $container->get('process_builder')
+            $container->get('locator.changed_files')
         );
 
         return $commands;

--- a/src/GrumPHP/Console/Application.php
+++ b/src/GrumPHP/Console/Application.php
@@ -116,6 +116,9 @@ class Application extends SymfonyConsole
             $container->get('config'),
             $container->get('filesystem')
         ));
+        $helperSet->set(new Helper\TaskRunnerHelper(
+            $container->get('task_runner')
+        ));
 
         return $helperSet;
     }

--- a/src/GrumPHP/Console/Command/Git/PreCommitCommand.php
+++ b/src/GrumPHP/Console/Command/Git/PreCommitCommand.php
@@ -7,7 +7,6 @@ use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Console\Helper\PathsHelper;
 use GrumPHP\Console\Helper\TaskRunnerHelper;
 use GrumPHP\Locator\LocatorInterface;
-use GrumPHP\Runner\TaskRunner;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -26,26 +25,19 @@ class PreCommitCommand extends Command
     protected $grumPHP;
 
     /**
-     * @var TaskRunner
-     */
-    protected $taskRunner;
-
-    /**
      * @var LocatorInterface
      */
     protected $changedFilesLocator;
 
     /**
      * @param GrumPHP $grumPHP
-     * @param TaskRunner $taskRunner
      * @param LocatorInterface $changedFilesLocator
      */
-    public function __construct(GrumPHP $grumPHP, TaskRunner $taskRunner, LocatorInterface $changedFilesLocator)
+    public function __construct(GrumPHP $grumPHP, LocatorInterface $changedFilesLocator)
     {
         parent::__construct();
 
         $this->grumPHP = $grumPHP;
-        $this->taskRunner = $taskRunner;
         $this->changedFilesLocator = $changedFilesLocator;
     }
 
@@ -65,11 +57,10 @@ class PreCommitCommand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-
         $files = $this->getCommittedFiles();
         $context = new GitPreCommitContext($files);
 
-        $this->taskRunner()->run($output, $context);
+        return $this->taskRunner()->run($output, $context);
     }
 
     /**

--- a/src/GrumPHP/Console/Helper/PathsHelper.php
+++ b/src/GrumPHP/Console/Helper/PathsHelper.php
@@ -209,11 +209,7 @@ class PathsHelper extends Helper
     }
 
     /**
-     * Returns the canonical name of this helper.
-     *
-     * @return string The canonical name
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function getName()
     {

--- a/src/GrumPHP/Console/Helper/TaskRunnerHelper.php
+++ b/src/GrumPHP/Console/Helper/TaskRunnerHelper.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace GrumPHP\Console\Helper;
+
+use GrumPHP\Exception\ExceptionInterface;
+use GrumPHP\Runner\TaskRunner;
+use GrumPHP\Task\Context\ContextInterface;
+use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class TaskRunnerHelper
+ *
+ * @package GrumPHP\Console\Helper
+ */
+class TaskRunnerHelper extends Helper
+{
+    const HELPER_NAME = 'taskrunner';
+
+    const CODE_SUCCESS = 0;
+    const CODE_ERROR = 1;
+
+    /**
+     * @var TaskRunner
+     */
+    private $taskRunner;
+
+    /**
+     * @param TaskRunner $taskRunner
+     */
+    public function __construct(TaskRunner $taskRunner)
+    {
+        $this->taskRunner = $taskRunner;
+    }
+
+    /**
+     * @return PathsHelper
+     */
+    private function paths()
+    {
+        return $this->getHelperSet()->get(PathsHelper::HELPER_NAME);
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return int
+     */
+    public function run(OutputInterface $output, ContextInterface $context)
+    {
+        try {
+            $this->taskRunner->run($context);
+        } catch (ExceptionInterface $e) {
+            // We'll fail hard on any exception not generated in GrumPHP
+
+            return $this->returnErrorMessage($output, $e->getMessage());
+        }
+
+        return $this->returnSuccessMessage($output);
+
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @param string          $errorMessage
+     *
+     * @return int
+     */
+    private function returnErrorMessage(OutputInterface $output, $errorMessage)
+    {
+        $failed = $this->paths()->getAsciiContent('failed');
+        if ($failed) {
+            $output->writeln('<fg=red>' . $failed . '</fg=red>');
+        }
+
+        $output->writeln('<fg=red>' . $errorMessage . '</fg=red>');
+        $output->writeln(
+            '<fg=yellow>To skip commit checks, add -n or --no-verify flag to commit command</fg=yellow>'
+        );
+
+        return self::CODE_ERROR;
+    }
+
+    /**
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    private function returnSuccessMessage(OutputInterface $output)
+    {
+        $succeeded = $this->paths()->getAsciiContent('succeeded');
+        if ($succeeded) {
+            $output->write('<fg=green>' . $succeeded . '</fg=green>');
+        }
+
+        return self::CODE_SUCCESS;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return self::HELPER_NAME;
+    }
+}

--- a/src/GrumPHP/Task/Behat.php
+++ b/src/GrumPHP/Task/Behat.php
@@ -4,6 +4,8 @@ namespace GrumPHP\Task;
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Exception\RuntimeException;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
 
 /**
  * Behat task
@@ -36,9 +38,17 @@ class Behat extends AbstractExternalTask
     /**
      * {@inheritdoc}
      */
-    public function run(FilesCollection $files)
+    public function canRunInContext(ContextInterface $context)
     {
-        $files = $files->name('*.php');
+        return ($context instanceof GitPreCommitContext);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(ContextInterface $context)
+    {
+        $files = $context->getFiles()->name('*.php');
         if (0 === count($files)) {
             return;
         }

--- a/src/GrumPHP/Task/Blacklist.php
+++ b/src/GrumPHP/Task/Blacklist.php
@@ -4,6 +4,8 @@ namespace GrumPHP\Task;
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Exception\RuntimeException;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
 
 /**
  * Blacklist task
@@ -35,9 +37,17 @@ class Blacklist extends AbstractExternalTask
     /**
      * {@inheritdoc}
      */
-    public function run(FilesCollection $files)
+    public function canRunInContext(ContextInterface $context)
     {
-        $files = $files->name('*.php');
+        return ($context instanceof GitPreCommitContext);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(ContextInterface $context)
+    {
+        $files = $context->getFiles()->name('*.php');
         if (0 === count($files)) {
             return;
         }

--- a/src/GrumPHP/Task/Context/ContextInterface.php
+++ b/src/GrumPHP/Task/Context/ContextInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GrumPHP\Task\Context;
+
+use GrumPHP\Collection\FilesCollection;
+
+/**
+ * Interface ContextInterface
+ *
+ * @package GrumPHP\Context
+ */
+interface ContextInterface
+{
+
+    /**
+     * @return FilesCollection
+     */
+    public function getFiles();
+}

--- a/src/GrumPHP/Task/Context/GitPreCommitContext.php
+++ b/src/GrumPHP/Task/Context/GitPreCommitContext.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace GrumPHP\Task\Context;
+
+use GrumPHP\Collection\FilesCollection;
+
+/**
+ * Class GitPreCommitContext
+ *
+ * @package GrumPHP\Task\Context
+ */
+class GitPreCommitContext implements ContextInterface
+{
+
+    /**
+     * @var FilesCollection
+     */
+    private $files;
+
+    /**
+     * @param FilesCollection $files
+     */
+    public function __construct(FilesCollection $files)
+    {
+        $this->files = $files;
+    }
+
+    /**
+     * @return FilesCollection
+     */
+    public function getFiles()
+    {
+        return $this->files;
+    }
+}

--- a/src/GrumPHP/Task/Phpcs.php
+++ b/src/GrumPHP/Task/Phpcs.php
@@ -4,6 +4,8 @@ namespace GrumPHP\Task;
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Exception\RuntimeException;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
 
 /**
  * Phpcs task
@@ -37,9 +39,17 @@ class Phpcs extends AbstractExternalTask
     /**
      * {@inheritdoc}
      */
-    public function run(FilesCollection $files)
+    public function canRunInContext(ContextInterface $context)
     {
-        $files = $files->name('*.php');
+        return ($context instanceof GitPreCommitContext);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(ContextInterface $context)
+    {
+        $files = $context->getFiles()->name('*.php');
         if (0 === count($files)) {
             return;
         }

--- a/src/GrumPHP/Task/Phpcsfixer.php
+++ b/src/GrumPHP/Task/Phpcsfixer.php
@@ -4,6 +4,8 @@ namespace GrumPHP\Task;
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Exception\RuntimeException;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
 
 /**
  * Php-cs-fixer task
@@ -37,9 +39,17 @@ class Phpcsfixer extends AbstractExternalTask
     /**
      * {@inheritdoc}
      */
-    public function run(FilesCollection $files)
+    public function canRunInContext(ContextInterface $context)
     {
-        $files = $files->name('*.php');
+        return ($context instanceof GitPreCommitContext);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(ContextInterface $context)
+    {
+        $files = $context->getFiles()->name('*.php');
         if (0 === count($files)) {
             return;
         }

--- a/src/GrumPHP/Task/Phpspec.php
+++ b/src/GrumPHP/Task/Phpspec.php
@@ -4,6 +4,8 @@ namespace GrumPHP\Task;
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Exception\RuntimeException;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
 
 /**
  * Phpspec task
@@ -34,9 +36,17 @@ class Phpspec extends AbstractExternalTask
     /**
      * {@inheritdoc}
      */
-    public function run(FilesCollection $files)
+    public function canRunInContext(ContextInterface $context)
     {
-        $files = $files->name('*.php');
+        return ($context instanceof GitPreCommitContext);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(ContextInterface $context)
+    {
+        $files = $context->getFiles()->name('*.php');
         if (0 === count($files)) {
             return;
         }

--- a/src/GrumPHP/Task/Phpunit.php
+++ b/src/GrumPHP/Task/Phpunit.php
@@ -4,6 +4,8 @@ namespace GrumPHP\Task;
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Exception\RuntimeException;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
 
 /**
  * Phpunit task
@@ -33,9 +35,17 @@ class Phpunit extends AbstractExternalTask
     /**
      * {@inheritdoc}
      */
-    public function run(FilesCollection $files)
+    public function canRunInContext(ContextInterface $context)
     {
-        $files = $files->name('*.php');
+        return ($context instanceof GitPreCommitContext);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(ContextInterface $context)
+    {
+        $files = $context->getFiles()->name('*.php');
         if (0 === count($files)) {
             return;
         }

--- a/src/GrumPHP/Task/TaskInterface.php
+++ b/src/GrumPHP/Task/TaskInterface.php
@@ -2,8 +2,8 @@
 
 namespace GrumPHP\Task;
 
-use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Exception\RuntimeException;
+use GrumPHP\Task\Context\ContextInterface;
 
 /**
  * Interface TaskInterface
@@ -23,10 +23,19 @@ interface TaskInterface
     public function getDefaultConfiguration();
 
     /**
-     * @param FilesCollection $files
+     * This methods specifies if a task can run in a specific context.
+     *
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    public function canRunInContext(ContextInterface $context);
+
+    /**
+     * @param ContextInterface $context
      *
      * @return void
      * @throws RuntimeException
      */
-    public function run(FilesCollection $files);
+    public function run(ContextInterface $context);
 }


### PR DESCRIPTION
This major refactoring has some BC breaks.
It is possible to specify which task can run in which context.
A console helper is created that is responsible for running the tasks in the console commands.
This way it is easy to reuse the taskrunner in multiple console commands: You will only need to pass a new context.

This PR will make it possible to develop #33.

@aderuwe, @igormukhingmailcom : Can you please review and tell me if you like it or not?