### PR TITLE
Introducting the ignore_unstaged_changes parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ parameters:
     bin_dir: "./vendor/bin"
     git_dir: "."
     stop_on_failure: false
-    ignore_unstaged_changes: false
+    ignore_unstaged_changes: true
     ascii:
         failed: grumphp-grumpy.txt
         succeeded: grumphp-happy.txt

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ parameters:
     bin_dir: "./vendor/bin"
     git_dir: "."
     stop_on_failure: false
+    ignore_unstaged_changes: false
     ascii:
         failed: grumphp-grumpy.txt
         succeeded: grumphp-happy.txt

--- a/doc/events.md
+++ b/doc/events.md
@@ -5,14 +5,17 @@ Internally the Symfony event dispatcher is being used.
 
 Following events are triggered during execution:
 
-| Event name              | Event class       | Triggered
-| ----------------------- | ----------------- | ----------
-| grumphp.task.run        | TaskEvent         | before a task is executed
-| grumphp.task.failed     | TaskFailedEvent   | when a task fails
-| grumphp.task.complete   | TaskEvent         | when a task succeeds
-| grumphp.runner.run      | RunnerEvent       | before the tasks are executed
-| grumphp.runner.failed   | RunnerFailedEvent | when one task failed
-| grumphp.runner.complete | RunnerEvent       | when all tasks succeed
+| Event name              | Event class           | Triggered
+| ----------------------- | --------------------- | ----------
+| grumphp.task.run        | TaskEvent             | before a task is executed
+| grumphp.task.failed     | TaskFailedEvent       | when a task fails
+| grumphp.task.complete   | TaskEvent             | when a task succeeds
+| grumphp.runner.run      | RunnerEvent           | before the tasks are executed
+| grumphp.runner.failed   | RunnerFailedEvent     | when one task failed
+| grumphp.runner.complete | RunnerEvent           | when all tasks succeed
+| console.command         | ConsoleCommandEvent   | before a CLI command is ran
+| console.terminate       | ConsoleTerminateEvent | before a CLI command terminates
+| console.exception       | ConsoleExceptionEvent | when a CLI command throws an unhandled exception.
 
 Configured events just like you would in Symfony: 
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -6,7 +6,7 @@ parameters:
     bin_dir: ./vendor/bin
     git_dir: .
     stop_on_failure: false
-    ignore_unstaged_changes: false
+    ignore_unstaged_changes: true
     ascii:
         failed: resource/grumphp-grumpy.txt
         succeeded: resource/grumphp-happy.txt
@@ -35,7 +35,7 @@ By default GrumPHP will continue running the configured tasks.
 
 **ignore_unstaged_changes**
 
-*Default: false*
+*Default: true*
 
 By enabling this option, GrumPHP will stash your unstaged changes in git before running the tasks.
 This way the tasks will run with the code that is actually committed without the unstaged changes.

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -6,6 +6,7 @@ parameters:
     bin_dir: ./vendor/bin
     git_dir: .
     stop_on_failure: false
+    ignore_unstaged_changes: false
     ascii:
         failed: resource/grumphp-grumpy.txt
         succeeded: resource/grumphp-happy.txt
@@ -31,6 +32,14 @@ This parameter is used to create the git hooks at the correct location. It defau
 
 This parameter will tell GrumPHP to stop running tasks when one of the tasks results in an error.
 By default GrumPHP will continue running the configured tasks. 
+
+**ignore_unstaged_changes**
+
+*Default: false*
+
+By enabling this option, GrumPHP will stash your unstaged changes in git before running the tasks.
+This way the tasks will run with the code that is actually committed without the unstaged changes.
+Note that during the commit, the unstaged changes will be stored in git stash.
 
 **ascii**
 

--- a/resources/config/parameters.yml
+++ b/resources/config/parameters.yml
@@ -3,6 +3,7 @@ parameters:
   git_dir: .
   tasks: []
   stop_on_failure: false
