### PR TITLE
Commit message task

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ For example: if you are working with JIRA, it is possible to add a pattern for t
 Use this parameter to specify one or multiple patterns. The value can be in regex or glob style.
 Here are some example matchers:
 
-- /JR-([0-9]*)/
+- /JIRA-([0-9]*)/
 - pre-fix*
 - *suffix
 - ...

--- a/README.md
+++ b/README.md
@@ -219,11 +219,11 @@ parameters:
                 - "exit;"
 ```
 
-#### Git commit message
+#### Git commit message (git_commit_message)
 
 The git comit message can be used in combination with the git hook `git:commit-msg`.
 It can be used to enforce patterns in a commit message.
-For example: if you are working with JIRA, it is possible to add a pattern for the JIRA issue numer.
+For example: if you are working with JIRA, it is possible to add a pattern for the JIRA issue number.
 
 **matchers**
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ parameters:
     tasks:
         behat: ~
         blacklist: ~
+        git_commit_message: ~
         phpcsfixer: ~
         phpcs:
             standard: "PSR2"
@@ -217,6 +218,38 @@ parameters:
                 - "var_dump("
                 - "exit;"
 ```
+
+#### Git commit message
+
+The git comit message can be used in combination with the git hook `git:commit-msg`.
+It can be used to enforce patterns in a commit message.
+For example: if you are working with JIRA, it is possible to add a pattern for the JIRA issue numer.
+
+**matchers**
+
+*Default: []*
+
+Use this parameter to specify one or multiple patterns. The value can be in regex or glob style.
+Here are some example matchers:
+
+- /JR-([0-9]*)/
+- pre-fix*
+- *suffix
+- ...
+
+**case_insensitive**
+
+*Default: true*
+
+Mark the matchers as case sensitive.
+
+**multiline**
+
+*Default:true*
+
+Markt he matchers as multiline.
+
+
 
 #### PHP-CS-Fixer
 

--- a/resources/config/services.yml
+++ b/resources/config/services.yml
@@ -97,3 +97,11 @@ services:
             - @process_builder
         tags:
             - {name: grumphp.task, config: blacklist}
+
+    task.git.commitmessage:
+        class: GrumPHP\Task\Git\CommitMessage
+        arguments:
+            - @config
+            - "@=parameter('tasks')['git_commit_message'] ? parameter('tasks')['git_commit_message'] : []"
+        tags:
+            - {name: grumphp.task, config: git_commit_message}

--- a/resources/hooks/commit-msg
+++ b/resources/hooks/commit-msg
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+#
+# Run the hook command.
+# Note: this will be replaced by the real command during copy.
+#
+
+GIT_USER=$(git config user.name)
+GIT_EMAIL=$(git config user.email)
+COMMIT_MSG_FILE=$1
+
+(cd "${HOOK_EXEC_PATH}" && exec $(HOOK_COMMAND) "--git-user=$GIT_USER" "--git-email=$GIT_EMAIL" "$COMMIT_MSG_FILE")
+
+# Validate exit code of above command
+RC=$?
+if [ "$RC" != 0 ]; then
+    exit $RC;
+fi
+
+# Clean exit:
+exit 0;

--- a/resources/hooks/pre-commit
+++ b/resources/hooks/pre-commit
@@ -4,7 +4,7 @@
 # Run the hook command.
 # Note: this will be replaced by the real command during copy.
 #
-(cd "${HOOK_EXEC_PATH}" && exec $(HOOK_COMMAND))
+(cd "${HOOK_EXEC_PATH}" && exec $(HOOK_COMMAND) '--skip-success-output')
 
 # Validate exit code of above command
 RC=$?

