### PR TITLE
Ability to use logger feature of gitonomy/gitlib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,13 @@
         "roave/security-advisories": "dev-master@dev",
         "fabpot/php-cs-fixer": "~1.0",
         "phpunit/phpunit": "^4.8",
-        "sensiolabs/security-checker": "^3.0"
+        "sensiolabs/security-checker": "^3.0",
+        "monolog/monolog": "~1.17"
     },
     "suggest": {
         "behat/behat": "Lets GrumPHP validate your project features.",
         "fabpot/php-cs-fixer": "Lets GrumPHP automatically fix your codestyle.",
+        "monolog/monolog": "Allow logging repository files retrieval",
         "phpspec/phpspec": "Lets GrumPHP spec your code.",
         "phpunit/phpunit": "Lets GrumPHP run your unit tests.",
         "squizlabs/php_codesniffer": "Lets GrumPHP sniff on your code.",

--- a/resources/config/services.yml
+++ b/resources/config/services.yml
@@ -23,6 +23,16 @@ services:
         arguments:
           - '%git_dir%'
 
+    logger.changed_files:
+        class: Monolog\Logger
+        arguments:
+          - "ChangedFiles"
+
+    logger.registered_files:
+        class: Monolog\Logger
+        arguments:
+          - "RegisteredFiles"
+
     task_runner:
         class: GrumPHP\Runner\TaskRunner
         arguments:
@@ -39,8 +49,10 @@ services:
         class: GrumPHP\Locator\ChangedFiles
         arguments:
           - '@git.repository'
+          - '@logger.changed_files'
 
     locator.registered_files:
         class: GrumPHP\Locator\RegisteredFiles
         arguments:
           - '@git.repository'
+          - '@logger.registered_files'

--- a/spec/GrumPHP/Locator/ChangedFilesSpec.php
+++ b/spec/GrumPHP/Locator/ChangedFilesSpec.php
@@ -9,12 +9,13 @@ use Gitonomy\Git\Repository;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Prophecy\Prophet;
+use Psr\Log\LoggerInterface;
 
 class ChangedFilesSpec extends ObjectBehavior
 {
-    function let(Repository $repository)
+    function let(Repository $repository, LoggerInterface $logger)
     {
-        $this->beConstructedWith($repository);
+        $this->beConstructedWith($repository, $logger);
     }
 
     function it_is_initializable()

--- a/spec/GrumPHP/Locator/RegisteredFilesSpec.php
+++ b/spec/GrumPHP/Locator/RegisteredFilesSpec.php
@@ -5,12 +5,13 @@ namespace spec\GrumPHP\Locator;
 use Gitonomy\Git\Repository;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
 
 class RegisteredFilesSpec extends ObjectBehavior
 {
-    function let(Repository $repository)
+    function let(Repository $repository, LoggerInterface $logger)
     {
-        $this->beConstructedWith($repository);
+        $this->beConstructedWith($repository, $logger);
     }
 
     function it_is_initializable()

--- a/src/GrumPHP/Console/Command/Git/CommitMsgCommand.php
+++ b/src/GrumPHP/Console/Command/Git/CommitMsgCommand.php
@@ -63,6 +63,10 @@ class CommitMsgCommand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+            $this->changedFilesLocator->setLogger();
+        }
+
         $files = $this->getCommittedFiles();
         $gitUser = $input->getOption('git-user');
         $gitEmail = $input->getOption('git-email');

--- a/src/GrumPHP/Console/Command/Git/PreCommitCommand.php
+++ b/src/GrumPHP/Console/Command/Git/PreCommitCommand.php
@@ -64,6 +64,10 @@ class PreCommitCommand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+            $this->changedFilesLocator->setLogger();
+        }
+
         $files = $this->getCommittedFiles();
         $context = new GitPreCommitContext($files);
         $skipSuccessOutput = (bool) $input->getOption('skip-success-output');

--- a/src/GrumPHP/Console/Command/RunCommand.php
+++ b/src/GrumPHP/Console/Command/RunCommand.php
@@ -59,6 +59,10 @@ class RunCommand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+            $this->registeredFilesLocator->setLogger();
+        }
+
         $files = $this->getRegisteredFiles();
         $context = new RunContext($files);
 

