### PR TITLE
phpunit task modifications

### DIFF
--- a/src/GrumPHP/Task/Phpunit.php
+++ b/src/GrumPHP/Task/Phpunit.php
@@ -57,7 +57,7 @@ class Phpunit extends AbstractExternalTask
         ));
 
         if ($config['config_file']) {
-            $this->processBuilder->add('-c' . $config['config_file']);
+            $this->processBuilder->add('--configuration=' . $config['config_file']);
         }
 
         $process = $this->processBuilder->getProcess();


### PR DESCRIPTION
Some tests throw exceptions with the message 'Unable to guess the Kernel directory.' In symfony.

I don't know why (I thought -c is the same as --configuration), but changing this, fixes the problem.