--- a/spec/GrumPHP/Task/Context/GitCommitMsgContextSpec.php
+++ b/spec/GrumPHP/Task/Context/GitCommitMsgContextSpec.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace spec\GrumPHP\Task\Context;
+
+use GrumPHP\Collection\FilesCollection;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class GitCommitMsgContextSpec extends ObjectBehavior
+{
+    /**
+     * @var string
+     */
+    protected $tempFile;
+
+    function let(FilesCollection $files, \SplFileInfo $fileInfo)
+    {
+        $this->beConstructedWith($files, $fileInfo, 'user', 'user@email.com');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Task\Context\GitCommitMsgContext');
+    }
+
+    function it_should_be_a_task_context()
+    {
+        $this->shouldImplement('GrumPHP\Task\Context\ContextInterface');
+    }
+
+    function it_should_have_files(FilesCollection $files)
+    {
+        $this->getFiles()->shouldBe($files);
+    }
+
+    function it_should_know_the_commit_msg(\SplFileInfo $fileInfo)
+    {
+        $message = 'message';
+        $messageSize = strlen($message);
+
+        $stream = new \SplFileObject('php://memory', 'w');
+        $stream->fwrite($message);
+        $stream->rewind();
+        $fileInfo->openFile('r')->shouldBeCalledTimes(1)->willReturn($stream);
+        $fileInfo->getSize()->willReturn($messageSize);
+
+        $this->getCommitMessage()->shouldReturn('message');
+
+        // Ask the message again to make sure it is not read twice:
+        $this->getCommitMessage()->shouldReturn('message');
+    }
+
+    function it_should_know_the_git_user()
+    {
+        $this->getUserName()->shouldBe('user');
+    }
+
+    function it_should_know_the_git_email()
+    {
+        $this->getUserEmail()->shouldBe('user@email.com');
+    }
+}

--- a/spec/GrumPHP/Task/Context/GitCommitMsgContextSpec.php
+++ b/spec/GrumPHP/Task/Context/GitCommitMsgContextSpec.php
@@ -33,23 +33,6 @@ class GitCommitMsgContextSpec extends ObjectBehavior
         $this->getFiles()->shouldBe($files);
     }
 
