### PR TITLE
Introducing Events, Progress and a run command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,4 @@ install:
   - composer update --prefer-dist  --no-scripts  --no-interaction
 
 script:
-   - ./vendor/bin/phpcs --standard=PSR2 src
-   - ./vendor/bin/phpspec run
-
+   - ./bin/grumphp run

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ It is possible to hook in to GrumPHP with events.
 Internally the Symfony event dispatcher is being used. 
 This means it can be configured just like you would in Symfony: 
 
-```sh
+```yml
 # grumphp.yml
 services:
     listener.some_listener:
@@ -457,12 +457,12 @@ Following events are triggered during execution:
 
 | Event name              | Event class       | Triggered
 | ----------------------- | ----------------- | ----------
-| grumphp.task.run        | TaskEvent         | Triggered before a task is executed.
-| grumphp.task.failed     | TaskFailedEvent   | Triggered when a task fails.
-| grumphp.task.complete   | TaskEvent         | Triggered when a task succeeds.
-| grumphp.runner.run      | RunnerEvent       | Triggered before the tasks are executed.
-| grumphp.runner.failed   | RunnerFailedEvent | Triggered when one task failed.
-| grumphp.runner.complete | RunnerEvent       | Triggered when all tasks succeed.
+| grumphp.task.run        | TaskEvent         | before a task is executed
+| grumphp.task.failed     | TaskFailedEvent   | when a task fails
+| grumphp.task.complete   | TaskEvent         | when a task succeeds
+| grumphp.runner.run      | RunnerEvent       | before the tasks are executed
+| grumphp.runner.failed   | RunnerFailedEvent | when one task failed
+| grumphp.runner.complete | RunnerEvent       | when all tasks succeed
 
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -71,6 +71,28 @@ The only downfall is that you will have to initialize the git hook manually:
 php ./vendor/bin/grumphp git:init --config=path/to/grumphp.yml
 ```
 
+### Global installation
+
+It is possible to install or update GrumPHP on your system with following commands:
+
+```sh
+composer global require phpro/grumphp
+composer global update phpro/grumphp
+```
+
+This will install the `grumphp` executable in the `~/.composer/vendor/bin` folder.
+Make sure to add this folder to your system `$PATH` variable:
+
+```
+# .zshrc or .bashrc
+export PATH="$HOME/.composer/vendor/bin:$PATH"
+```
+
+That's all! The `grumphp` command will be available on your CLI and will be used by default.
+
+*Note:* that you might want to re-initialize your project git hooks to make sure the system-wide executable is being used. Run the `grumphp git:init` command in the project directory.
+*Note:* When you globally installed 3rd party tools like e.g. `phpunit`, those will also be used instead of the composer executables. 
+
 ## Build your own conventions checker
 
 You can see [example](https://github.com/linkorb/conventions-checker) 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ composer require --dev leaphub/phpcs-symfony2-standard
 Following this, you can add the path to your phpcs task.
 
 ```yml
+# grumphp.yml
 parameters:
     tasks:
         phpcs:
@@ -411,7 +412,7 @@ You just have to create a class that implements the `GrumPHP\Task\TaskInterface`
 Next register it to the service manager and add your task configuration:
 
 ```yaml
-# resources/config/services.yml
+# grumphp.yml
 parameters:
     tasks:
         myConfigKey:
@@ -432,6 +433,38 @@ You're welcome!
 
 You just registered your custom task in no time! Pretty cool right?!
 
+## Events
+
+It is possible to hook in to GrumPHP with events.
+Internally the Symfony event dispatcher is being used. 
+This means it can be configured just like you would in Symfony: 
+
+```sh
+# grumphp.yml
+services:
+    listener.some_listener:
+        class: MyNamespace\EventListener\MyListener
+        tags:
+            - { name: grumphp.event_listener, event: grumphp.runner.run }
+            - { name: grumphp.event_listener, event: grumphp.runner.run, method: customMethod, priority: 10 }
+    listener.some_subscriber:
+        class: MyNamespace\EventSubscriber\MySubscriber
+        tags:
+            - { name: grumphp.event_subscriber }
+```
+
+Following events are triggered during execution:
+
+| Event name              | Event class       | Triggered
+| ----------------------- | ----------------- | ----------
+| grumphp.task.run        | TaskEvent         | Triggered before a task is executed.
+| grumphp.task.failed     | TaskFailedEvent   | Triggered when a task fails.
+| grumphp.task.complete   | TaskEvent         | Triggered when a task succeeds.
+| grumphp.runner.run      | RunnerEvent       | Triggered before the tasks are executed.
+| grumphp.runner.failed   | RunnerFailedEvent | Triggered when one task failed.
+| grumphp.runner.complete | RunnerEvent       | Triggered when all tasks succeed.
+
+
 ## Roadmap
 
 Following tasks are still on the roadmap:
@@ -451,8 +484,13 @@ GrumPHP will be triggered with GIT hooks. However, you can execute the trigger a
 
 ```sh
 php ./vendor/bin/grumphp git:pre-commit