+  ignore_unstaged_changes: false
   extensions: []
   ascii:
     failed: grumphp-grumpy.txt

--- a/resources/config/parameters.yml
+++ b/resources/config/parameters.yml
@@ -3,7 +3,7 @@ parameters:
   git_dir: .
   tasks: []
   stop_on_failure: false
-  ignore_unstaged_changes: false
+  ignore_unstaged_changes: true
   extensions: []
   ascii:
     failed: grumphp-grumpy.txt

--- a/resources/config/services.yml
+++ b/resources/config/services.yml
@@ -5,7 +5,9 @@ services:
           - '@service_container'
 
     event_dispatcher:
-        class: Symfony\Component\EventDispatcher\EventDispatcher
+        class: Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher
+        arguments:
+          - '@service_container'
 
     filesystem:
         class: Symfony\Component\Filesystem\Filesystem

--- a/resources/config/subscribers.yml
+++ b/resources/config/subscribers.yml
@@ -1,0 +1,8 @@
+services:
+  subscriber.stash_unstaged_changes:
+    class: GrumPHP\Event\Subscriber\StashUnstagedChangesSubscriber
+    arguments:
+      - '@config'
+      - '@git.repository'
+    tags:
+      - { name: grumphp.event_subscriber }

--- a/resources/config/subscribers.yml
+++ b/resources/config/subscribers.yml
@@ -4,5 +4,6 @@ services:
     arguments:
       - '@config'
       - '@git.repository'
+      - '@grumphp.io'
     tags:
       - { name: grumphp.event_subscriber }

--- a/spec/GrumPHP/Configuration/GrumPHPSpec.php
+++ b/spec/GrumPHP/Configuration/GrumPHPSpec.php
@@ -40,6 +40,12 @@ class GrumPHPSpec extends ObjectBehavior
         $this->stopOnFailure()->shouldReturn(true);
     }
 
+    function it_knows_to_ignore_unstaged_changes(ContainerInterface $container)
+    {
+        $container->getParameter('ignore_unstaged_changes')->willReturn(true);
+        $this->ignoreUnstagedChanges()->shouldReturn(true);
+    }
+
     function it_should_return_empty_ascii_location_for_unknown_resources(ContainerInterface $container)
     {
         $container->getParameter('ascii')->willReturn(array());

--- a/spec/GrumPHP/Event/RunnerEventSpec.php
+++ b/spec/GrumPHP/Event/RunnerEventSpec.php
@@ -3,14 +3,15 @@
 namespace spec\GrumPHP\Event;
 
 use GrumPHP\Collection\TasksCollection;
+use GrumPHP\Task\Context\ContextInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class RunnerEventSpec extends ObjectBehavior
 {
-    function let(TasksCollection $tasks)
+    function let(TasksCollection $tasks, ContextInterface $context)
     {
-        $this->beConstructedWith($tasks);
+        $this->beConstructedWith($tasks, $context);
     }
 
     function it_is_initializable()
@@ -26,5 +27,10 @@ class RunnerEventSpec extends ObjectBehavior
     function it_has_tasks(TasksCollection $tasks)
     {
         $this->getTasks()->shouldBe($tasks);
+    }
+
+    function it_should_have_a_context(ContextInterface $context)
+    {
+        $this->getContext()->shouldBe($context);
     }
 }

--- a/spec/GrumPHP/Event/RunnerFailedEventSpec.php
+++ b/spec/GrumPHP/Event/RunnerFailedEventSpec.php
@@ -3,14 +3,15 @@
 namespace spec\GrumPHP\Event;
 
 use GrumPHP\Collection\TasksCollection;
+use GrumPHP\Task\Context\ContextInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class RunnerFailedEventSpec extends ObjectBehavior
 {
-    function let(TasksCollection $tasks)
+    function let(TasksCollection $tasks, ContextInterface $context)
     {
-        $this->beConstructedWith($tasks, array());
+        $this->beConstructedWith($tasks, $context, array());
     }
 
     function it_is_initializable()
@@ -26,6 +27,11 @@ class RunnerFailedEventSpec extends ObjectBehavior
     function it_has_tasks(TasksCollection $tasks)
     {
         $this->getTasks()->shouldBe($tasks);
+    }
+
+    function it_should_have_a_context(ContextInterface $context)
+    {
+        $this->getContext()->shouldBe($context);
     }
 
     function it_should_contain_the_error_messages()

--- a/spec/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriberSpec.php
+++ b/spec/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriberSpec.php
@@ -97,4 +97,15 @@ class StashUnstagedChangesSubscriberSpec extends ObjectBehavior
         $this->saveStash($event);
         $this->popStash($event);
     }
+
+    function it_should_pop_changes_when_an_error_occurs(Repository $repository)
+    {
+        $event = new RunnerEvent(new TasksCollection(), new GitPreCommitContext(new FilesCollection()));
+
+        $repository->run('stash', Argument::containing('save'))->shouldBeCalled();
+        $repository->run('stash', Argument::containing('pop'))->shouldBeCalled();
+
+        $this->saveStash($event);
+        $this->handleErrors();
+    }
 }

