### PR TITLE
Unset the default value for the config option

### DIFF
--- a/spec/GrumPHP/Task/PhpcsfixerSpec.php
+++ b/spec/GrumPHP/Task/PhpcsfixerSpec.php
@@ -60,7 +60,6 @@ class PhpcsfixerSpec extends ObjectBehavior
 
     function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
     {
-        $processBuilder->add('--config=default')->shouldBeCalled();
         $processBuilder->add('--verbose')->shouldBeCalled();
         $processBuilder->add('fix')->shouldBeCalled();
         $processBuilder->add('file1.php')->shouldBeCalled();
@@ -83,7 +82,6 @@ class PhpcsfixerSpec extends ObjectBehavior
         Process $process,
         ContextInterface $context
     ) {
-        $processBuilder->add('--config=default')->shouldBeCalled();
         $processBuilder->add('--verbose')->shouldBeCalled();
         $processBuilder->add('fix')->shouldBeCalled();
         $processBuilder->add('file1.php')->shouldBeCalled();

--- a/src/GrumPHP/Task/Phpcsfixer.php
+++ b/src/GrumPHP/Task/Phpcsfixer.php
@@ -20,7 +20,7 @@ class Phpcsfixer extends AbstractExternalTask
     public function getDefaultConfiguration()
     {
         return array(
-            'config' => 'default',
+            'config' => null,
             'config_file' => null,
             'fixers' => array(),
             'level' => '',


### PR DESCRIPTION
As --config value shadow the configuration used in the file selected by --config-file
and we was using always the default --config=default in the process,
the config in the file was never used