### PR TITLE
Fix git blacklist task

### DIFF
--- a/spec/GrumPHP/Collection/ProcessArgumentsCollectionSpec.php
+++ b/spec/GrumPHP/Collection/ProcessArgumentsCollectionSpec.php
@@ -48,6 +48,17 @@ class ProcessArgumentsCollectionSpec extends ObjectBehavior
         ));
     }
 
+    function it_should_be_able_to_add_an_argument_array_with_separated_values()
+    {
+        $this->addArgumentArrayWithSeparatedValue('--item', array(1, 2));
+        $this->getValues()->shouldBe(array(
+            '--item',
+            1,
+            '--item',
+            2,
+        ));
+    }
+
     function it_should_be_able_to_add_required_argument()
     {
         $this->shouldThrow('GrumPHP\Exception\InvalidArgumentException')->duringAddRequiredArgument('--argument=%s', false);

--- a/src/GrumPHP/Collection/ProcessArgumentsCollection.php
+++ b/src/GrumPHP/Collection/ProcessArgumentsCollection.php
@@ -61,6 +61,20 @@ class ProcessArgumentsCollection extends ArrayCollection
     }
 
     /**
+     * Some CLI tools prefer to split the argument and the value.
+     *
+     * @param       $argument
+     * @param array $values
+     */
+    public function addArgumentArrayWithSeparatedValue($argument, array $values)
+    {
+        foreach ($values as $value) {
+            $this->add(sprintf($argument, $value));
+            $this->add($value);
+        }
+    }
+
+    /**
      * @param string $argument
      * @param string $value
      */

--- a/src/GrumPHP/Task/Git/Blacklist.php
+++ b/src/GrumPHP/Task/Git/Blacklist.php
@@ -63,7 +63,7 @@ class Blacklist extends AbstractExternalTask
         $arguments->add('grep');
         $arguments->add('--cached');
         $arguments->add('-n');
-        $arguments->addArgumentArray('-e %s', $config['keywords']);
+        $arguments->addArgumentArrayWithSeparatedValue('-e', $config['keywords']);
         $arguments->addFiles($files);
 
         $process = $this->processBuilder->buildProcess($arguments);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #124 

This ticket contains an additional option to add an array of arguments but with a separated entry for the value itself. This can be handy to create options like: `'-e' 'pattern'`
This commit also fixes the git blacklist task.