### PR TITLE
Make it easier to configure task.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "symfony/event-dispatcher": "~2.5|~3.0",
         "symfony/filesystem": "~2.4|~3.0",
         "symfony/finder": "~2.4|~3.0",
-        "symfony/options-resolver": "~2.3|~3.0",
+        "symfony/options-resolver": "~2.6|~3.0",
         "symfony/process": "~2.4|~3.0",
         "symfony/yaml": "~2.4|~3.0"
     },

--- a/spec/GrumPHP/Task/BehatSpec.php
+++ b/spec/GrumPHP/Task/BehatSpec.php
@@ -32,6 +32,16 @@ class BehatSpec extends ObjectBehavior
         $this->getName()->shouldBe('behat');
     }
 
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
+        $options->getDefinedOptions()->shouldContain('config');
+        $options->getDefinedOptions()->shouldContain('format');
+        $options->getDefinedOptions()->shouldContain('suite');
+        $options->getDefinedOptions()->shouldContain('stop_on_failure');
+    }
+
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
     {
         $this->canRunInContext($context)->shouldReturn(true);

--- a/spec/GrumPHP/Task/CodeceptionSpec.php
+++ b/spec/GrumPHP/Task/CodeceptionSpec.php
@@ -32,6 +32,16 @@ class CodeceptionSpec extends ObjectBehavior
         $this->getName()->shouldBe('codeception');
     }
 
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
+        $options->getDefinedOptions()->shouldContain('config_file');
+        $options->getDefinedOptions()->shouldContain('suite');
+        $options->getDefinedOptions()->shouldContain('test');
+        $options->getDefinedOptions()->shouldContain('fail-fast');
+    }
+
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
     {
         $this->canRunInContext($context)->shouldReturn(true);

--- a/spec/GrumPHP/Task/Git/BlacklistSpec.php
+++ b/spec/GrumPHP/Task/Git/BlacklistSpec.php
@@ -32,6 +32,13 @@ class BlacklistSpec extends ObjectBehavior
         $this->getName()->shouldBe('git_blacklist');
     }
 
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
+        $options->getDefinedOptions()->shouldContain('keywords');
+    }
+
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
     {
         $this->canRunInContext($context)->shouldReturn(true);

--- a/spec/GrumPHP/Task/Git/CommitMessageSpec.php
+++ b/spec/GrumPHP/Task/Git/CommitMessageSpec.php
@@ -22,6 +22,15 @@ class CommitMessageSpec extends ObjectBehavior
         $this->getName()->shouldBe('git_commit_message');
     }
 
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
+        $options->getDefinedOptions()->shouldContain('case_insensitive');
+        $options->getDefinedOptions()->shouldContain('multiline');
+        $options->getDefinedOptions()->shouldContain('matchers');
+    }
+
     function it_is_initializable()
     {
         $this->shouldHaveType('GrumPHP\Task\Git\CommitMessage');

--- a/spec/GrumPHP/Task/GruntSpec.php
+++ b/spec/GrumPHP/Task/GruntSpec.php
@@ -32,6 +32,15 @@ class GruntSpec extends ObjectBehavior
         $this->getName()->shouldBe('grunt');
     }
 
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
+        $options->getDefinedOptions()->shouldContain('grunt_file');
+        $options->getDefinedOptions()->shouldContain('task');
+        $options->getDefinedOptions()->shouldContain('triggered_by');
+    }
+
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
     {
         $this->canRunInContext($context)->shouldReturn(true);

--- a/spec/GrumPHP/Task/PhpcsSpec.php
+++ b/spec/GrumPHP/Task/PhpcsSpec.php
@@ -33,6 +33,17 @@ class PhpcsSpec extends ObjectBehavior
         $this->getName()->shouldBe('phpcs');
     }
 
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
+        $options->getDefinedOptions()->shouldContain('standard');
+        $options->getDefinedOptions()->shouldContain('show_warnings');
+        $options->getDefinedOptions()->shouldContain('tab_width');
+        $options->getDefinedOptions()->shouldContain('ignore_patterns');
+        $options->getDefinedOptions()->shouldContain('sniffs');
+    }
+
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
     {
         $this->canRunInContext($context)->shouldReturn(true);

--- a/spec/GrumPHP/Task/PhpcsfixerSpec.php
+++ b/spec/GrumPHP/Task/PhpcsfixerSpec.php
@@ -33,6 +33,17 @@ class PhpcsfixerSpec extends ObjectBehavior
         $this->getName()->shouldBe('phpcsfixer');
     }
 
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
+        $options->getDefinedOptions()->shouldContain('config');
+        $options->getDefinedOptions()->shouldContain('config_file');
+        $options->getDefinedOptions()->shouldContain('fixers');
+        $options->getDefinedOptions()->shouldContain('level');
+        $options->getDefinedOptions()->shouldContain('verbose');
+    }
+
     function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder, ContextInterface $context)
     {
         $processBuilder->createArgumentsForCommand('php-cs-fixer')->shouldNotBeCalled();

--- a/spec/GrumPHP/Task/PhpspecSpec.php
+++ b/spec/GrumPHP/Task/PhpspecSpec.php
@@ -33,6 +33,14 @@ class PhpspecSpec extends ObjectBehavior
         $this->getName()->shouldBe('phpspec');
     }
 
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
+        $options->getDefinedOptions()->shouldContain('config_file');
+        $options->getDefinedOptions()->shouldContain('stop_on_failure');
+    }
+
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
     {
         $this->canRunInContext($context)->shouldReturn(true);

--- a/spec/GrumPHP/Task/PhpunitSpec.php
+++ b/spec/GrumPHP/Task/PhpunitSpec.php
@@ -32,6 +32,13 @@ class PhpunitSpec extends ObjectBehavior
         $this->getName()->shouldBe('phpunit');
     }
 
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
+        $options->getDefinedOptions()->shouldContain('config_file');
+    }
+
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
     {
         $this->canRunInContext($context)->shouldReturn(true);

--- a/src/GrumPHP/Task/AbstractExternalTask.php
+++ b/src/GrumPHP/Task/AbstractExternalTask.php
@@ -37,9 +37,8 @@ abstract class AbstractExternalTask implements TaskInterface
      */
     public function getConfiguration()
     {
-        return array_merge(
-            $this->getDefaultConfiguration(),
-            $this->grumPHP->getTaskConfiguration($this->getName())
-        );
+        $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+
+        return $this->getConfigurableOptions()->resolve($configured);
     }
 }