--- a/spec/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriberSpec.php
+++ b/spec/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriberSpec.php
@@ -9,6 +9,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\TasksCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Event\RunnerEvent;
+use GrumPHP\IO\IOInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use PhpSpec\ObjectBehavior;
@@ -16,14 +17,14 @@ use Prophecy\Argument;
 
 class StashUnstagedChangesSubscriberSpec extends ObjectBehavior
 {
-    function let(GrumPHP $grumPHP, Repository $repository, WorkingCopy $workingCopy, Diff $unstaged)
+    function let(GrumPHP $grumPHP, Repository $repository, IOInterface $io, WorkingCopy $workingCopy, Diff $unstaged)
     {
         $grumPHP->ignoreUnstagedChanges()->willReturn(true);
         $repository->getWorkingCopy()->willReturn($workingCopy);
         $workingCopy->getDiffPending()->willReturn($unstaged);
         $unstaged->getFiles()->willReturn(array('file1.php'));
 
-        $this->beConstructedWith($grumPHP, $repository);
+        $this->beConstructedWith($grumPHP, $repository, $io);
     }
 
     function it_is_initializable()

--- a/spec/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriberSpec.php
+++ b/spec/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriberSpec.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace spec\GrumPHP\Event\Subscriber;
+
+use Gitonomy\Git\Repository;
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Collection\TasksCollection;
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Event\RunnerEvent;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class StashUnstagedChangesSubscriberSpec extends ObjectBehavior
+{
+    function let(GrumPHP $grumPHP, Repository $repository)
+    {
+        $grumPHP->ignoreUnstagedChanges()->willReturn(true);
+        $this->beConstructedWith($grumPHP, $repository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Event\Subscriber\StashUnstagedChangesSubscriber');
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldImplement('Symfony\Component\EventDispatcher\EventSubscriberInterface');
+    }
+
+    function it_should_subscribe_to_events()
+    {
+        $this->getSubscribedEvents()->shouldBeArray();
+    }
+
+    function it_should_not_run_when_disabled(GrumPHP $grumPHP, Repository $repository)
+    {
+        $event = new RunnerEvent(new TasksCollection(), new GitPreCommitContext(new FilesCollection()));
+        $grumPHP->ignoreUnstagedChanges()->willReturn(false);
+
+        $this->saveStash($event);
+        $this->popStash($event);
+
+        $repository->run(Argument::cetera())->shouldNotBeCalled();
+    }
+
+    function it_should_not_run_in_invalid_context(Repository $repository)
+    {
+        $event = new RunnerEvent(new TasksCollection(), new RunContext(new FilesCollection()));
+
+        $this->saveStash($event);
+        $this->popStash($event);
+
+        $repository->run(Argument::cetera())->shouldNotBeCalled();
+    }
+
+    function it_should_not_try_to_pop_when_stash_saving_failed(Repository $repository)
+    {
+        $event = new RunnerEvent(new TasksCollection(), new GitPreCommitContext(new FilesCollection()));
+
+        $repository->run('stash', Argument::containing('save'))->willThrow('Exception');
+        $repository->run('stash', Argument::containing('pop'))->shouldNotBeCalled();
+
+        $this->saveStash($event);
+        $this->popStash($event);
+    }
+
+    function it_should_display_exception_when_pop_fails(Repository $repository)
+    {
+        $event = new RunnerEvent(new TasksCollection(), new GitPreCommitContext(new FilesCollection()));
+
+        $repository->run('stash', Argument::containing('save'))->shouldBeCalled();
+        $repository->run('stash', Argument::containing('pop'))->willThrow('Exception');
+
+        $this->saveStash($event);
+        $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringPopStash($event);
+    }
+
+    function it_should_stash_changes(Repository $repository)
+    {
+        $event = new RunnerEvent(new TasksCollection(), new GitPreCommitContext(new FilesCollection()));
+
+        $repository->run('stash', Argument::containing('save'))->shouldBeCalled();
+
+        $this->saveStash($event);
+    }
+
+    function it_should_pop_changes(Repository $repository)
+    {
+        $event = new RunnerEvent(new TasksCollection(), new GitPreCommitContext(new FilesCollection()));
+
+        $repository->run('stash', Argument::containing('save'))->shouldBeCalled();
+        $repository->run('stash', Argument::containing('pop'))->shouldBeCalled();
+
+        $this->saveStash($event);
+        $this->popStash($event);
+    }
+}

--- a/spec/GrumPHP/Event/TaskEventSpec.php
+++ b/spec/GrumPHP/Event/TaskEventSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\GrumPHP\Event;
 
+use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -9,9 +10,9 @@ use Prophecy\Argument;
 class TaskEventSpec extends ObjectBehavior
 {
 
-    function let(TaskInterface $task)
+    function let(TaskInterface $task, ContextInterface $context)
     {
-        $this->beConstructedWith($task);
+        $this->beConstructedWith($task, $context);
     }
 
     function it_is_initializable()
@@ -27,5 +28,10 @@ class TaskEventSpec extends ObjectBehavior
     function it_has_a_task(TaskInterface $task)
     {
         $this->getTask()->shouldBe($task);
+    }
+
+    function it_should_have_a_context(ContextInterface $context)
+    {
+        $this->getContext()->shouldBe($context);
     }
 }

--- a/spec/GrumPHP/Event/TaskFailedEventSpec.php
+++ b/spec/GrumPHP/Event/TaskFailedEventSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\GrumPHP\Event;
 
+use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -10,9 +11,9 @@ class TaskFailedEventSpec extends ObjectBehavior
 {
 
 
-    function let(TaskInterface $task, \Exception $exception)
+    function let(TaskInterface $task, ContextInterface $context, \Exception $exception)
     {
-        $this->beConstructedWith($task, $exception);
+        $this->beConstructedWith($task, $context, $exception);
     }
 
     function it_is_initializable()
@@ -33,5 +34,10 @@ class TaskFailedEventSpec extends ObjectBehavior
     function it_should_contain_the_exception(\Exception $exception)
     {
         $this->getException()->shouldBe($exception);
+    }
+
+    function it_should_have_a_context(ContextInterface $context)
+    {
+        $this->getContext()->shouldBe($context);
     }
 }

--- a/src/GrumPHP/Configuration/ContainerFactory.php
+++ b/src/GrumPHP/Configuration/ContainerFactory.php
@@ -30,6 +30,7 @@ final class ContainerFactory
         $loader->load('linters.yml');
         $loader->load('parameters.yml');
         $loader->load('services.yml');
+        $loader->load('subscribers.yml');
         $loader->load('tasks.yml');
 
         // Load grumphp.yml file:

--- a/src/GrumPHP/Configuration/GrumPHP.php
+++ b/src/GrumPHP/Configuration/GrumPHP.php
@@ -48,6 +48,14 @@ class GrumPHP
     }
 
     /**
+     * @return bool
+     */
+    public function ignoreUnstagedChanges()
+    {
+        return (bool) $this->container->getParameter('ignore_unstaged_changes');
+    }
+
+    /**
      * @return array
      */
     public function getRegisteredTasks()

--- a/src/GrumPHP/Console/Application.php
+++ b/src/GrumPHP/Console/Application.php
@@ -42,6 +42,9 @@ class Application extends SymfonyConsole
     public function __construct()
     {
         parent::__construct(self::APP_NAME, self::APP_VERSION);
+
+        $this->container = $this->getContainer();
+        $this->setDispatcher($this->container->get('event_dispatcher'));
     }
 
     /**

--- a/src/GrumPHP/Event/RunnerEvent.php
+++ b/src/GrumPHP/Event/RunnerEvent.php
@@ -3,6 +3,7 @@
 namespace GrumPHP\Event;
 
 use GrumPHP\Collection\TasksCollection;
+use GrumPHP\Task\Context\ContextInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -18,11 +19,18 @@ class RunnerEvent extends Event
     private $tasks;
 
     /**
-     * @param TasksCollection $tasks
+     * @var ContextInterface
      */
-    public function __construct(TasksCollection $tasks)
+    private $context;
+
+    /**
+     * @param TasksCollection  $tasks
+     * @param ContextInterface $context
+     */
+    public function __construct(TasksCollection $tasks, ContextInterface $context)
     {
         $this->tasks = $tasks;
+        $this->context = $context;
     }
 
     /**
@@ -31,5 +39,13 @@ class RunnerEvent extends Event
     public function getTasks()
     {
         return $this->tasks;
+    }
+
+    /**
+     * @return ContextInterface
+     */
+    public function getContext()
+    {
+        return $this->context;
     }
 }