+php ./vendor/bin/grumphp git:commit-msg
 ```
 
+If you want to run the tests on the full codebase, you can run the command:
+```sh
+php ./vendor/bin/grumphp run
+```
 
 # Compatibility
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ You will see following message in the composer logs:
 
 To make GrumPHP even more awesome, it will suggest installing some extra packages:
 
-- squizlabs/php_codesniffer : ~2.3
+- behat/behat : ~3.0
+- fabpot/php-cs-fixer: ~1.10
 - phpspec/phpspec : ~2.1
 - phpunit/phpunit : ~4.5
 - roave/security-advisories : dev-master@dev
+- squizlabs/php_codesniffer : ~2.3
 
 GrumPHP will never push you into using a specific task. You can choose the tasks that fit your needs, and activate or
 deactivate any task in no time!

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ export PATH="$HOME/.composer/vendor/bin:$PATH"
 
 That's all! The `grumphp` command will be available on your CLI and will be used by default.
 
-*Note:* that you might want to re-initialize your project git hooks to make sure the system-wide executable is being used. Run the `grumphp git:init` command in the project directory.
-*Note:* When you globally installed 3rd party tools like e.g. `phpunit`, those will also be used instead of the composer executables. 
+**Note:** that you might want to re-initialize your project git hooks to make sure the system-wide executable is being used. Run the `grumphp git:init` command in the project directory.
+
+**Note:** When you globally installed 3rd party tools like e.g. `phpunit`, those will also be used instead of the composer executables. 
 
 ## Build your own conventions checker
 

--- a/README.md
+++ b/README.md
@@ -494,13 +494,22 @@ Following events are triggered during execution:
 
 Following tasks are still on the roadmap:
 
-- composer.json and composer.lock need to be committed at the same time
+- composer validate command
 - phpmd
 - phpcpd
 - phpdcd
+- twig lint
+- json lint
+- yaml lint
+- xml lint / dtd validation
+- grunt tests
+- gulp tests
+- npm test tests
 - ...
 
-In a future version, it will also be possible to use GrumPHP as a Continious Integration tool.
+New features or bugfixes can be logged at the [https://github.com/phpro/grumphp/issues](issues list).
+Want to help out? Feel free to contact us!
+
 
 # Execution
 

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "composer-plugin-api": "~1.0",
         "symfony/console": "^2.4",
         "symfony/expression-language": "^2.4",
+        "symfony/event-dispatcher": "^2.4",
         "symfony/process": "^2.4",
         "symfony/filesystem": "^2.4",
         "symfony/finder": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,12 @@
         "fabpot/php-cs-fixer": "~1.0"
     },
     "suggest": {
-      "roave/security-advisories": "Lets GrumPHP be sure that there are no known security issues.",
-      "squizlabs/php_codesniffer": "Lets GrumPHP sniff on your code.",
-      "phpspec/phpspec": "Lets GrumPHP spec your code.",
-      "phpunit/phpunit": "Lets GrumPHP run your unit tests.",
-      "fabpot/php-cs-fixer": "Lets GrumPHP automatically fix your codestyle."
+        "behat/behat": "Lets GrumPHP validate your project features.",
+        "fabpot/php-cs-fixer": "Lets GrumPHP automatically fix your codestyle.",
+        "phpspec/phpspec": "Lets GrumPHP spec your code.",
+        "phpunit/phpunit": "Lets GrumPHP run your unit tests.",
+        "squizlabs/php_codesniffer": "Lets GrumPHP sniff on your code.",
+        "roave/security-advisories": "Lets GrumPHP be sure that there are no known security issues."
     },
     "authors": [
         {

--- a/resources/config/services.yml
+++ b/resources/config/services.yml
@@ -12,6 +12,9 @@ services:
         class: GrumPHP\Configuration\GrumPHP
         arguments: [@service_container]
 
+    event_dispatcher:
+        class: Symfony\Component\EventDispatcher\EventDispatcher
+
     filesystem:
         class: Symfony\Component\Filesystem\Filesystem
 
@@ -29,6 +32,8 @@ services:
 
     task_runner:
         class: GrumPHP\Runner\TaskRunner
+        arguments:
+          - @event_dispatcher
 
     locator.external_command:
         class: GrumPHP\Locator\ExternalCommand
@@ -36,6 +41,10 @@ services:
 
     locator.changed_files:
         class: GrumPHP\Locator\ChangedFiles
+        arguments: [@git.repository]
+
+    locator.registered_files:
+        class: GrumPHP\Locator\RegisteredFiles
         arguments: [@git.repository]
 
     task.phpcs:

--- a/spec/GrumPHP/Console/Helper/TaskRunnerHelperSpec.php
+++ b/spec/GrumPHP/Console/Helper/TaskRunnerHelperSpec.php
@@ -10,15 +10,16 @@ use GrumPHP\Runner\TaskRunner;
 use GrumPHP\Task\Context\ContextInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class TaskRunnerHelperSpec extends ObjectBehavior
 {
-    function let(TaskRunner $taskRunner, HelperSet $helperSet, PathsHelper $pathsHelper)
+    function let(TaskRunner $taskRunner, EventDispatcherInterface $eventDispatcher, HelperSet $helperSet, PathsHelper $pathsHelper)
     {
-        $this->beConstructedWith($taskRunner);
+        $this->beConstructedWith($taskRunner, $eventDispatcher);
 
         $helperSet->get(PathsHelper::HELPER_NAME)->willreturn($pathsHelper);
         $this->setHelperSet($helperSet);
@@ -33,6 +34,17 @@ class TaskRunnerHelperSpec extends ObjectBehavior
     function it_should_return_success_code_during_exceptions(OutputInterface $output, TaskRunner $taskRunner, ContextInterface $context)
     {
         $taskRunner->run($context)->shouldBeCalled();
+        $this->run($output, $context)->shouldReturn(TaskRunnerHelper::CODE_SUCCESS);
+    }
+
+    function it_should_add_a_progress_listener_during_run(
+        OutputInterface $output,
+        TaskRunner $taskRunner,
+        ContextInterface $context,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $taskRunner->run($context)->shouldBeCalled();
+        $eventDispatcher->addSubscriber(Argument::type('GrumPHP\Event\Subscriber\ProgressSubscriber'))->shouldBeCalled();
         $this->run($output, $context)->shouldReturn(TaskRunnerHelper::CODE_SUCCESS);
     }
 }

--- a/spec/GrumPHP/Event/RunnerEventSpec.php
+++ b/spec/GrumPHP/Event/RunnerEventSpec.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace spec\GrumPHP\Event;
+
+use GrumPHP\Collection\TasksCollection;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class RunnerEventSpec extends ObjectBehavior
+{
+    function let(TasksCollection $tasks)
+    {
+        $this->beConstructedWith($tasks);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Event\RunnerEvent');
+    }
+
+    function it_is_an_event()
+    {
+        $this->shouldHaveType('Symfony\Component\EventDispatcher\Event');
+    }
+
+    function it_has_tasks(TasksCollection $tasks)
+    {
+        $this->getTasks()->shouldBe($tasks);
+    }
+}

--- a/spec/GrumPHP/Event/RunnerFailedEventSpec.php
+++ b/spec/GrumPHP/Event/RunnerFailedEventSpec.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace spec\GrumPHP\Event;
+
+use GrumPHP\Collection\TasksCollection;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class RunnerFailedEventSpec extends ObjectBehavior
+{
+    function let(TasksCollection $tasks)
+    {
+        $this->beConstructedWith($tasks, []);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Event\RunnerFailedEvent');
+    }
+
+    function it_is_a_runner_event()
+    {
+        $this->shouldHaveType('GrumPHP\Event\RunnerEvent');
+    }
+
+    function it_has_tasks(TasksCollection $tasks)
+    {
+        $this->getTasks()->shouldBe($tasks);
+    }
+
+    function it_should_contain_the_error_messages()
+    {
+        $this->getMessages()->shouldBe([]);
+    }
+}

--- a/spec/GrumPHP/Event/RunnerFailedEventSpec.php
+++ b/spec/GrumPHP/Event/RunnerFailedEventSpec.php
@@ -10,7 +10,7 @@ class RunnerFailedEventSpec extends ObjectBehavior
 {
     function let(TasksCollection $tasks)
     {
-        $this->beConstructedWith($tasks, []);
+        $this->beConstructedWith($tasks, array());
     }
 
     function it_is_initializable()
@@ -30,6 +30,6 @@ class RunnerFailedEventSpec extends ObjectBehavior
 
     function it_should_contain_the_error_messages()
     {
-        $this->getMessages()->shouldBe([]);
+        $this->getMessages()->shouldBe(array());
     }
 }

--- a/spec/GrumPHP/Event/Subscriber/ProgressSubscriberSpec.php
+++ b/spec/GrumPHP/Event/Subscriber/ProgressSubscriberSpec.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace spec\GrumPHP\Event\Subscriber;
+
+use GrumPHP\Collection\TasksCollection;
+use GrumPHP\Event\RunnerEvent;
+use GrumPHP\Event\TaskEvent;
+use GrumPHP\Task\TaskInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ProgressSubscriberSpec extends ObjectBehavior
+{
+    function let(OutputInterface $output, ProgressBar $progressBar)
+    {
+        $this->beConstructedWith($output, $progressBar);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Event\Subscriber\ProgressSubscriber');
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldImplement('Symfony\Component\EventDispatcher\EventSubscriberInterface');
+    }
+
+    function it_should_subscribe_to_events()
+    {
+        $this->getSubscribedEvents()->shouldBeArray();
+    }
+
+    function it_starts_progress(ProgressBar $progressBar, RunnerEvent $event, TasksCollection $tasks)
+    {
+        $tasks->count()->willReturn(2);
+        $event->getTasks()->willReturn($tasks);
+
+        $progressBar->setFormat(Argument::type('string'))->shouldBeCalled();
+        $progressBar->setOverwrite(false)->shouldBeCalled();
+        $progressBar->setMessage(Argument::type('string'))->shouldBeCalled();
+        $progressBar->start(2)->shouldBeCalled();
+
+        $this->startProgress($event);
+    }
+
+    function it_should_advance_progress(ProgressBar $progressBar, TaskEvent $event, TaskInterface $task)
+    {
+        $event->getTask()->willReturn($task);
+
+        $progressBar->setFormat(Argument::type('string'))->shouldBeCalled();
+        $progressBar->setOverwrite(false)->shouldBeCalled();
+        $progressBar->setMessage(Argument::type('string'))->shouldBeCalled();
+        $progressBar->advance()->shouldBeCalled();
+
+        $this->advanceProgress($event);
+    }
+
+    function it_finishes_progress(OutputInterface $output, ProgressBar $progressBar, RunnerEvent $event)
+    {
+        $progressBar->setOverwrite(false)->shouldBeCalled();
+        $progressBar->finish()->shouldBeCalled();
+        $output->writeln('')->shouldBeCalled();
+
+        $this->finishProgress($event);
+    }
+}

--- a/spec/GrumPHP/Event/TaskEventSpec.php
+++ b/spec/GrumPHP/Event/TaskEventSpec.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace spec\GrumPHP\Event;
+
+use GrumPHP\Task\TaskInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class TaskEventSpec extends ObjectBehavior
+{
+
+    function let(TaskInterface $task)
+    {
+        $this->beConstructedWith($task);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Event\TaskEvent');
+    }
+
+    function it_is_an_event()
+    {
+        $this->shouldHaveType('Symfony\Component\EventDispatcher\Event');
+    }
+
+    function it_has_a_task(TaskInterface $task)
+    {
+        $this->getTask()->shouldBe($task);
+    }
+}

--- a/spec/GrumPHP/Event/TaskFailedEventSpec.php
+++ b/spec/GrumPHP/Event/TaskFailedEventSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\GrumPHP\Event;
+
+use GrumPHP\Task\TaskInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class TaskFailedEventSpec extends ObjectBehavior
+{
+
+
+    function let(TaskInterface $task, \Exception $exception)
+    {
+        $this->beConstructedWith($task, $exception);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Event\TaskFailedEvent');
+    }
+
+    function it_is_a_runner_event()
+    {
+        $this->shouldHaveType('GrumPHP\Event\TaskEvent');
+    }
+
+    function it_has_a_task(TaskInterface $task)
+    {
+        $this->getTask()->shouldBe($task);
+    }
+
+    function it_should_contain_the_exception(\Exception $exception)
+    {
+        $this->getException()->shouldBe($exception);
+    }
+}

--- a/spec/GrumPHP/Locator/RegisteredFilesSpec.php
+++ b/spec/GrumPHP/Locator/RegisteredFilesSpec.php
@@ -25,7 +25,7 @@ class RegisteredFilesSpec extends ObjectBehavior
 
     function it_will_list_all_diffed_files(Repository $repository)
     {
-        $files = ['file1.txt', 'file2.txt'];
+        $files = array('file1.txt', 'file2.txt');
         $repository->run('ls-files')->willReturn(implode(PHP_EOL, $files));
 
         $result = $this->locate();

--- a/spec/GrumPHP/Locator/RegisteredFilesSpec.php
+++ b/spec/GrumPHP/Locator/RegisteredFilesSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\GrumPHP\Locator;
+
+use Gitonomy\Git\Repository;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class RegisteredFilesSpec extends ObjectBehavior
+{
+    function let(Repository $repository)
+    {
+        $this->beConstructedWith($repository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Locator\RegisteredFiles');
+    }
+
+    function it_is_a_grumphp_locator()
+    {
+        $this->shouldHaveType('GrumPHP\Locator\LocatorInterface');
+    }
+
+    function it_will_list_all_diffed_files(Repository $repository)
+    {
+        $files = ['file1.txt', 'file2.txt'];
+        $repository->run('ls-files')->willReturn(implode(PHP_EOL, $files));
+
+        $result = $this->locate();
+        $result->shouldBeAnInstanceOf('GrumPHP\Collection\FilesCollection');
+        $result[0]->getPathname()->shouldBe('file1.txt');
+        $result[1]->getPathname()->shouldBe('file2.txt');
+        $result->getIterator()->count()->shouldBe(2);
+    }
+}

--- a/spec/GrumPHP/Runner/TaskRunnerSpec.php
+++ b/spec/GrumPHP/Runner/TaskRunnerSpec.php
@@ -97,11 +97,10 @@ class TaskRunnerSpec extends ObjectBehavior
         ContextInterface $context
     ) {
         $task1->run($context)->willThrow('GrumPHP\Exception\RuntimeException');
-        $task2->run($context)->shouldBeCalled();
+        $task2->run($context)->willThrow('GrumPHP\Exception\RuntimeException');
 
         $eventDispatcher->dispatch(RunnerEvents::RUNNER_RUN, Argument::type('GrumPHP\Event\RunnerEvent'))->shouldBeCalled();
         $eventDispatcher->dispatch(TaskEvents::TASK_RUN, Argument::type('GrumPHP\Event\TaskEvent'))->shouldBeCalled();
-        $eventDispatcher->dispatch(TaskEvents::TASK_COMPLETE, Argument::type('GrumPHP\Event\TaskEvent'))->shouldBeCalled();
         $eventDispatcher->dispatch(TaskEvents::TASK_FAILED, Argument::type('GrumPHP\Event\TaskFailedEvent'))->shouldBeCalled();
         $eventDispatcher->dispatch(RunnerEvents::RUNNER_FAILED, Argument::type('GrumPHP\Event\RunnerFailedEvent'))->shouldBeCalled();
 

--- a/spec/GrumPHP/Task/BehatSpec.php
+++ b/spec/GrumPHP/Task/BehatSpec.php
@@ -7,6 +7,7 @@ use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -37,6 +38,11 @@ class BehatSpec extends ObjectBehavior
     }
 
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_run_in_run_context(RunContext $context)
     {
         $this->canRunInContext($context)->shouldReturn(true);
     }

--- a/spec/GrumPHP/Task/PhpcsSpec.php
+++ b/spec/GrumPHP/Task/PhpcsSpec.php
@@ -7,6 +7,7 @@ use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -38,6 +39,12 @@ class PhpcsSpec extends ObjectBehavior
     }
 
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+
+    function it_should_run_in_run_context(RunContext $context)
     {
         $this->canRunInContext($context)->shouldReturn(true);
     }

--- a/spec/GrumPHP/Task/PhpcsfixerSpec.php
+++ b/spec/GrumPHP/Task/PhpcsfixerSpec.php
@@ -7,6 +7,7 @@ use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -48,6 +49,11 @@ class PhpcsfixerSpec extends ObjectBehavior
     }
 
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_run_in_run_context(RunContext $context)
     {
         $this->canRunInContext($context)->shouldReturn(true);
     }

--- a/spec/GrumPHP/Task/PhpspecSpec.php
+++ b/spec/GrumPHP/Task/PhpspecSpec.php
@@ -7,6 +7,7 @@ use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -38,6 +39,11 @@ class PhpspecSpec extends ObjectBehavior
     }
 
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_run_in_run_context(RunContext $context)
     {
         $this->canRunInContext($context)->shouldReturn(true);
     }

--- a/spec/GrumPHP/Task/PhpunitSpec.php
+++ b/spec/GrumPHP/Task/PhpunitSpec.php
@@ -7,6 +7,7 @@ use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\LocatorInterface;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
@@ -37,6 +38,11 @@ class PhpunitSpec extends ObjectBehavior
     }
 
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_run_in_run_context(RunContext $context)
     {
         $this->canRunInContext($context)->shouldReturn(true);
     }

--- a/src/GrumPHP/Configuration/Compiler/TaskCompilerPass.php
+++ b/src/GrumPHP/Configuration/Compiler/TaskCompilerPass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GrumPHP\Configuration;
+namespace GrumPHP\Configuration\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * Class TaskCompilerPass
  *
- * @package GrumPHP\Configuration
+ * @package GrumPHP\Configuration\Compiler
  */
 class TaskCompilerPass implements CompilerPassInterface
 {

--- a/src/GrumPHP/Configuration/ContainerFactory.php
+++ b/src/GrumPHP/Configuration/ContainerFactory.php
@@ -2,10 +2,11 @@
 
 namespace GrumPHP\Configuration;
 
-use RuntimeException;
+use GrumPHP\Configuration\Compiler\TaskCompilerPass;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\Filesystem\Filesystem;
 
 final class ContainerFactory
@@ -19,6 +20,9 @@ final class ContainerFactory
     {
         $container = new ContainerBuilder();
         $container->addCompilerPass(new TaskCompilerPass());
+        $container->addCompilerPass(
+            new RegisterListenersPass('event_dispatcher', 'grumphp.event_listener', 'grumphp.event_subscriber')
+        );
 
         // Load basic service file + custom user configuration
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../../../resources/config'));

--- a/src/GrumPHP/Console/Application.php
+++ b/src/GrumPHP/Console/Application.php
@@ -95,6 +95,10 @@ class Application extends SymfonyConsole
             $container->get('git.repository'),
             $container->get('task_runner')
         );
+        $commands[] = new Command\RunCommand(
+            $container->get('config'),
+            $container->get('locator.registered_files')
+        );
 
         $commands[] = new Command\Git\CommitMsgCommand(
             $container->get('config'),
@@ -127,7 +131,8 @@ class Application extends SymfonyConsole
             $container->get('filesystem')
         ));
         $helperSet->set(new Helper\TaskRunnerHelper(
-            $container->get('task_runner')
+            $container->get('task_runner'),
+            $container->get('event_dispatcher')
         ));
 
         return $helperSet;

--- a/src/GrumPHP/Console/Command/Git/CommitMsgCommand.php
+++ b/src/GrumPHP/Console/Command/Git/CommitMsgCommand.php
@@ -69,6 +69,7 @@ class CommitMsgCommand extends Command
         $commitMsgPath = $input->getArgument('commit-msg-file');
         $commitMsgFile = new SplFileInfo($commitMsgPath);
 
+        $output->writeln('<fg=yellow>GrumPHP detected a commit-msg command.</fg=yellow>');
         $context = new GitCommitMsgContext($files, $commitMsgFile, $gitUser, $gitEmail);
         return $this->taskRunner()->run($output, $context);
     }

--- a/src/GrumPHP/Console/Command/Git/PreCommitCommand.php
+++ b/src/GrumPHP/Console/Command/Git/PreCommitCommand.php
@@ -68,6 +68,7 @@ class PreCommitCommand extends Command
         $context = new GitPreCommitContext($files);
         $skipSuccessOutput = (bool) $input->getOption('skip-success-output');
 
+        $output->writeln('<fg=yellow>GrumPHP detected a pre-commit command.</fg=yellow>');
         return $this->taskRunner()->run($output, $context, $skipSuccessOutput);
     }
 

--- a/src/GrumPHP/Console/Command/RunCommand.php
+++ b/src/GrumPHP/Console/Command/RunCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace GrumPHP\Console\Command;
+
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Console\Helper\PathsHelper;
+use GrumPHP\Console\Helper\TaskRunnerHelper;
+use GrumPHP\Locator\LocatorInterface;
+use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class RunCommand
+ *
+ * @package GrumPHP\Console\Command
+ */
+class RunCommand extends Command
+{
+    const COMMAND_NAME = 'run';
+
+    /**
+     * @var GrumPHP
+     */
+    protected $grumPHP;
+
+    /**
+     * @var LocatorInterface
+     */
+    protected $registeredFilesLocator;
+
+    /**
+     * @param GrumPHP $grumPHP
+     * @param LocatorInterface $registeredFilesLocator
+     */
+    public function __construct(GrumPHP $grumPHP, LocatorInterface $registeredFilesLocator)
+    {
+        parent::__construct();
+
+        $this->grumPHP = $grumPHP;
+        $this->registeredFilesLocator = $registeredFilesLocator;
+    }
+
+    /**
+     * Configure command
+     */
+    protected function configure()
+    {
+        $this->setName(self::COMMAND_NAME);
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return int|void
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $files = $this->getRegisteredFiles();
+        $context = new RunContext($files);
+
+        return $this->taskRunner()->run($output, $context);
+    }
+
+    /**
+     * @return FilesCollection
+     */
+    protected function getRegisteredFiles()
+    {
+        return $this->registeredFilesLocator->locate();
+    }
+
+    /**
+     * @return TaskRunnerHelper
+     */
+    protected function taskRunner()
+    {
+        return $this->getHelper(TaskRunnerHelper::HELPER_NAME);
+    }
+
+    /**
+     * @return PathsHelper
+     */
+    protected function paths()
+    {
+        return $this->getHelper(PathsHelper::HELPER_NAME);
+    }
+}

--- a/src/GrumPHP/Event/RunnerEvent.php
+++ b/src/GrumPHP/Event/RunnerEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace GrumPHP\Event;
+
+use GrumPHP\Collection\TasksCollection;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class RunnerEvent
+ *
+ * @package GrumPHP\Event
+ */
+class RunnerEvent extends Event
+{
+    /**
+     * @var TasksCollection
+     */
+    private $tasks;
+
+    /**
+     * @param TasksCollection $tasks
+     */
+    public function __construct(TasksCollection $tasks)
+    {
+        $this->tasks = $tasks;
+    }
+
+    /**
+     * @return TasksCollection
+     */
+    public function getTasks()
+    {
+        return $this->tasks;
+    }
+}

--- a/src/GrumPHP/Event/RunnerEvents.php
+++ b/src/GrumPHP/Event/RunnerEvents.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GrumPHP\Event;
+
+/**
+ * Class RunnerEvents
+ *
+ * @package GrumPHP\Events
+ */
+final class RunnerEvents
+{
+    const RUNNER_RUN = 'grumphp.runner.run';
+    const RUNNER_COMPLETE = 'grumphp.runner.complete';
+    const RUNNER_FAILED = 'grumphp.runner.failed';
+}

--- a/src/GrumPHP/Event/RunnerFailedEvent.php
+++ b/src/GrumPHP/Event/RunnerFailedEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace GrumPHP\Event;
+
+use GrumPHP\Collection\TasksCollection;
+
+/**
+ * Class RunnerFailedEvent
+ *
+ * @package GrumPHP\Event
+ */
+class RunnerFailedEvent extends RunnerEvent
+{
+    /**
+     * @var array
+     */
+    private $messages;
+
+    /**
+     * @param TasksCollection $tasks
+     * @param array           $messages
+     */
+    public function __construct(TasksCollection $tasks, array $messages)
+    {
+        parent::__construct($tasks);
+        $this->messages = $messages;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMessages()
+    {
+        return $this->messages;
+    }
+}

--- a/src/GrumPHP/Event/Subscriber/ProgressSubscriber.php
+++ b/src/GrumPHP/Event/Subscriber/ProgressSubscriber.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace GrumPHP\Event\Subscriber;
+
+use GrumPHP\Event\RunnerEvent;
+use GrumPHP\Event\RunnerEvents;
+use GrumPHP\Event\TaskEvent;
+use GrumPHP\Event\TaskEvents;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use ReflectionClass;
+
+/**
+ * Class ProgressSubscriber
+ *
+ * @package GrumPHP\Event\Subscriber
+ */
+class ProgressSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var ProgressBar
+     */
+    private $progressBar;
+
+    /**
+     * @var string
+     */
+    private $progressFormat;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @param OutputInterface  $output
+     * @param ProgressBar $progressBar
+     */
+    public function __construct(OutputInterface $output, ProgressBar $progressBar)
+    {
+        $this->output = $output;
+        $this->progressBar = $progressBar ?: new ProgressBar($output);
+        $this->progressBar->setOverwrite(false);
+        $this->progressFormat = "<fg=yellow>Running task %current%/%max%:</fg=yellow> %message%";
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            RunnerEvents::RUNNER_RUN => 'startProgress',
+            TaskEvents::TASK_RUN => 'advanceProgress',
+            RunnerEvents::RUNNER_COMPLETE => 'finishProgress',
+            RunnerEvents::RUNNER_FAILED => 'finishProgress',
+        ];
+    }
+
+    /**
+     * @param RunnerEvent $event
+     */
+    public function startProgress(RunnerEvent $event)
+    {
+        $numberOftasks = $event->getTasks()->count();
+        $this->progressBar->setFormat('<fg=yellow>%message%</fg=yellow>');
+        $this->progressBar->setMessage('GrumPHP is sniffing your code!');
+        $this->progressBar->start($numberOftasks);
+    }
+
+    /**
+     * @param TaskEvent $event
+     */
+    public function advanceProgress(TaskEvent $event)
+    {
+        $taskReflection = new ReflectionClass($event->getTask());
+        $taskName = $taskReflection->getShortName();
+
+        $this->progressBar->setFormat($this->progressFormat);
+        $this->progressBar->setMessage($taskName);
+        $this->progressBar->advance();
+    }
+
+    /**
+     * @param RunnerEvent $runnerEvent
+     */
+    public function finishProgress(RunnerEvent $runnerEvent)
+    {
+        $this->progressBar->finish();
+        $this->output->writeln('');
+    }
+}

--- a/src/GrumPHP/Event/Subscriber/ProgressSubscriber.php
+++ b/src/GrumPHP/Event/Subscriber/ProgressSubscriber.php
@@ -50,12 +50,12 @@ class ProgressSubscriber implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return [
+        return array(
             RunnerEvents::RUNNER_RUN => 'startProgress',
             TaskEvents::TASK_RUN => 'advanceProgress',
             RunnerEvents::RUNNER_COMPLETE => 'finishProgress',
             RunnerEvents::RUNNER_FAILED => 'finishProgress',
-        ];
+        );
     }
 
     /**

--- a/src/GrumPHP/Event/TaskEvent.php
+++ b/src/GrumPHP/Event/TaskEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace GrumPHP\Event;
+
+use GrumPHP\Task\TaskInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class TaskEvent
+ *
+ * @package GrumPHP\Event
+ */
+class TaskEvent extends Event
+{
+    /**
+     * @var TaskInterface
+     */
+    private $task;
+
+    /**
+     * @param TaskInterface $task
+     */
+    public function __construct(TaskInterface $task)
+    {
+        $this->task = $task;
+    }
+
+    /**
+     * @return TaskInterface
+     */
+    public function getTask()
+    {
+        return $this->task;
+    }
+}

--- a/src/GrumPHP/Event/TaskEvents.php
+++ b/src/GrumPHP/Event/TaskEvents.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GrumPHP\Event;
+
+/**
+ * Class TaskEvents
+ *
+ * @package GrumPHP\Event
+ */
+final class TaskEvents
+{
+    const TASK_RUN = 'grumphp.task.run';
+    const TASK_COMPLETE = 'grumphp.task.complete';
+    const TASK_FAILED = 'grumphp.task.failed';
+}

--- a/src/GrumPHP/Event/TaskFailedEvent.php
+++ b/src/GrumPHP/Event/TaskFailedEvent.php
@@ -12,7 +12,6 @@ use GrumPHP\Task\TaskInterface;
  */
 class TaskFailedEvent extends TaskEvent
 {
-
     /**
      * @var Exception
      */

--- a/src/GrumPHP/Event/TaskFailedEvent.php
+++ b/src/GrumPHP/Event/TaskFailedEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace GrumPHP\Event;
+
+use Exception;
+use GrumPHP\Task\TaskInterface;
+
+/**
+ * Class TaskFailedEvent
+ *
+ * @package GrumPHP\Event
+ */
+class TaskFailedEvent extends TaskEvent
+{
+
+    /**
+     * @var Exception
+     */
+    private $exception;
+
+    /**
+     * @param TaskInterface $task
+     * @param Exception     $exception
+     */
+    public function __construct(TaskInterface $task, Exception $exception)
+    {
+        parent::__construct($task);
+
+        $this->exception = $exception;
+    }
+
+    /**
+     * @return Exception
+     */
+    public function getException()
+    {
+        return $this->exception;
+    }
+}

--- a/src/GrumPHP/Locator/RegisteredFiles.php
+++ b/src/GrumPHP/Locator/RegisteredFiles.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace GrumPHP\Locator;
+
+use Gitonomy\Git\Repository;
+use GrumPHP\Collection\FilesCollection;
+use SplFileInfo;
+
+/**
+ * Class RegisteredFiles
+ *
+ * @package GrumPHP\Locator
+ */
+class RegisteredFiles implements LocatorInterface
+{
+    /**
+     * @var Repository
+     */
+    private $repository;
+
+    /**
+     * @param Repository $repository
+     */
+    public function __construct(Repository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @return FilesCollection
+     */
+    public function locate()
+    {
+        $allFiles = trim($this->repository->run('ls-files'));
+        $filePaths = explode(PHP_EOL, $allFiles);
+
+        $files = array();
+        foreach ($filePaths as $file) {
+            $files[] = new SplFileInfo($file);
+
+        }
+
+        return new FilesCollection($files);
+    }
+}

--- a/src/GrumPHP/Runner/TaskRunner.php
+++ b/src/GrumPHP/Runner/TaskRunner.php
@@ -80,12 +80,12 @@ class TaskRunner
             try {
                 $this->eventDispatcher->dispatch(TaskEvents::TASK_RUN, new TaskEvent($task));
                 $task->run($context);
+                $this->eventDispatcher->dispatch(TaskEvents::TASK_COMPLETE, new TaskEvent($task));
             } catch (RuntimeException $e) {
                 $this->eventDispatcher->dispatch(TaskEvents::TASK_FAILED, new TaskFailedEvent($task, $e));
                 $messages[] = $e->getMessage();
                 $failures = true;
             }
-            $this->eventDispatcher->dispatch(TaskEvents::TASK_COMPLETE, new TaskEvent($task));
         }
 
         if ($failures) {

--- a/src/GrumPHP/Runner/TaskRunner.php
+++ b/src/GrumPHP/Runner/TaskRunner.php
@@ -4,10 +4,17 @@ namespace GrumPHP\Runner;
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\TasksCollection;
+use GrumPHP\Event\RunnerEvent;
+use GrumPHP\Event\RunnerEvents;
+use GrumPHP\Event\RunnerFailedEvent;
+use GrumPHP\Event\TaskEvent;
+use GrumPHP\Event\TaskEvents;
+use GrumPHP\Event\TaskFailedEvent;
 use GrumPHP\Exception\FailureException;
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Class TaskRunner
@@ -19,14 +26,22 @@ class TaskRunner
     /**
      * @var TasksCollection|TaskInterface[]
      */
-    protected $tasks;
+    private $tasks;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
 
     /**
      * @constructor
+     *
+     * @param EventDispatcherInterface $eventDispatcher
      */
-    public function __construct()
+    public function __construct(EventDispatcherInterface $eventDispatcher)
     {
         $this->tasks = new TasksCollection();
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -58,19 +73,26 @@ class TaskRunner
     {
         $failures = false;
         $messages = array();
-
         $tasks = $this->tasks->filterByContext($context);
+
+        $this->eventDispatcher->dispatch(RunnerEvents::RUNNER_RUN, new RunnerEvent($tasks));
         foreach ($tasks as $task) {
             try {
+                $this->eventDispatcher->dispatch(TaskEvents::TASK_RUN, new TaskEvent($task));
                 $task->run($context);
             } catch (RuntimeException $e) {
-                $failures = true;
+                $this->eventDispatcher->dispatch(TaskEvents::TASK_FAILED, new TaskFailedEvent($task, $e));
                 $messages[] = $e->getMessage();
+                $failures = true;
             }
+            $this->eventDispatcher->dispatch(TaskEvents::TASK_COMPLETE, new TaskEvent($task));
         }
 
         if ($failures) {
+            $this->eventDispatcher->dispatch(RunnerEvents::RUNNER_FAILED, new RunnerFailedEvent($tasks, $messages));
             throw new FailureException(implode(PHP_EOL, $messages));
         }
+
+        $this->eventDispatcher->dispatch(RunnerEvents::RUNNER_COMPLETE, new RunnerEvent($tasks));
     }
 }

--- a/src/GrumPHP/Task/Behat.php
+++ b/src/GrumPHP/Task/Behat.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
 
 /**
  * Behat task
@@ -40,7 +41,7 @@ class Behat extends AbstractExternalTask
      */
     public function canRunInContext(ContextInterface $context)
     {
-        return ($context instanceof GitPreCommitContext);
+        return ($context instanceof GitPreCommitContext || $context instanceof RunContext);
     }
 
     /**

--- a/src/GrumPHP/Task/Context/RunContext.php
+++ b/src/GrumPHP/Task/Context/RunContext.php
@@ -11,7 +11,6 @@ use GrumPHP\Collection\FilesCollection;
  */
 class RunContext implements ContextInterface
 {
-
     /**
      * @var FilesCollection
      */

--- a/src/GrumPHP/Task/Context/RunContext.php
+++ b/src/GrumPHP/Task/Context/RunContext.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace GrumPHP\Task\Context;
+
+use GrumPHP\Collection\FilesCollection;
+
+/**
+ * Class RunContext
+ *
+ * @package GrumPHP\Task\Context
+ */
+class RunContext implements ContextInterface
+{
+
+    /**
+     * @var FilesCollection
+     */
+    private $files;
+
+    /**
+     * @param FilesCollection $files
+     */
+    public function __construct(FilesCollection $files)
+    {
+        $this->files = $files;
+    }
+
+    /**
+     * @return FilesCollection
+     */
+    public function getFiles()
+    {
+        return $this->files;
+    }
+}

--- a/src/GrumPHP/Task/Phpcs.php
+++ b/src/GrumPHP/Task/Phpcs.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
 
 /**
  * Phpcs task
@@ -41,7 +42,7 @@ class Phpcs extends AbstractExternalTask
      */
     public function canRunInContext(ContextInterface $context)
     {
-        return ($context instanceof GitPreCommitContext);
+        return ($context instanceof GitPreCommitContext || $context instanceof RunContext);
     }
 
     /**

--- a/src/GrumPHP/Task/Phpcsfixer.php
+++ b/src/GrumPHP/Task/Phpcsfixer.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
 
 /**
  * Php-cs-fixer task
@@ -41,7 +42,7 @@ class Phpcsfixer extends AbstractExternalTask
      */
     public function canRunInContext(ContextInterface $context)
     {
-        return ($context instanceof GitPreCommitContext);
+        return ($context instanceof GitPreCommitContext || $context instanceof RunContext);
     }
 
     /**

--- a/src/GrumPHP/Task/Phpspec.php
+++ b/src/GrumPHP/Task/Phpspec.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
 
 /**
  * Phpspec task
@@ -38,7 +39,7 @@ class Phpspec extends AbstractExternalTask
      */
     public function canRunInContext(ContextInterface $context)
     {
-        return ($context instanceof GitPreCommitContext);
+        return ($context instanceof GitPreCommitContext || $context instanceof RunContext);
     }
 
     /**

--- a/src/GrumPHP/Task/Phpunit.php
+++ b/src/GrumPHP/Task/Phpunit.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
 
 /**
  * Phpunit task
@@ -37,7 +38,7 @@ class Phpunit extends AbstractExternalTask
      */
     public function canRunInContext(ContextInterface $context)
     {
-        return ($context instanceof GitPreCommitContext);
+        return ($context instanceof GitPreCommitContext || $context instanceof RunContext);
     }
 
     /**


### PR DESCRIPTION
This PR will make it possible to:

- Hook in GrumPHP through events
- Display progress when runnning tasks. This way you know WHY a commit is taking a long time. It is always enabled at the moment but could be configurable in the future.
- A basic run command that will run the commands on all the files that are registered to git.
- A new locator that can find out which files are and will be committed to git.
- Use the grumphp command system-wide

This will resolve issues: #46, #33, #20 and #42.
For know it seems enough for CI to be able to run the tasks with the run command.

Another issue should be opened to make it possible to skip tests when running the tasks.

Can you take a look at this @aderuwe, @igormukhingmailcom ? Thanks!