--- a/src/GrumPHP/Task/Behat.php
+++ b/src/GrumPHP/Task/Behat.php
@@ -37,7 +37,7 @@ class Behat extends AbstractExternalTask
         $resolver->addAllowedTypes('config', array('null', 'string'));
         $resolver->addAllowedTypes('format', array('null', 'string'));
         $resolver->addAllowedTypes('suite', array('null', 'string'));
-        $resolver->addAllowedTypes('stop_on_failure', array('boolean'));
+        $resolver->addAllowedTypes('stop_on_failure', array('bool'));
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Behat.php
+++ b/src/GrumPHP/Task/Behat.php
@@ -6,6 +6,7 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Behat task
@@ -21,16 +22,24 @@ class Behat extends AbstractExternalTask
     }
 
     /**
-     * @return array
+     * @return OptionsResolver
      */
-    public function getDefaultConfiguration()
+    public function getConfigurableOptions()
     {
-        return array(
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults(array(
             'config' => null,
             'format' => null,
             'suite' => null,
             'stop_on_failure' => false,
-        );
+        ));
+
+        $resolver->addAllowedTypes('config', array('null', 'string'));
+        $resolver->addAllowedTypes('format', array('null', 'string'));
+        $resolver->addAllowedTypes('suite', array('null', 'string'));
+        $resolver->addAllowedTypes('stop_on_failure', array('boolean'));
+
+        return $resolver;
     }
 
     /**

--- a/src/GrumPHP/Task/Codeception.php
+++ b/src/GrumPHP/Task/Codeception.php
@@ -6,6 +6,7 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Codeception task
@@ -23,18 +24,24 @@ class Codeception extends AbstractExternalTask
     }
 
     /**
-     * Default command configuration
-     *
-     * @return array
+     * @return OptionsResolver
      */
