### PR TITLE
Remove branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,10 +44,7 @@
         }
     ],
     "extra": {
-      "class": "GrumPHP\\Composer\\GrumPHPPlugin",
-      "branch-alias": {
-        "dev-master": "0.2-dev"
-      }
+      "class": "GrumPHP\\Composer\\GrumPHPPlugin"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
With the frequent tagging/releasing that we do, we probably don't need a branch alias after all. And having it point to 0.2.x-dev was no longer correct in any case.