-    function it_should_know_the_commit_msg(\SplFileInfo $fileInfo)
-    {
-        $message = 'message';
-        $messageSize = strlen($message);
-
-        $stream = new \SplFileObject('php://memory', 'w');
-        $stream->fwrite($message);
-        $stream->rewind();
-        $fileInfo->openFile('r')->shouldBeCalledTimes(1)->willReturn($stream);
-        $fileInfo->getSize()->willReturn($messageSize);
-
-        $this->getCommitMessage()->shouldReturn('message');
-
-        // Ask the message again to make sure it is not read twice:
-        $this->getCommitMessage()->shouldReturn('message');
-    }
-
     function it_should_know_the_git_user()
     {
         $this->getUserName()->shouldBe('user');

--- a/spec/GrumPHP/Task/Git/CommitMessageSpec.php
+++ b/spec/GrumPHP/Task/Git/CommitMessageSpec.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace spec\GrumPHP\Task\Git;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Task\Context\GitCommitMsgContext;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class CommitMessageSpec extends ObjectBehavior
+{
+    function let(GrumPHP $grumPHP)
+    {
+        $this->beConstructedWith($grumPHP, array(
+            'matchers' => ['test', '*es*', 'te[s][t]', '/^te(.*)/', '/(.*)st$/', '/t(e|a)st/', 'TEST']
+        ));
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Task\Git\CommitMessage');
+    }
+
+    function it_is_a_grumphp_task()
+    {
+        $this->shouldImplement('GrumPHP\Task\TaskInterface');
+    }
+
+    function it_should_run_in_git_commit_msg_context(GitCommitMsgContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_runs_the_suite(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn('test');
+
+        $this->run($context);
+    }
+
+    function it_throws_exception_if_the_process_fails(GitCommitMsgContext $context) {
+        $context->getCommitMessage()->willReturn('invalid');
+        $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringRun($context);
+    }
+}

--- a/spec/GrumPHP/Task/Git/CommitMessageSpec.php
+++ b/spec/GrumPHP/Task/Git/CommitMessageSpec.php
@@ -12,7 +12,7 @@ class CommitMessageSpec extends ObjectBehavior
     function let(GrumPHP $grumPHP)
     {
         $this->beConstructedWith($grumPHP, array(
-            'matchers' => ['test', '*es*', 'te[s][t]', '/^te(.*)/', '/(.*)st$/', '/t(e|a)st/', 'TEST']
+            'matchers' => array('test', '*es*', 'te[s][t]', '/^te(.*)/', '/(.*)st$/', '/t(e|a)st/', 'TEST')
         ));
     }
 

--- a/src/GrumPHP/Console/Application.php
+++ b/src/GrumPHP/Console/Application.php
@@ -144,7 +144,7 @@ class Application extends SymfonyConsole
 
         // Load cli options:
         $input = new ArgvInput();
-        $configPath = $input->getParameterOption(['--config', '-c'], $this->getConfigDefaultPath());
+        $configPath = $input->getParameterOption(array('--config', '-c'), $this->getConfigDefaultPath());
 
         // Make sure to set the full path when it is declared relative
         // This will fix some issues in windows.

--- a/src/GrumPHP/Console/Command/Git/CommitMsgCommand.php
+++ b/src/GrumPHP/Console/Command/Git/CommitMsgCommand.php
@@ -7,17 +7,19 @@ use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Console\Helper\PathsHelper;
 use GrumPHP\Console\Helper\TaskRunnerHelper;
 use GrumPHP\Locator\LocatorInterface;
-use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\GitCommitMsgContext;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * This command runs the git pre-commit hook.
+ * This command runs the git commit-msg hook.
  */
-class PreCommitCommand extends Command
+class CommitMsgCommand extends Command
 {
-    const COMMAND_NAME = 'git:pre-commit';
+    const COMMAND_NAME = 'git:commit-msg';
 
     /**
      * @var GrumPHP
@@ -47,6 +49,9 @@ class PreCommitCommand extends Command
     protected function configure()
     {
         $this->setName(self::COMMAND_NAME);
+        $this->addOption('git-user', null, InputOption::VALUE_REQUIRED, 'The configured git user name.', '');
+        $this->addOption('git-email', null, InputOption::VALUE_REQUIRED, 'The configured git email.', '');
+        $this->addArgument('commit-msg-file', InputArgument::REQUIRED, 'The configured commit message file.');
     }
 
     /**
@@ -58,9 +63,12 @@ class PreCommitCommand extends Command
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $files = $this->getCommittedFiles();
-        $context = new GitPreCommitContext($files);
+        $gitUser = $input->getOption('git-user');
+        $gitEmail = $input->getOption('git-email');
+        $commitMsgFile = $input->getArgument('commit-msg-file');
 
-        return $this->taskRunner()->run($output, $context, true);
+        $context = new GitCommitMsgContext($files, $commitMsgFile, $gitUser, $gitEmail);
+        return $this->taskRunner()->run($output, $context);
     }
 
     /**

--- a/src/GrumPHP/Console/Command/Git/CommitMsgCommand.php
+++ b/src/GrumPHP/Console/Command/Git/CommitMsgCommand.php
@@ -8,6 +8,7 @@ use GrumPHP\Console\Helper\PathsHelper;
 use GrumPHP\Console\Helper\TaskRunnerHelper;
 use GrumPHP\Locator\LocatorInterface;
 use GrumPHP\Task\Context\GitCommitMsgContext;
+use SplFileInfo;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -65,7 +66,8 @@ class CommitMsgCommand extends Command
         $files = $this->getCommittedFiles();
         $gitUser = $input->getOption('git-user');
         $gitEmail = $input->getOption('git-email');
-        $commitMsgFile = $input->getArgument('commit-msg-file');
+        $commitMsgPath = $input->getArgument('commit-msg-file');
+        $commitMsgFile = new SplFileInfo($commitMsgPath);
 
         $context = new GitCommitMsgContext($files, $commitMsgFile, $gitUser, $gitEmail);
         return $this->taskRunner()->run($output, $context);

--- a/src/GrumPHP/Console/Command/Git/DeInitCommand.php
+++ b/src/GrumPHP/Console/Command/Git/DeInitCommand.php
@@ -21,6 +21,7 @@ class DeInitCommand extends Command
      */
     protected static $hooks = array(
         'pre-commit',
+        'commit-msg',
     );
 
     /**

--- a/src/GrumPHP/Console/Command/Git/InitCommand.php
+++ b/src/GrumPHP/Console/Command/Git/InitCommand.php
@@ -22,6 +22,7 @@ class InitCommand extends Command
      */
     public static $hooks = array(
         'pre-commit',
+        'commit-msg',
     );
 
     /**

--- a/src/GrumPHP/Console/Command/Git/PreCommitCommand.php
+++ b/src/GrumPHP/Console/Command/Git/PreCommitCommand.php
@@ -10,6 +10,7 @@ use GrumPHP\Locator\LocatorInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -47,6 +48,12 @@ class PreCommitCommand extends Command
     protected function configure()
     {
         $this->setName(self::COMMAND_NAME);
+        $this->addOption(
+            'skip-success-output',
+            null,
+            InputOption::VALUE_NONE,
+            'Skips the success output. This will be shown by another command in the git commit hook chain.'
+        );
     }
 
     /**
@@ -59,8 +66,9 @@ class PreCommitCommand extends Command
     {
         $files = $this->getCommittedFiles();
         $context = new GitPreCommitContext($files);
+        $skipSuccessOutput = (bool) $input->getOption('skip-success-output');
 
-        return $this->taskRunner()->run($output, $context, true);
+        return $this->taskRunner()->run($output, $context, $skipSuccessOutput);
     }
 
     /**

--- a/src/GrumPHP/Console/Helper/TaskRunnerHelper.php
+++ b/src/GrumPHP/Console/Helper/TaskRunnerHelper.php
@@ -42,11 +42,13 @@ class TaskRunnerHelper extends Helper
     }
 
     /**
+     * @param OutputInterface  $output
      * @param ContextInterface $context
+     * @param bool|false       $skipSuccessOutput
      *
      * @return int
      */
-    public function run(OutputInterface $output, ContextInterface $context)
+    public function run(OutputInterface $output, ContextInterface $context, $skipSuccessOutput = false)
     {
         try {
             $this->taskRunner->run($context);
@@ -54,6 +56,11 @@ class TaskRunnerHelper extends Helper
             // We'll fail hard on any exception not generated in GrumPHP
 
             return $this->returnErrorMessage($output, $e->getMessage());
+        }
+
+        // Skip before returning any messages
+        if ($skipSuccessOutput) {
+            return self::CODE_SUCCESS;
         }
 
         return $this->returnSuccessMessage($output);

--- a/src/GrumPHP/Task/Context/GitCommitMsgContext.php
+++ b/src/GrumPHP/Task/Context/GitCommitMsgContext.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace GrumPHP\Task\Context;
+
+use GrumPHP\Collection\FilesCollection;
+
+/**
+ * Class GitCommitMsgContext
+ *
+ * @package GrumPHP\Task\Context
+ */
+class GitCommitMsgContext implements ContextInterface
+{
+
+    /**
+     * @var FilesCollection
+     */
+    private $files;
+
+    /**
+     * @var string
+     */
+    private $commitMessage = null;
+
+    /**
+     * @var string
+     */
+    private $commitMessageFile;
+
+    /**
+     * @var string
+     */
+    private $userName;
+
+    /**
+     * @var string
+     */
+    private $userEmail;
+
+    /**
+     * @param FilesCollection $files
+     * @param string          $commitMessageFile
+     * @param string          $userName
+     * @param string          $userEmail
+     */
+    public function __construct(FilesCollection $files, $commitMessageFile, $userName, $userEmail)
+    {
+        $this->files = $files;
+        $this->commitMessageFile = $commitMessageFile;
+        $this->userName = $userName;
+        $this->userEmail = $userEmail;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCommitMessage()
+    {
+        if (is_null($this->commitMessage)) {
+            $this->commitMessage = file_get_contents($this->commitMessageFile);
+        }
+
+        return $this->commitMessage;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserName()
+    {
+        return $this->userName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserEmail()
+    {
+        return $this->userEmail;
+    }
+
+    /**
+     * @return FilesCollection
+     */
+    public function getFiles()
+    {
+        return $this->files;
+    }
+}

--- a/src/GrumPHP/Task/Context/GitCommitMsgContext.php
+++ b/src/GrumPHP/Task/Context/GitCommitMsgContext.php
@@ -58,9 +58,7 @@ class GitCommitMsgContext implements ContextInterface
     public function getCommitMessage()
     {
         if (is_null($this->commitMessage)) {
-            $file = $this->commitMessageFile;
-            $stream = $file->openFile('r');
-            $this->commitMessage = $stream->fread($file->getSize());
+            $this->commitMessage = file_get_contents($this->commitMessageFile->getPathname());
         }
 
         return $this->commitMessage;

--- a/src/GrumPHP/Task/Context/GitCommitMsgContext.php
+++ b/src/GrumPHP/Task/Context/GitCommitMsgContext.php
@@ -3,6 +3,7 @@
 namespace GrumPHP\Task\Context;
 
 use GrumPHP\Collection\FilesCollection;
+use SplFileInfo;
 
 /**
  * Class GitCommitMsgContext
@@ -23,7 +24,7 @@ class GitCommitMsgContext implements ContextInterface
     private $commitMessage = null;
 
     /**
-     * @var string
+     * @var SplFileInfo
      */
     private $commitMessageFile;
 
@@ -39,11 +40,11 @@ class GitCommitMsgContext implements ContextInterface
 
     /**
      * @param FilesCollection $files
-     * @param string          $commitMessageFile
+     * @param SplFileInfo     $commitMessageFile
      * @param string          $userName
      * @param string          $userEmail
      */
-    public function __construct(FilesCollection $files, $commitMessageFile, $userName, $userEmail)
+    public function __construct(FilesCollection $files, SplFileInfo $commitMessageFile, $userName, $userEmail)
     {
         $this->files = $files;
         $this->commitMessageFile = $commitMessageFile;
@@ -57,7 +58,9 @@ class GitCommitMsgContext implements ContextInterface
     public function getCommitMessage()
     {
         if (is_null($this->commitMessage)) {
-            $this->commitMessage = file_get_contents($this->commitMessageFile);
+            $file = $this->commitMessageFile;
+            $stream = $file->openFile('r');
+            $this->commitMessage = $stream->fread($file->getSize());
         }
 
         return $this->commitMessage;

--- a/src/GrumPHP/Task/Git/CommitMessage.php
+++ b/src/GrumPHP/Task/Git/CommitMessage.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace GrumPHP\Task\Git;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Exception\RuntimeException;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitCommitMsgContext;
+use Symfony\Component\Finder\Expression\Expression;
+
+/**
+ * Class CommitMessage
+ *
+ * @package GrumPHP\Task
+ */
+class CommitMessage implements TaskInterface
+{
+    /**
+     * @param GrumPHP $grumPHP
+     * @param array $configuration
+     */
+    public function __construct(
+        GrumPHP $grumPHP,
+        array $configuration
+    ) {
+        $this->grumPHP = $grumPHP;
+        $this->configuration = array_merge($this->getDefaultConfiguration(), $configuration);
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfiguration()
+    {
+        return $this->configuration;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDefaultConfiguration()
+    {
+        return array(
+            'case_insensitive' => true,
+            'multiline' => true,
+            'matchers' => array(),
+        );
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    public function canRunInContext(ContextInterface $context)
+    {
+        return $context instanceof GitCommitMsgContext;
+    }
+
+    /**
+     * @param ContextInterface|GitCommitMsgContext $context
+     */
+    public function run(ContextInterface $context)
+    {
+        $config = $this->getConfiguration();
+        $commitMessage = $context->getCommitMessage();
+
+        foreach ($config['matchers'] as $rule) {
+            $expression = Expression::create($rule);
+            $regex = $expression->getRegex();
+
+            if ((bool) $config['case_insensitive']) {
+                $regex->addOption('i');
+            }
+
+            if ((bool) $config['multiline']) {
+                $regex->addOption('m');
+            }
+
+            if (!preg_match($regex->render(), $commitMessage)) {
+                throw new RuntimeException(
+                    sprintf('The commit message does not match the rule: %s', $rule)
+                );
+            }
+        }
+    }
+}

--- a/src/GrumPHP/Task/Git/CommitMessage.php
+++ b/src/GrumPHP/Task/Git/CommitMessage.php
@@ -6,6 +6,7 @@ use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitCommitMsgContext;
+use GrumPHP\Task\TaskInterface;
 use Symfony\Component\Finder\Expression\Expression;
 
 /**


### PR DESCRIPTION
This commit adds a new git hook: `commit:msg`.
You will be able to match patterns to git commit messages.
In the future additional tasks like a check on username etc. can be added. (For example: user vagrant can not commit)

What do you think @aderuwe, @igormukhingmailcom  ?
It's not a code-quality task, but it is always nice to have some control about the commit messages.
For example validating a jira issue number in the commit msg etc.