--- a/src/GrumPHP/Event/RunnerFailedEvent.php
+++ b/src/GrumPHP/Event/RunnerFailedEvent.php
@@ -3,6 +3,7 @@
 namespace GrumPHP\Event;
 
 use GrumPHP\Collection\TasksCollection;
+use GrumPHP\Task\Context\ContextInterface;
 
 /**
  * Class RunnerFailedEvent
@@ -17,12 +18,13 @@ class RunnerFailedEvent extends RunnerEvent
     private $messages;
 
     /**
-     * @param TasksCollection $tasks
-     * @param array           $messages
+     * @param TasksCollection  $tasks
+     * @param ContextInterface $context
+     * @param array            $messages
      */
-    public function __construct(TasksCollection $tasks, array $messages)
+    public function __construct(TasksCollection $tasks, ContextInterface $context, array $messages)
     {
-        parent::__construct($tasks);
+        parent::__construct($tasks, $context);
         $this->messages = $messages;
     }
 

--- a/src/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriber.php
+++ b/src/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriber.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace GrumPHP\Event\Subscriber;
+
+use Exception;
+use Gitonomy\Git\Exception\ProcessException;
+use Gitonomy\Git\Repository;
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Event\RunnerEvent;
+use GrumPHP\Event\RunnerEvents;
+use GrumPHP\Exception\RuntimeException;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class StashUnstagedChangesSubscriber
+ *
+ * @package GrumPHP\Event\Subscriber
+ */
+class StashUnstagedChangesSubscriber implements EventSubscriberInterface
+{
+
+    /**
+     * @var GrumPHP
+     */
+    private $grumPHP;
+
+    /**
+     * @var Repository
+     */
+    private $repository;
+
+    /**
+     * @var bool
+     */
+    private $stashIsApplied = false;
+
+    /**
+     * @param GrumPHP    $grumPHP
+     * @param Repository $repository
+     */
+    public function __construct(GrumPHP $grumPHP, Repository $repository)
+    {
+        $this->grumPHP = $grumPHP;
+        $this->repository = $repository;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            RunnerEvents::RUNNER_RUN => 'saveStash',
+            RunnerEvents::RUNNER_COMPLETE => 'popStash',
+            RunnerEvents::RUNNER_FAILED => 'popStash',
+        );
+    }
+
+    /**
+     * @param RunnerEvent $e
+     *
+     * @return void
+     */
+    public function saveStash(RunnerEvent $e)
+    {
+        if (!$this->isStashEnabled($e->getContext())) {
+            return;
+        }
+
+        try {
+            $this->repository->run('stash', array('save', '--quiet', '--keep-index', uniqid('grumphp')));
+        } catch (Exception $e) {
+            // No worries ...
+            return;
+        }
+
+        $this->stashIsApplied = true;
+    }
+
+    /**
+     * @param RunnerEvent $e
+     *
+     * @return void
+     * @throws ProcessException
+     */
+    public function popStash(RunnerEvent $e)
+    {
+        if (!$this->isStashEnabled($e->getContext()) || !$this->stashIsApplied) {
+            return;
+        }
+
+        try {
+            $this->repository->run('stash', array('pop', '--quiet'));
+        } catch (Exception $e) {
+            throw new RuntimeException(
+                'The stashed changes could not be applied. Please run `git stash pop` manually!'
+                . 'More info: ' . $e->__toString(),
+                0,
+                $e
+            );
+        }
+
+        $this->stashIsApplied = false;
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    private function isStashEnabled(ContextInterface $context)
+    {
+        return $this->grumPHP->ignoreUnstagedChanges() && $context instanceof GitPreCommitContext;
+    }
+}