-    public function getDefaultConfiguration()
+    public function getConfigurableOptions()
     {
-        return array(
-            'config_file'   => null,
-            'suite'         => null,
-            'test'          => null,
-            'fail-fast'     => null
-        );
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults(array(
+            'config_file' => null,
+            'suite' => null,
+            'test'  => null,
+            'fail-fast' => false
+        ));
+
+        $resolver->addAllowedTypes('config_file', array('null', 'string'));
+        $resolver->addAllowedTypes('suite', array('null', 'string'));
+        $resolver->addAllowedTypes('test', array('null', 'string'));
+        $resolver->addAllowedTypes('fail-fast', array('boolean'));
+
+        return $resolver;
     }
 
     /**
@@ -60,9 +67,9 @@ class Codeception extends AbstractExternalTask
         $arguments = $this->processBuilder->createArgumentsForCommand('codecept');
         $arguments->add('run');
         $arguments->addOptionalArgument('--config=%s', $config['config_file']);
-        $arguments->addOptionalArgument('--fail-fast=%s', $config['fail-fast']);
-        $arguments->addOptionalArgument('suite', $config['suite']);
-        $arguments->addOptionalArgument('test', $config['test']);
+        $arguments->addOptionalArgument('--fail-fast', $config['fail-fast']);
+        $arguments->addOptionalArgument('%s', $config['suite']);
+        $arguments->addOptionalArgument('%s', $config['test']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();

--- a/src/GrumPHP/Task/Codeception.php
+++ b/src/GrumPHP/Task/Codeception.php
@@ -39,7 +39,7 @@ class Codeception extends AbstractExternalTask
         $resolver->addAllowedTypes('config_file', array('null', 'string'));
         $resolver->addAllowedTypes('suite', array('null', 'string'));
         $resolver->addAllowedTypes('test', array('null', 'string'));
-        $resolver->addAllowedTypes('fail-fast', array('boolean'));
+        $resolver->addAllowedTypes('fail-fast', array('bool'));
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Git/Blacklist.php
+++ b/src/GrumPHP/Task/Git/Blacklist.php
@@ -6,6 +6,7 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\AbstractExternalTask;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Git Blacklist Task
@@ -23,13 +24,18 @@ class Blacklist extends AbstractExternalTask
     }
 
     /**
-     * @return array
+     * @return OptionsResolver
      */
-    public function getDefaultConfiguration()
+    public function getConfigurableOptions()
     {
-        return array(
-            'keywords' => null,
-        );
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults(array(
+            'keywords' => array(),
+        ));
+
+        $resolver->addAllowedTypes('keywords', array('array'));
+
+        return $resolver;
     }
 
     /**

--- a/src/GrumPHP/Task/Git/CommitMessage.php
+++ b/src/GrumPHP/Task/Git/CommitMessage.php
@@ -55,8 +55,8 @@ class CommitMessage implements TaskInterface
             'matchers' => array(),
         ));
 
-        $resolver->addAllowedTypes('case_insensitive', array('boolean'));
-        $resolver->addAllowedTypes('multiline', array('boolean'));
+        $resolver->addAllowedTypes('case_insensitive', array('bool'));
+        $resolver->addAllowedTypes('multiline', array('bool'));
         $resolver->addAllowedTypes('matchers', array('array'));
 
         return $resolver;

--- a/src/GrumPHP/Task/Git/CommitMessage.php
+++ b/src/GrumPHP/Task/Git/CommitMessage.php
@@ -8,6 +8,7 @@ use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitCommitMsgContext;
 use GrumPHP\Task\TaskInterface;
 use GrumPHP\Util\Regex;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Git CommitMessage Task
@@ -37,22 +38,28 @@ class CommitMessage implements TaskInterface
      */
     public function getConfiguration()
     {
-        return array_merge(
-            $this->getDefaultConfiguration(),
-            $this->grumPHP->getTaskConfiguration($this->getName())
-        );
+        $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+
+        return $this->getConfigurableOptions()->resolve($configured);
     }
 
     /**
-     * @return array
+     * @return OptionsResolver
      */
