### PR TITLE
Phpcs: Don't use the PSR2 standard by default.

### DIFF
--- a/doc/tasks/phpcs.md
+++ b/doc/tasks/phpcs.md
@@ -8,7 +8,7 @@ It lives under the `phpcs` namespace and has following configurable parameters:
 parameters:
     tasks:
         phpcs:
-            standard: PSR2
+            standard: ~
             show_warnings: true
             tab_width: ~
             ignore_patterns: []
@@ -19,9 +19,19 @@ parameters:
 
 **standard**
 
-*Default: PSR2*
+*Default: null*
 
 This parameter will describe which standard is being used to validate your code for bad coding standards.
+By default it is set to null so that the Phpcs defaults are being used.
+Phpcs will be using the PEAR or local `phpcs.xml` standard by default.
+You can configure this task to use any standard supported by the Phpcs CLI.
+For Example: `PEAR`, `PHPCS`, `PSR1`, `PSR2`, `Squiz` and `Zend`
+
+You can get a list of all installed phpcs standards with the command:
+
+```sh
+phpcs -i
+```
 
 
 **show_warnings**

--- a/src/GrumPHP/Task/Phpcs.php
+++ b/src/GrumPHP/Task/Phpcs.php
@@ -28,7 +28,7 @@ class Phpcs extends AbstractExternalTask
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults(array(
-            'standard' => 'PSR2',
+            'standard' => null,
             'show_warnings' => true,
             'tab_width' => null,
             'ignore_patterns' => array(),
@@ -36,7 +36,7 @@ class Phpcs extends AbstractExternalTask
             'triggered_by' => array('php')
         ));
 
-        $resolver->addAllowedTypes('standard', array('string'));
+        $resolver->addAllowedTypes('standard', array('null', 'string'));
         $resolver->addAllowedTypes('show_warnings', array('bool'));
         $resolver->addAllowedTypes('tab_width', array('null', 'int'));
         $resolver->addAllowedTypes('ignore_patterns', array('array'));
@@ -68,7 +68,7 @@ class Phpcs extends AbstractExternalTask
         $config = $this->getConfiguration();
 
         $arguments = $this->processBuilder->createArgumentsForCommand('phpcs');
-        $arguments->addRequiredArgument('--standard=%s', $config['standard']);
+        $arguments->addOptionalArgument('--standard=%s', $config['standard']);
         $arguments->addOptionalArgument('--warning-severity=0', !$config['show_warnings']);
         $arguments->addOptionalArgument('--tab-width=%s', $config['tab_width']);
         $arguments->addOptionalCommaSeparatedArgument('--sniffs=%s', $config['sniffs']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #129

This PR will remove the default PSR2 configuration from PHPCS and use the built-in phpcs defaults instead. 