--- a/src/GrumPHP/Event/TaskEvent.php
+++ b/src/GrumPHP/Event/TaskEvent.php
@@ -2,6 +2,7 @@
 
 namespace GrumPHP\Event;
 
+use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 use Symfony\Component\EventDispatcher\Event;
 
@@ -18,11 +19,18 @@ class TaskEvent extends Event
     private $task;
 
     /**
-     * @param TaskInterface $task
+     * @var ContextInterface
      */
-    public function __construct(TaskInterface $task)
+    private $context;
+
+    /**
+     * @param TaskInterface    $task
+     * @param ContextInterface $context
+     */
+    public function __construct(TaskInterface $task, ContextInterface $context)
     {
         $this->task = $task;
+        $this->context = $context;
     }
 
     /**
@@ -31,5 +39,13 @@ class TaskEvent extends Event
     public function getTask()
     {
         return $this->task;
+    }
+
+    /**
+     * @return ContextInterface
+     */
+    public function getContext()
+    {
+        return $this->context;
     }
 }

--- a/src/GrumPHP/Event/TaskFailedEvent.php
+++ b/src/GrumPHP/Event/TaskFailedEvent.php
@@ -3,6 +3,7 @@
 namespace GrumPHP\Event;
 
 use Exception;
+use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 
 /**
@@ -18,12 +19,13 @@ class TaskFailedEvent extends TaskEvent
     private $exception;
 
     /**
-     * @param TaskInterface $task
-     * @param Exception     $exception
+     * @param TaskInterface    $task
+     * @param ContextInterface $context
+     * @param Exception        $exception
      */
-    public function __construct(TaskInterface $task, Exception $exception)
+    public function __construct(TaskInterface $task, ContextInterface $context, Exception $exception)
     {
-        parent::__construct($task);
+        parent::__construct($task, $context);
 
         $this->exception = $exception;
     }


### PR DESCRIPTION
Introducting the ignore_unstaged_changes parameter that saved unstaged files to the stash before running the pre-commit tasks.

More information can be found in #100.

**Note that this PR will result in some BC breaks!!!**