-    public function getDefaultConfiguration()
+    public function getConfigurableOptions()
     {
-        return array(
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults(array(
             'case_insensitive' => true,
             'multiline' => true,
             'matchers' => array(),
-        );
+        ));
+
+        $resolver->addAllowedTypes('case_insensitive', array('boolean'));
+        $resolver->addAllowedTypes('multiline', array('boolean'));
+        $resolver->addAllowedTypes('matchers', array('array'));
+
+        return $resolver;
     }
 
     /**

--- a/src/GrumPHP/Task/Grunt.php
+++ b/src/GrumPHP/Task/Grunt.php
@@ -6,6 +6,7 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Grunt task
@@ -21,15 +22,22 @@ class Grunt extends AbstractExternalTask
     }
 
     /**
-     * @return array
+     * @return OptionsResolver
      */
-    public function getDefaultConfiguration()
+    public function getConfigurableOptions()
     {
-        return array(
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults(array(
             'grunt_file' => null,
             'task' => null,
             'triggered_by' => array('js', 'jsx', 'coffee', 'ts', 'less', 'sass', 'scss')
-        );
+        ));
+
+        $resolver->addAllowedTypes('grunt_file', array('null', 'string'));
+        $resolver->addAllowedTypes('task', array('null', 'string'));
+        $resolver->addAllowedTypes('triggered_by', array('array'));
+
+        return $resolver;
     }
 
     /**

--- a/src/GrumPHP/Task/Phpcs.php
+++ b/src/GrumPHP/Task/Phpcs.php
@@ -36,7 +36,7 @@ class Phpcs extends AbstractExternalTask
         ));
 
         $resolver->addAllowedTypes('standard', array('string'));
-        $resolver->addAllowedTypes('show_warnings', array('boolean'));
+        $resolver->addAllowedTypes('show_warnings', array('bool'));
         $resolver->addAllowedTypes('tab_width', array('null', 'int'));
         $resolver->addAllowedTypes('ignore_patterns', array('array'));
         $resolver->addAllowedTypes('sniffs', array('array'));

--- a/src/GrumPHP/Task/Phpcs.php
+++ b/src/GrumPHP/Task/Phpcs.php
@@ -6,6 +6,7 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Phpcs task
@@ -21,17 +22,26 @@ class Phpcs extends AbstractExternalTask
     }
 
     /**
-     * @return array
+     * @return OptionsResolver
      */
-    public function getDefaultConfiguration()
+    public function getConfigurableOptions()
     {
-        return array(
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults(array(
             'standard' => 'PSR2',
             'show_warnings' => true,
             'tab_width' => null,
             'ignore_patterns' => array(),
             'sniffs' => array(),
-        );
+        ));
+
+        $resolver->addAllowedTypes('standard', array('string'));
+        $resolver->addAllowedTypes('show_warnings', array('boolean'));
+        $resolver->addAllowedTypes('tab_width', array('null', 'int'));
+        $resolver->addAllowedTypes('ignore_patterns', array('array'));
+        $resolver->addAllowedTypes('sniffs', array('array'));
+
+        return $resolver;
     }
 
     /**

--- a/src/GrumPHP/Task/Phpcsfixer.php
+++ b/src/GrumPHP/Task/Phpcsfixer.php
@@ -7,6 +7,7 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Php-cs-fixer task
@@ -22,17 +23,26 @@ class Phpcsfixer extends AbstractExternalTask
     }
 
     /**
-     * @return array
+     * @return OptionsResolver
      */
