### PR TITLE
Remove version for less documentation maintenance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ We don't want to bore you with all the details, so quick: install it yourself an
 This package is composer plugin and should be installed to your project's dev dependency using composer:
 
 ```sh
-composer self-update
-composer require --dev phpro/grumphp:~0.1
+composer require phpro/grumphp
 ```
 
 When the package is installed, GrumPHP will attach itself to the git hooks of your project.


### PR DESCRIPTION
Remove version for less documentation maintenance.

This will allow composer to determine the last stable version. 

```sh
$ composer require phpro/grumphp
Using version ^0.4.1 for phpro/grumphp
./composer.json has been created
Loading composer repositories with package information
...
```