--- a/src/GrumPHP/Locator/AbstractFiles.php
+++ b/src/GrumPHP/Locator/AbstractFiles.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace GrumPHP\Locator;
+
+use Gitonomy\Git\Repository;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class Git
+ *
+ * @package GrumPHP\Locator
+ */
+abstract class AbstractFiles
+{
+    /**
+     * @var Repository
+     */
+    protected $repository;
+
+    /**
+     * @var Psr\Log\LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @param Repository $repository
+     * @param Psr\Log\LoggerInterface $logger Compatible PSR-3 logger
+     */
+    public function __construct(Repository $repository, LoggerInterface $logger)
+    {
+        $this->repository = $repository;
+        $this->logger     = $logger;
+    }
+
+    /**
+     * Sets a PSR-3 logger
+     * @return $this
+     */
+    public function setLogger()
+    {
+        $this->repository->setLogger($this->logger);
+
+        return $this;
+    }
+}

--- a/src/GrumPHP/Locator/ChangedFiles.php
+++ b/src/GrumPHP/Locator/ChangedFiles.php
@@ -6,28 +6,15 @@ use Gitonomy\Git\Diff\File;
 use Gitonomy\Git\Repository;
 use GrumPHP\Collection\FilesCollection;
 use Symfony\Component\Finder\SplFileInfo;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class Git
  *
  * @package GrumPHP\Locator
  */
-class ChangedFiles
+class ChangedFiles extends AbstractFiles
 {
-    /**
-     * @var Repository
-     */
-    protected $repository;
-
-    /**
-     * @param Repository $repository
-     */
-    public function __construct(Repository $repository)
-    {
-        $this->repository = $repository;
-
-    }
-
     /**
      * @return FilesCollection
      */

--- a/src/GrumPHP/Locator/RegisteredFiles.php
+++ b/src/GrumPHP/Locator/RegisteredFiles.php
@@ -5,27 +5,15 @@ namespace GrumPHP\Locator;
 use Gitonomy\Git\Repository;
 use GrumPHP\Collection\FilesCollection;
 use Symfony\Component\Finder\SplFileInfo;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class RegisteredFiles
  *
  * @package GrumPHP\Locator
  */
-class RegisteredFiles
+class RegisteredFiles extends AbstractFiles
 {
-    /**
-     * @var Repository
-     */
-    private $repository;
-
-    /**
-     * @param Repository $repository
-     */
-    public function __construct(Repository $repository)
-    {
-        $this->repository = $repository;
-    }
-
     /**
      * @return FilesCollection
      */


### PR DESCRIPTION
Use console verbose level 1, 2, or 3

Examples:
```
grumphp run -v
[2016-02-06 13:23:40] RegisteredFiles.INFO: run command: ls-files ""  [] []
[2016-02-06 13:23:41] RegisteredFiles.DEBUG: last command (ls-files) duration: 312.00ms [] []
[2016-02-06 13:23:41] RegisteredFiles.DEBUG: last command (ls-files) return code: 0 [] []
[2016-02-06 13:23:41] RegisteredFiles.DEBUG: last command (ls-files) output: task/Phpparser.php task/sample2.php  [] []
GrumPHP is sniffing your code!
Running task 1/6: Phpcs
Running task 2/6: Phpspec
Running task 3/6: Phpunit
Running task 4/6: Composer
Running task 5/6: SecurityChecker
Running task 6/6: YamlLint
```

```
grumphp git:pre-commit -vv
[2016-02-06 13:26:11] ChangedFiles.INFO: run command: diff "-r -p -m -M --full-index --staged"  [] []
[2016-02-06 13:26:11] ChangedFiles.DEBUG: last command (diff) duration: 327.60ms [] []
[2016-02-06 13:26:11] ChangedFiles.DEBUG: last command (diff) return code: 0 [] []

and more ...
```

```
grumphp git:commit-msg -v "blah bla"
[2016-02-06 13:27:43] ChangedFiles.INFO: run command: diff "-r -p -m -M --full-index --staged"  [] []
[2016-02-06 13:27:43] ChangedFiles.DEBUG: last command (diff) duration: 327.60ms [] []
[2016-02-06 13:27:43] ChangedFiles.DEBUG: last command (diff) return code: 0 [] []

and lot more ...
```