-    public function getDefaultConfiguration()
+    public function getConfigurableOptions()
     {
-        return array(
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults(array(
             'config' => null,
             'config_file' => null,
             'fixers' => array(),
-            'level' => '',
+            'level' => null,
             'verbose' => true,
-        );
+        ));
+
+        $resolver->addAllowedTypes('config', array('null', 'string'));
+        $resolver->addAllowedTypes('config_file', array('null', 'string'));
+        $resolver->addAllowedTypes('fixers', array('array'));
+        $resolver->addAllowedTypes('level', array('null', 'string'));
+        $resolver->addAllowedTypes('verbose', array('boolean'));
+
+        return $resolver;
     }
 
     /**

--- a/src/GrumPHP/Task/Phpcsfixer.php
+++ b/src/GrumPHP/Task/Phpcsfixer.php
@@ -40,7 +40,7 @@ class Phpcsfixer extends AbstractExternalTask
         $resolver->addAllowedTypes('config_file', array('null', 'string'));
         $resolver->addAllowedTypes('fixers', array('array'));
         $resolver->addAllowedTypes('level', array('null', 'string'));
-        $resolver->addAllowedTypes('verbose', array('boolean'));
+        $resolver->addAllowedTypes('verbose', array('bool'));
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Phpspec.php
+++ b/src/GrumPHP/Task/Phpspec.php
@@ -6,6 +6,7 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Phpspec task
@@ -21,14 +22,20 @@ class Phpspec extends AbstractExternalTask
     }
 
     /**
-     * @return array
+     * @return OptionsResolver
      */
-    public function getDefaultConfiguration()
+    public function getConfigurableOptions()
     {
-        return array(
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults(array(
             'config_file' => null,
             'stop_on_failure' => false,
-        );
+        ));
+
+        $resolver->addAllowedTypes('config_file', array('null', 'string'));
+        $resolver->addAllowedTypes('stop_on_failure', array('boolean'));
+
+        return $resolver;
     }
 
     /**

--- a/src/GrumPHP/Task/Phpspec.php
+++ b/src/GrumPHP/Task/Phpspec.php
@@ -33,7 +33,7 @@ class Phpspec extends AbstractExternalTask
         ));
 
         $resolver->addAllowedTypes('config_file', array('null', 'string'));
-        $resolver->addAllowedTypes('stop_on_failure', array('boolean'));
+        $resolver->addAllowedTypes('stop_on_failure', array('bool'));
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Phpunit.php
+++ b/src/GrumPHP/Task/Phpunit.php
@@ -6,6 +6,7 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Phpunit task
@@ -21,13 +22,18 @@ class Phpunit extends AbstractExternalTask
     }
 
     /**
-     * @return array
+     * @return OptionsResolver
      */
-    public function getDefaultConfiguration()
+    public function getConfigurableOptions()
     {
-        return array(
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults(array(
             'config_file' => null,
-        );
+        ));
+
+        $resolver->addAllowedTypes('config_file', array('null', 'string'));
+
+        return $resolver;
     }
 
     /**

--- a/src/GrumPHP/Task/TaskInterface.php
+++ b/src/GrumPHP/Task/TaskInterface.php
@@ -4,6 +4,7 @@ namespace GrumPHP\Task;
 
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Task\Context\ContextInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Interface TaskInterface
@@ -24,9 +25,9 @@ interface TaskInterface
     public function getConfiguration();
 
     /**
-     * @return array
+     * @return OptionsResolver
      */
-    public function getDefaultConfiguration();
+    public function getConfigurableOptions();
 
     /**
      * This methods specifies if a task can run in a specific context.


### PR DESCRIPTION
This PR replaces the `getDefaultConfiguration()` method with a `getConfigurableOptions()` method.
By using the Symfony `OptionsResolver`, it is now easier to configure tasks in `grumphp.yml`.
When you type a typo or add a wrong configuration type, the resolver will complain and tell you what to do.