### PR TITLE
Introduce process formatters and improve the PhpCsFixer command.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.3.6",
         "composer-plugin-api": "~1.0",
-        "composer/composer": "^1.0-beta2",
+        "composer/composer": "^1.0",
         "doctrine/collections": "~1.2",
         "gitonomy/gitlib": "~0.1.7",
         "seld/jsonlint": "~1.1",
@@ -25,7 +25,7 @@
         "phpspec/phpspec": "~2.5",
         "phpspec/prophecy": "~1.6",
         "squizlabs/php_codesniffer": "~2.3",
-        "fabpot/php-cs-fixer": "~1.0",
+        "fabpot/php-cs-fixer": "~1.11",
         "phpunit/phpunit": "^4.8",
         "sensiolabs/security-checker": "^3.0"
     },

--- a/doc/tasks/php_cs_fixer.md
+++ b/doc/tasks/php_cs_fixer.md
@@ -19,7 +19,7 @@ parameters:
 
 *Default: null*
 
-You can specify the path to the .php_cs file.
+You can specify the path to the `.php_cs` file.
 
 
 **config**

--- a/resources/config/formatter.yml
+++ b/resources/config/formatter.yml
@@ -1,0 +1,5 @@
+services:
+    formatter.raw_process:
+        class: GrumPHP\Formatter\RawProcessFormatter
+    formatter.php_cs_fixer:
+        class: GrumPHP\Formatter\PhpCsFixerFormatter

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -4,6 +4,7 @@ services:
         arguments:
             - '@config'
             - '@process_builder'
+            - '@formatter.raw_process'
         tags:
             - {name: grumphp.task, config: ant}
 
@@ -12,6 +13,7 @@ services:
         arguments:
             - '@config'
             - '@process_builder'
+            - '@formatter.raw_process'
         tags:
             - {name: grumphp.task, config: behat}
 
@@ -20,6 +22,7 @@ services:
         arguments:
             - '@config'
             - '@process_builder'
+            - '@formatter.raw_process'
         tags:
             - {name: grumphp.task, config: codeception}
 
@@ -28,6 +31,7 @@ services:
         arguments:
             - '@config'
             - '@process_builder'
+            - '@formatter.raw_process'
         tags:
             - {name: grumphp.task, config: composer}
 
@@ -36,6 +40,7 @@ services:
         arguments:
             - '@config'
             - '@process_builder'
+            - '@formatter.raw_process'
         tags:
             - {name: grumphp.task, config: gherkin}
 
@@ -44,6 +49,7 @@ services:
         arguments:
             - '@config'
             - '@process_builder'
+            - '@formatter.raw_process'
         tags:
             - {name: grumphp.task, config: git_blacklist}
 
@@ -59,6 +65,7 @@ services:
         arguments:
             - '@config'
             - '@process_builder'
+            - '@formatter.raw_process'
         tags:
             - {name: grumphp.task, config: grunt}
 
@@ -67,6 +74,7 @@ services:
         arguments:
             - '@config'
             - '@process_builder'
+            - '@formatter.raw_process'
         tags:
             - {name: grumphp.task, config: gulp}
     task.jsonlint:
@@ -82,6 +90,7 @@ services:
         arguments:
             - '@config'
             - '@process_builder'
+            - '@formatter.raw_process'
         tags:
             - {name: grumphp.task, config: make}
 
@@ -90,6 +99,7 @@ services:
         arguments:
             - '@config'
             - '@process_builder'
+            - '@formatter.raw_process'
         tags:
             - {name: grumphp.task, config: phing}
 
@@ -98,6 +108,7 @@ services:
         arguments:
           - '@config'
           - '@process_builder'
+          - '@formatter.raw_process'
         tags:
           - {name: grumphp.task, config: phpcs}
 
@@ -106,6 +117,7 @@ services:
         arguments:
           - '@config'
           - '@process_builder'
+          - '@formatter.php_cs_fixer'
         tags:
           - {name: grumphp.task, config: phpcsfixer}
 
@@ -114,6 +126,7 @@ services:
         arguments:
           - '@config'
           - '@process_builder'
+          - '@formatter.raw_process'
         tags:
           - {name: grumphp.task, config: phpspec}
 
@@ -122,6 +135,7 @@ services:
         arguments:
             - '@config'
             - '@process_builder'
+            - '@formatter.raw_process'
         tags:
             - {name: grumphp.task, config: phpunit}
 
@@ -130,6 +144,7 @@ services:
         arguments:
             - '@config'
             - '@process_builder'
+            - '@formatter.raw_process'
         tags:
             - {name: grumphp.task, config: robo}
 
@@ -138,6 +153,7 @@ services:
         arguments:
             - '@config'
             - '@process_builder'
+            - '@formatter.raw_process'
         tags:
             - {name: grumphp.task, config: securitychecker}
 
@@ -146,6 +162,7 @@ services:
         arguments:
             - '@config'
             - '@process_builder'
+            - '@formatter.raw_process'
         tags:
             - {name: grumphp.task, config: shell}
 

--- a/spec/GrumPHP/Collection/FilesCollectionSpec.php
+++ b/spec/GrumPHP/Collection/FilesCollectionSpec.php
@@ -2,10 +2,14 @@
 
 namespace spec\GrumPHP\Collection;
 
+use GrumPHP\Collection\FilesCollection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 
+/**
+ * @mixin FilesCollection
+ */
 class FilesCollectionSpec extends ObjectBehavior
 {
     /**

--- a/spec/GrumPHP/Collection/LintErrorsCollectionSpec.php
+++ b/spec/GrumPHP/Collection/LintErrorsCollectionSpec.php
@@ -2,10 +2,14 @@
 
 namespace spec\GrumPHP\Collection;
 
+use GrumPHP\Collection\LintErrorsCollection;
 use GrumPHP\Linter\LintError;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin LintErrorsCollection
+ */
 class LintErrorsCollectionSpec extends ObjectBehavior
 {
     function let()

--- a/spec/GrumPHP/Collection/ProcessArgumentsCollectionSpec.php
+++ b/spec/GrumPHP/Collection/ProcessArgumentsCollectionSpec.php
@@ -3,10 +3,14 @@
 namespace spec\GrumPHP\Collection;
 
 use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Collection\ProcessArgumentsCollection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use SplFileInfo;
 
+/**
+ * @mixin ProcessArgumentsCollection
+ */
 class ProcessArgumentsCollectionSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Collection/TaskResultCollectionSpec.php
+++ b/spec/GrumPHP/Collection/TaskResultCollectionSpec.php
@@ -8,6 +8,9 @@ use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 
+/**
+ * @mixin TaskResultCollection
+ */
 class TaskResultCollectionSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Collection/TasksCollectionSpec.php
+++ b/spec/GrumPHP/Collection/TasksCollectionSpec.php
@@ -2,12 +2,16 @@
 
 namespace spec\GrumPHP\Collection;
 
+use GrumPHP\Collection\TasksCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin TasksCollection
+ */
 class TasksCollectionSpec extends ObjectBehavior
 {
     public function let(TaskInterface $task1, TaskInterface $task2)

--- a/spec/GrumPHP/Composer/GrumPHPPluginSpec.php
+++ b/spec/GrumPHP/Composer/GrumPHPPluginSpec.php
@@ -2,9 +2,13 @@
 
 namespace spec\GrumPHP\Composer;
 
+use GrumPHP\Composer\GrumPHPPlugin;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin GrumPHPPlugin
+ */
 class GrumPHPPluginSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Configuration/GrumPHPSpec.php
+++ b/spec/GrumPHP/Configuration/GrumPHPSpec.php
@@ -4,12 +4,16 @@ namespace spec\GrumPHP\Configuration;
 
 use GrumPHP\Configuration\Compiler\TaskCompilerPass;
 use GrumPHP\Configuration\ContainerFactory;
+use GrumPHP\Configuration\GrumPHP;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * @mixin GrumPHP
+ */
 class GrumPHPSpec extends ObjectBehavior
 {
     function let(ContainerInterface $container)

--- a/spec/GrumPHP/Console/Helper/ComposerHelperSpec.php
+++ b/spec/GrumPHP/Console/Helper/ComposerHelperSpec.php
@@ -4,9 +4,13 @@ namespace spec\GrumPHP\Console\Helper;
 
 use Composer\Config;
 use Composer\Package\RootPackage;
+use GrumPHP\Console\Helper\ComposerHelper;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin ComposerHelper
+ */
 class ComposerHelperSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Console/Helper/PathsHelperSpec.php
+++ b/spec/GrumPHP/Console/Helper/PathsHelperSpec.php
@@ -3,10 +3,14 @@
 namespace spec\GrumPHP\Console\Helper;
 
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Console\Helper\PathsHelper;
 use Symfony\Component\Filesystem\Filesystem;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin PathsHelper
+ */
 class PathsHelperSpec extends ObjectBehavior
 {
     function let(GrumPHP $config, Filesystem $fileSystem)

--- a/spec/GrumPHP/Console/Helper/TaskRunnerHelperSpec.php
+++ b/spec/GrumPHP/Console/Helper/TaskRunnerHelperSpec.php
@@ -16,6 +16,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin TaskRunnerHelper
+ */
 class TaskRunnerHelperSpec extends ObjectBehavior
 {
     function let(TaskRunner $taskRunner, EventDispatcherInterface $eventDispatcher, HelperSet $helperSet, PathsHelper $pathsHelper)

--- a/spec/GrumPHP/Event/RunnerEventSpec.php
+++ b/spec/GrumPHP/Event/RunnerEventSpec.php
@@ -4,10 +4,14 @@ namespace spec\GrumPHP\Event;
 
 use GrumPHP\Collection\TaskResultCollection;
 use GrumPHP\Collection\TasksCollection;
+use GrumPHP\Event\RunnerEvent;
 use GrumPHP\Task\Context\ContextInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin RunnerEvent
+ */
 class RunnerEventSpec extends ObjectBehavior
 {
     function let(TasksCollection $tasks, ContextInterface $context, TaskResultCollection $taskResults)

--- a/spec/GrumPHP/Event/RunnerFailedEventSpec.php
+++ b/spec/GrumPHP/Event/RunnerFailedEventSpec.php
@@ -4,11 +4,15 @@ namespace spec\GrumPHP\Event;
 
 use GrumPHP\Collection\TaskResultCollection;
 use GrumPHP\Collection\TasksCollection;
+use GrumPHP\Event\RunnerFailedEvent;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin RunnerFailedEvent
+ */
 class RunnerFailedEventSpec extends ObjectBehavior
 {
     function let(TasksCollection $tasks, ContextInterface $context, TaskResultCollection $taskResults)

--- a/spec/GrumPHP/Event/Subscriber/ProgressSubscriberSpec.php
+++ b/spec/GrumPHP/Event/Subscriber/ProgressSubscriberSpec.php
@@ -4,6 +4,7 @@ namespace spec\GrumPHP\Event\Subscriber;
 
 use GrumPHP\Collection\TasksCollection;
 use GrumPHP\Event\RunnerEvent;
+use GrumPHP\Event\Subscriber\ProgressSubscriber;
 use GrumPHP\Event\TaskEvent;
 use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
@@ -11,6 +12,9 @@ use Prophecy\Argument;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @mixin ProgressSubscriber
+ */
 class ProgressSubscriberSpec extends ObjectBehavior
 {
     function let(OutputInterface $output, ProgressBar $progressBar)

--- a/spec/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriberSpec.php
+++ b/spec/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriberSpec.php
@@ -10,12 +10,16 @@ use GrumPHP\Collection\TaskResultCollection;
 use GrumPHP\Collection\TasksCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Event\RunnerEvent;
+use GrumPHP\Event\Subscriber\StashUnstagedChangesSubscriber;
 use GrumPHP\IO\IOInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin StashUnstagedChangesSubscriber
+ */
 class StashUnstagedChangesSubscriberSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, Repository $repository, IOInterface $io, WorkingCopy $workingCopy, Diff $unstaged)

--- a/spec/GrumPHP/Event/TaskEventSpec.php
+++ b/spec/GrumPHP/Event/TaskEventSpec.php
@@ -2,11 +2,15 @@
 
 namespace spec\GrumPHP\Event;
 
+use GrumPHP\Event\TaskEvent;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin TaskEvent
+ */
 class TaskEventSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Event/TaskFailedEventSpec.php
+++ b/spec/GrumPHP/Event/TaskFailedEventSpec.php
@@ -2,11 +2,15 @@
 
 namespace spec\GrumPHP\Event;
 
+use GrumPHP\Event\TaskFailedEvent;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin TaskFailedEvent
+ */
 class TaskFailedEventSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Formatter/PhpCsFixerFormatterSpec.php
+++ b/spec/GrumPHP/Formatter/PhpCsFixerFormatterSpec.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace spec\GrumPHP\Formatter;
+
+use GrumPHP\Formatter\PhpCsFixerFormatter;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Process\Process;
+
+/**
+ * @mixin PhpCsFixerFormatter
+ */
+class PhpCsFixerFormatterSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Formatter\PhpCsFixerFormatter');
+    }
+    
+    function it_is_a_process_formatter()
+    {
+        $this->shouldHaveType('GrumPHP\Formatter\ProcessFormatterInterface');
+    }
+
+    function it_handles_command_exceptions(Process $process)
+    {
+        $process->getOutput()->willReturn('');
+        $process->getErrorOutput()->willReturn('stderr');
+        $this->format($process)->shouldReturn('stderr');
+    }
+
+    function it_handles_invalid_json(Process $process)
+    {
+        $process->getOutput()->willReturn('invalid');
+        $this->format($process)->shouldReturn('invalid');
+    }
+
+    function it_handles_invalid_file_formats(Process $process)
+    {
+        $json = $this->parseJson(array('invalid'));
+        $process->getOutput()->willReturn($json);
+        $this->format($process)->shouldStartWith('Invalid file: ');
+    }
+
+    function it_formats_php_cs_fixer_json_output_for_single_file(Process $process)
+    {
+        $json = $this->parseJson(array(
+            array('name' => 'name1', ),
+        ));
+        $process->getOutput()->willReturn($json);
+        $this->format($process)->shouldBe('1) name1');
+    }
+
+    function it_formats_php_cs_fixer_json_output_for_multiple_files(Process $process)
+    {
+        $json = $this->parseJson(array(
+            array('name' => 'name1', ),
+            array('name' => 'name2', 'appliedFixers' => array('fixer1', 'fixer2')),
+        ));
+        $process->getOutput()->willReturn($json);
+        $this->format($process)->shouldBe('1) name1' . PHP_EOL . '2) name2 (fixer1,fixer2)');
+    }
+
+    function it_should_be_possible_to_reset_the_counter(Process $process)
+    {
+        $json = $this->parseJson(array(array('name' => 'name1')));
+        $process->getOutput()->willReturn($json);
+
+        $this->format($process)->shouldBe('1) name1');
+        $this->resetCounter();
+        $this->format($process)->shouldBe('1) name1');
+    }
+
+    function it_formats_suggestions(Process $process)
+    {
+        $process->getCommandLine()->willReturn('phpcsfixer \'--dry-run\' \'--format=json\' .');
+        $this->formatSuggestion($process)->shouldReturn('phpcsfixer .');
+    }
+
+    function it_formats_the_error_message()
+    {
+        $this->formatErrorMessage(array('message1'), array('message2'))->shouldBeString();
+    }
+
+    /**
+     * @param $files
+     *
+     * @return string
+     */
+    private function parseJson(array $files)
+    {
+        return json_encode(array('files' => $files));
+    }
+}

--- a/spec/GrumPHP/Formatter/RawProcessFormatterSpec.php
+++ b/spec/GrumPHP/Formatter/RawProcessFormatterSpec.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace spec\GrumPHP\Formatter;
+
+use GrumPHP\Formatter\RawProcessFormatter;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Process\Process;
+
+/**
+ * @mixin RawProcessFormatter
+ */
+class RawProcessFormatterSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Formatter\RawProcessFormatter');
+    }
+
+    function it_is_a_process_formatter()
+    {
+        $this->shouldHaveType('GrumPHP\Formatter\ProcessFormatterInterface');
+    }
+
+    function it_displays_the_full_process_output(Process $process)
+    {
+        $process->getOutput()->willReturn('stdout');
+        $process->getErrorOutput()->willReturn('stderr');
+        $this->format($process)->shouldReturn('stdout' . PHP_EOL . 'stderr');
+    }
+
+    function it_displays_stdout_only(Process $process)
+    {
+        $process->getOutput()->willReturn('stdout');
+        $process->getErrorOutput()->willReturn('');
+        $this->format($process)->shouldReturn('stdout');
+    }
+
+    function it_displays_stderr_only(Process $process)
+    {
+        $process->getOutput()->willReturn('');
+        $process->getErrorOutput()->willReturn('stderr');
+        $this->format($process)->shouldReturn('stderr');
+    }
+}

--- a/spec/GrumPHP/IO/ConsoleIOSpec.php
+++ b/spec/GrumPHP/IO/ConsoleIOSpec.php
@@ -2,12 +2,16 @@
 
 namespace spec\GrumPHP\IO;
 
+use Composer\IO\ConsoleIO;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @mixin ConsoleIO
+ */
 class ConsoleIOSpec extends ObjectBehavior
 {
     function let(InputInterface $input, OutputInterface $output)

--- a/spec/GrumPHP/IO/NullIOSpec.php
+++ b/spec/GrumPHP/IO/NullIOSpec.php
@@ -2,9 +2,13 @@
 
 namespace spec\GrumPHP\IO;
 
+use GrumPHP\IO\NullIO;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin NullIO
+ */
 class NullIOSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Linter/Json/JsonLintErrorSpec.php
+++ b/spec/GrumPHP/Linter/Json/JsonLintErrorSpec.php
@@ -2,10 +2,14 @@
 
 namespace spec\GrumPHP\Linter\Json;
 
+use GrumPHP\Linter\Json\JsonLintError;
 use GrumPHP\Linter\LintError;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin JsonLintError
+ */
 class JsonLintErrorSpec extends ObjectBehavior
 {
     function let()

--- a/spec/GrumPHP/Linter/Json/JsonLinterSpec.php
+++ b/spec/GrumPHP/Linter/Json/JsonLinterSpec.php
@@ -2,9 +2,13 @@
 
 namespace spec\GrumPHP\Linter\Json;
 
+use GrumPHP\Linter\Json\JsonLinter;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin JsonLinter
+ */
 class JsonLinterSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Linter/LintErrorSpec.php
+++ b/spec/GrumPHP/Linter/LintErrorSpec.php
@@ -6,6 +6,9 @@ use GrumPHP\Linter\LintError;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin LintError
+ */
 class LintErrorSpec extends ObjectBehavior
 {
     function let()

--- a/spec/GrumPHP/Linter/Xml/XmlLintErrorSpec.php
+++ b/spec/GrumPHP/Linter/Xml/XmlLintErrorSpec.php
@@ -3,9 +3,13 @@
 namespace spec\GrumPHP\Linter\Xml;
 
 use GrumPHP\Linter\LintError;
+use GrumPHP\Linter\Xml\XmlLintError;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin XmlLintError
+ */
 class XmlLintErrorSpec extends ObjectBehavior
 {
     function let()

--- a/spec/GrumPHP/Linter/Xml/XmlLinterSpec.php
+++ b/spec/GrumPHP/Linter/Xml/XmlLinterSpec.php
@@ -2,9 +2,13 @@
 
 namespace spec\GrumPHP\Linter\Xml;
 
+use GrumPHP\Linter\Xml\XmlLinter;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin XmlLinter
+ */
 class XmlLinterSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Linter/Yaml/YamlLintErrorSpec.php
+++ b/spec/GrumPHP/Linter/Yaml/YamlLintErrorSpec.php
@@ -3,9 +3,13 @@
 namespace spec\GrumPHP\Linter\Yaml;
 
 use GrumPHP\Linter\LintError;
+use GrumPHP\Linter\Yaml\YamlLintError;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin YamlLintError
+ */
 class YamlLintErrorSpec extends ObjectBehavior
 {
     function let()

--- a/spec/GrumPHP/Linter/Yaml/YamlLinterSpec.php
+++ b/spec/GrumPHP/Linter/Yaml/YamlLinterSpec.php
@@ -2,9 +2,13 @@
 
 namespace spec\GrumPHP\Linter\Yaml;
 
+use GrumPHP\Linter\Yaml\YamlLinter;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin YamlLinter
+ */
 class YamlLinterSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Locator/ChangedFilesSpec.php
+++ b/spec/GrumPHP/Locator/ChangedFilesSpec.php
@@ -6,10 +6,14 @@ use Gitonomy\Git\Diff\Diff;
 use Gitonomy\Git\Diff\File;
 use Gitonomy\Git\WorkingCopy;
 use Gitonomy\Git\Repository;
+use GrumPHP\Locator\ChangedFiles;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Prophecy\Prophet;
 
+/**
+ * @mixin ChangedFiles
+ */
 class ChangedFilesSpec extends ObjectBehavior
 {
     function let(Repository $repository)

--- a/spec/GrumPHP/Locator/ConfigurationFileSpec.php
+++ b/spec/GrumPHP/Locator/ConfigurationFileSpec.php
@@ -3,10 +3,14 @@
 namespace spec\GrumPHP\Locator;
 
 use Composer\Package\PackageInterface;
+use GrumPHP\Locator\ConfigurationFile;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @mixin ConfigurationFile
+ */
 class ConfigurationFileSpec extends ObjectBehavior
 {
     function let(Filesystem $filesystem)

--- a/spec/GrumPHP/Locator/ExternalCommandSpec.php
+++ b/spec/GrumPHP/Locator/ExternalCommandSpec.php
@@ -2,10 +2,14 @@
 
 namespace spec\GrumPHP\Locator;
 
+use GrumPHP\Locator\ExternalCommand;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\ExecutableFinder;
 
+/**
+ * @mixin ExternalCommand
+ */
 class ExternalCommandSpec extends ObjectBehavior
 {
     function let(ExecutableFinder $executableFinder)

--- a/spec/GrumPHP/Locator/RegisteredFilesSpec.php
+++ b/spec/GrumPHP/Locator/RegisteredFilesSpec.php
@@ -3,9 +3,13 @@
 namespace spec\GrumPHP\Locator;
 
 use Gitonomy\Git\Repository;
+use GrumPHP\Locator\RegisteredFiles;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin RegisteredFiles
+ */
 class RegisteredFilesSpec extends ObjectBehavior
 {
     function let(Repository $repository)

--- a/spec/GrumPHP/Process/ProcessBuilderSpec.php
+++ b/spec/GrumPHP/Process/ProcessBuilderSpec.php
@@ -4,10 +4,14 @@ namespace spec\GrumPHP\Process;
 
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Locator\ExternalCommand;
+use GrumPHP\Process\ProcessBuilder;
 use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin ProcessBuilder
+ */
 class ProcessBuilderSpec extends ObjectBehavior
 {
     function let(ExternalCommand $externalCommandLocator)

--- a/spec/GrumPHP/Runner/TaskResultSpec.php
+++ b/spec/GrumPHP/Runner/TaskResultSpec.php
@@ -7,6 +7,9 @@ use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 
+/**
+ * @mixin TaskResult
+ */
 class TaskResultSpec extends ObjectBehavior
 {
     const FAILED_TASK_MESSAGE = 'failed task message';

--- a/spec/GrumPHP/Runner/TaskRunnerSpec.php
+++ b/spec/GrumPHP/Runner/TaskRunnerSpec.php
@@ -6,12 +6,16 @@ use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Event\RunnerEvents;
 use GrumPHP\Event\TaskEvents;
 use GrumPHP\Runner\TaskResult;
+use GrumPHP\Runner\TaskRunner;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @mixin TaskRunner
+ */
 class TaskRunnerSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/AntSpec.php
+++ b/spec/GrumPHP/Task/AntSpec.php
@@ -5,8 +5,10 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Ant;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -15,12 +17,15 @@ use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Ant
+ */
 class AntSpec extends ObjectBehavior
 {
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('ant')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -92,7 +97,6 @@ class AntSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.php', '.', 'test.php')

--- a/spec/GrumPHP/Task/BehatSpec.php
+++ b/spec/GrumPHP/Task/BehatSpec.php
@@ -5,8 +5,10 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Behat;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -15,12 +17,15 @@ use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Behat
+ */
 class BehatSpec extends ObjectBehavior
 {
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('behat')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -93,7 +98,6 @@ class BehatSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.php', '.', 'test.php')

--- a/spec/GrumPHP/Task/CodeceptionSpec.php
+++ b/spec/GrumPHP/Task/CodeceptionSpec.php
@@ -5,8 +5,10 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Codeception;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -15,12 +17,15 @@ use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Codeception
+ */
 class CodeceptionSpec extends ObjectBehavior
 {
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('codeception')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -93,7 +98,6 @@ class CodeceptionSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.php', '.', 'test.php')

--- a/spec/GrumPHP/Task/ComposerSpec.php
+++ b/spec/GrumPHP/Task/ComposerSpec.php
@@ -5,8 +5,10 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Composer;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -15,12 +17,15 @@ use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Composer
+ */
 class ComposerSpec extends ObjectBehavior
 {
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('composer')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -95,7 +100,6 @@ class ComposerSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('composer.json', '.', 'composer.json')

--- a/spec/GrumPHP/Task/Context/GitCommitMsgContextSpec.php
+++ b/spec/GrumPHP/Task/Context/GitCommitMsgContextSpec.php
@@ -3,9 +3,13 @@
 namespace spec\GrumPHP\Task\Context;
 
 use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Task\Context\GitCommitMsgContext;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin GitCommitMsgContext
+ */
 class GitCommitMsgContextSpec extends ObjectBehavior
 {
     /**

--- a/spec/GrumPHP/Task/Context/RunContextSpec.php
+++ b/spec/GrumPHP/Task/Context/RunContextSpec.php
@@ -3,14 +3,14 @@
 namespace spec\GrumPHP\Task\Context;
 
 use GrumPHP\Collection\FilesCollection;
-use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 /**
- * @mixin GitPreCommitContext
+ * @mixin RunContext
  */
-class GitPreCommitContextSpec extends ObjectBehavior
+class RunContextSpec extends ObjectBehavior
 {
     function let(FilesCollection $files)
     {
@@ -19,7 +19,7 @@ class GitPreCommitContextSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('GrumPHP\Task\Context\GitPreCommitContext');
+        $this->shouldHaveType('GrumPHP\Task\Context\RunContext');
     }
 
     function it_should_be_a_task_context()

--- a/spec/GrumPHP/Task/GherkinSpec.php
+++ b/spec/GrumPHP/Task/GherkinSpec.php
@@ -5,22 +5,27 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\Gherkin;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Gherkin
+ */
 class GherkinSpec extends ObjectBehavior
 {
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('gherkin')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -91,7 +96,6 @@ class GherkinSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.feature', '.', 'test.feature')

--- a/spec/GrumPHP/Task/Git/BlacklistSpec.php
+++ b/spec/GrumPHP/Task/Git/BlacklistSpec.php
@@ -5,22 +5,27 @@ namespace spec\GrumPHP\Task\Git;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Git\Blacklist;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Blacklist
+ */
 class BlacklistSpec extends ObjectBehavior
 {
 
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('git_blacklist')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -115,7 +120,6 @@ class BlacklistSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('file1.php', '.', 'file1.php'),

--- a/spec/GrumPHP/Task/Git/CommitMessageSpec.php
+++ b/spec/GrumPHP/Task/Git/CommitMessageSpec.php
@@ -4,9 +4,13 @@ namespace spec\GrumPHP\Task\Git;
 
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Task\Context\GitCommitMsgContext;
+use GrumPHP\Task\Git\CommitMessage;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin CommitMessage
+ */
 class CommitMessageSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP)

--- a/spec/GrumPHP/Task/GruntSpec.php
+++ b/spec/GrumPHP/Task/GruntSpec.php
@@ -5,22 +5,27 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\Grunt;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Grunt
+ */
 class GruntSpec extends ObjectBehavior
 {
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('grunt')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -92,7 +97,6 @@ class GruntSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.js', '.', 'test.js')

--- a/spec/GrumPHP/Task/GulpSpec.php
+++ b/spec/GrumPHP/Task/GulpSpec.php
@@ -5,22 +5,27 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\Gulp;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Gulp
+ */
 class GulpSpec extends ObjectBehavior
 {
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('gulp')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -92,7 +97,6 @@ class GulpSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.js', '.', 'test.js')

--- a/spec/GrumPHP/Task/JsonLintSpec.php
+++ b/spec/GrumPHP/Task/JsonLintSpec.php
@@ -12,9 +12,13 @@ use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\JsonLint;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 
+/**
+ * @mixin JsonLint
+ */
 class JsonLintSpec extends AbstractLinterTaskSpec
 {
     function let(GrumPHP $grumPHP, JsonLinter $linter)

--- a/spec/GrumPHP/Task/MakeSpec.php
+++ b/spec/GrumPHP/Task/MakeSpec.php
@@ -5,22 +5,27 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\Make;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Make
+ */
 class MakeSpec extends ObjectBehavior
 {
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('make')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -91,7 +96,6 @@ class MakeSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.php', '.', 'test.php')

--- a/spec/GrumPHP/Task/PhingSpec.php
+++ b/spec/GrumPHP/Task/PhingSpec.php
@@ -5,22 +5,27 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\Phing;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Phing
+ */
 class PhingSpec extends ObjectBehavior
 {
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('phing')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -92,7 +97,6 @@ class PhingSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.php', '.', 'test.php')

--- a/spec/GrumPHP/Task/PhpcsSpec.php
+++ b/spec/GrumPHP/Task/PhpcsSpec.php
@@ -5,23 +5,28 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\Phpcs;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Phpcs
+ */
 class PhpcsSpec extends ObjectBehavior
 {
 
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('phpcs')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -115,7 +120,6 @@ class PhpcsSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('file1.php', '.', 'file1.php'),

--- a/spec/GrumPHP/Task/PhpspecSpec.php
+++ b/spec/GrumPHP/Task/PhpspecSpec.php
@@ -5,23 +5,28 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\Phpspec;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Phpspec
+ */
 class PhpspecSpec extends ObjectBehavior
 {
 
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('phpspec')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -62,7 +67,7 @@ class PhpspecSpec extends ObjectBehavior
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
         $result->getResultCode()->shouldBe(TaskResult::SKIPPED);
     }
-    
+
     function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
     {
         $arguments = new ProcessArgumentsCollection();
@@ -89,7 +94,6 @@ class PhpspecSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.php', '.', 'test.php')

--- a/spec/GrumPHP/Task/PhpunitSpec.php
+++ b/spec/GrumPHP/Task/PhpunitSpec.php
@@ -5,22 +5,27 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\Phpunit;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Phpunit
+ */
 class PhpunitSpec extends ObjectBehavior
 {
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('phpunit')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -87,7 +92,6 @@ class PhpunitSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.php', '.', 'test.php')

--- a/spec/GrumPHP/Task/RoboSpec.php
+++ b/spec/GrumPHP/Task/RoboSpec.php
@@ -5,22 +5,27 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\Robo;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Robo
+ */
 class RoboSpec extends ObjectBehavior
 {
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('robo')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -92,7 +97,6 @@ class RoboSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.php', '.', 'test.php')

--- a/spec/GrumPHP/Task/SecurityCheckerSpec.php
+++ b/spec/GrumPHP/Task/SecurityCheckerSpec.php
@@ -5,22 +5,27 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\SecurityChecker;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin SecurityChecker
+ */
 class SecurityCheckerSpec extends ObjectBehavior
 {
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('securitychecker')->willReturn(array());
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -126,7 +131,6 @@ class SecurityCheckerSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('composer.lock', '.', 'composer.lock')

--- a/spec/GrumPHP/Task/ShellSpec.php
+++ b/spec/GrumPHP/Task/ShellSpec.php
@@ -5,24 +5,29 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\Shell;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Shell
+ */
 class ShellSpec extends ObjectBehavior
 {
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('shell')->willReturn(array(
             'scripts' => array('script.sh')
         ));
-        $this->beConstructedWith($grumPHP, $processBuilder);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
     function it_is_initializable()
@@ -93,7 +98,6 @@ class ShellSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
-        $process->getOutput()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('test.php', '.', 'test.php')

--- a/spec/GrumPHP/Task/XmlLintSpec.php
+++ b/spec/GrumPHP/Task/XmlLintSpec.php
@@ -12,9 +12,13 @@ use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\XmlLint;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 
+/**
+ * @mixin XmlLint
+ */
 class XmlLintSpec extends AbstractLinterTaskSpec
 {
     function let(GrumPHP $grumPHP, XmlLinter $linter)

--- a/spec/GrumPHP/Task/YamlLintSpec.php
+++ b/spec/GrumPHP/Task/YamlLintSpec.php
@@ -12,9 +12,13 @@ use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\YamlLint;
 use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 
+/**
+ * @mixin YamlLint
+ */
 class YamlLintSpec extends AbstractLinterTaskSpec
 {
     function let(GrumPHP $grumPHP, YamlLinter $linter)

--- a/spec/GrumPHP/Util/RegexSpec.php
+++ b/spec/GrumPHP/Util/RegexSpec.php
@@ -2,9 +2,13 @@
 
 namespace spec\GrumPHP\Util;
 
+use GrumPHP\Util\Regex;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
+/**
+ * @mixin Regex
+ */
 class RegexSpec extends ObjectBehavior
 {
 

--- a/src/GrumPHP/Configuration/ContainerFactory.php
+++ b/src/GrumPHP/Configuration/ContainerFactory.php
@@ -27,6 +27,7 @@ final class ContainerFactory
 
         // Load basic service file + custom user configuration
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../../../resources/config'));
+        $loader->load('formatter.yml');
         $loader->load('linters.yml');
         $loader->load('parameters.yml');
         $loader->load('services.yml');

--- a/src/GrumPHP/Console/Command/ConfigureCommand.php
+++ b/src/GrumPHP/Console/Command/ConfigureCommand.php
@@ -161,8 +161,7 @@ class ConfigureCommand extends Command
 
         // Build configuration
         return array(
-            'parameters' => array
-            (
+            'parameters' => array(
                 'git_dir' => $gitDir,
                 'bin_dir' => $binDir,
                 'tasks' => array_map(function ($task) {

--- a/src/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriber.php
+++ b/src/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriber.php
@@ -123,7 +123,7 @@ class StashUnstagedChangesSubscriber implements EventSubscriberInterface
     {
         $pending = $this->repository->getWorkingCopy()->getDiffPending();
         if (!count($pending->getFiles())) {
-             return;
+            return;
         }
 
         try {

--- a/src/GrumPHP/Formatter/PhpCsFixerFormatter.php
+++ b/src/GrumPHP/Formatter/PhpCsFixerFormatter.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace GrumPHP\Formatter;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Class PhpCsFixerFormatter
+ *
+ * @package GrumPHP\Formatter
+ */
+class PhpCsFixerFormatter implements ProcessFormatterInterface
+{
+    /**
+     * @var int
+     */
+    private $counter = 0;
+
+    /**
+     * Resets the internal counter.
+     */
+    public function resetCounter()
+    {
+        $this->counter = 0;
+    }
+
+    /**
+     * @param Process $process
+     *
+     * @return string
+     */
+    public function format(Process $process)
+    {
+        $output = $process->getOutput();
+        if (!$output) {
+            return $process->getErrorOutput();
+        }
+
+        if (!$json = json_decode($output, true)) {
+            return $output;
+        }
+
+        return $this->formatJsonResponse($json);
+    }
+
+    /**
+     * @param Process $process
+     *
+     * @return string
+     */
+    public function formatSuggestion(Process $process)
+    {
+        return str_replace(array("'--dry-run' ", "'--format=json' "), '', $process->getCommandLine());
+    }
+
+    /**
+     * @param array $messages
+     * @param array $suggestions
+     *
+     * @return string
+     */
+    public function formatErrorMessage(array $messages, array $suggestions)
+    {
+        return sprintf(
+            '%sYou can fix all errors by running following commands:%s',
+            implode(PHP_EOL, $messages) . PHP_EOL . PHP_EOL,
+            PHP_EOL . implode(PHP_EOL, $suggestions)
+        );
+    }
+
+    /**
+     * @param array $json
+     *
+     * @return string
+     */
+    private function formatJsonResponse(array $json)
+    {
+        $formatted = array();
+        foreach ($json['files'] as $file) {
+            if (!is_array($file) || !isset($file['name'])) {
+                $formatted[] = 'Invalid file: ' . print_r($file, true);
+                continue;
+            }
+
+            $formatted[] = $this->formatFile($file);
+        }
+
+        return implode(PHP_EOL, $formatted);
+    }
+
+    /**
+     * @param array $file
+     *
+     * @return string
+     */
+    private function formatFile(array $file)
+    {
+        if (!isset($file['name'])) {
+            return 'Invalid file: ' . print_r($file, true);
+        }
+
+        $hasFixers = isset($file['appliedFixers']);
+
+        return sprintf(
+            '%s) %s%s',
+            ++$this->counter,
+            $file['name'],
+            $hasFixers ? ' (' . implode(',', $file['appliedFixers']) . ')' : ''
+        );
+    }
+}

--- a/src/GrumPHP/Formatter/ProcessFormatterInterface.php
+++ b/src/GrumPHP/Formatter/ProcessFormatterInterface.php
@@ -1,0 +1,19 @@
+<?php
+namespace GrumPHP\Formatter;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Class RawProcessFormatter
+ *
+ * @package GrumPHP\Formatter
+ */
+interface ProcessFormatterInterface
+{
+    /**
+     * @param Process $process
+     *
+     * @return string
+     */
+    public function format(Process $process);
+}

--- a/src/GrumPHP/Formatter/RawProcessFormatter.php
+++ b/src/GrumPHP/Formatter/RawProcessFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace GrumPHP\Formatter;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Class RawProcessFormatter
+ *
+ * @package GrumPHP\Formatter
+ */
+class RawProcessFormatter implements ProcessFormatterInterface
+{
+    /**
+     * This method will format the output of a Process object to a string.
+     *
+     * @param Process $process
+     *
+     * @return string
+     */
+    public function format(Process $process)
+    {
+        $stdout = $process->getOutput();
+        $stderr = $process->getErrorOutput();
+
+        return trim($stdout . PHP_EOL . $stderr);
+    }
+}

--- a/src/GrumPHP/Locator/ChangedFiles.php
+++ b/src/GrumPHP/Locator/ChangedFiles.php
@@ -25,7 +25,6 @@ class ChangedFiles
     public function __construct(Repository $repository)
     {
         $this->repository = $repository;
-
     }
 
     /**

--- a/src/GrumPHP/Task/AbstractExternalTask.php
+++ b/src/GrumPHP/Task/AbstractExternalTask.php
@@ -3,6 +3,7 @@
 namespace GrumPHP\Task;
 
 use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 
 /**
@@ -23,13 +24,19 @@ abstract class AbstractExternalTask implements TaskInterface
     protected $processBuilder;
 
     /**
+     * @var ProcessFormatterInterface
+     */
+    protected $formatter;
+
+    /**
      * @param GrumPHP $grumPHP
      * @param ProcessBuilder $processBuilder
      */
-    public function __construct(GrumPHP $grumPHP, ProcessBuilder $processBuilder)
+    public function __construct(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $this->grumPHP = $grumPHP;
         $this->processBuilder = $processBuilder;
+        $this->formatter = $formatter;
     }
 
     /**

--- a/src/GrumPHP/Task/Ant.php
+++ b/src/GrumPHP/Task/Ant.php
@@ -67,7 +67,7 @@ class Ant extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            return TaskResult::createFailed($this, $context, $process->getOutput());
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);

--- a/src/GrumPHP/Task/Behat.php
+++ b/src/GrumPHP/Task/Behat.php
@@ -72,7 +72,7 @@ class Behat extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            return TaskResult::createFailed($this, $context, $process->getOutput());
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);

--- a/src/GrumPHP/Task/Codeception.php
+++ b/src/GrumPHP/Task/Codeception.php
@@ -75,7 +75,7 @@ class Codeception extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            return TaskResult::createFailed($this, $context, $process->getOutput());
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);

--- a/src/GrumPHP/Task/Composer.php
+++ b/src/GrumPHP/Task/Composer.php
@@ -83,7 +83,7 @@ class Composer extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            return TaskResult::createFailed($this, $context, $process->getOutput());
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);

--- a/src/GrumPHP/Task/Gherkin.php
+++ b/src/GrumPHP/Task/Gherkin.php
@@ -67,7 +67,7 @@ class Gherkin extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            return TaskResult::createFailed($this, $context, $process->getOutput());
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);

--- a/src/GrumPHP/Task/Git/Blacklist.php
+++ b/src/GrumPHP/Task/Git/Blacklist.php
@@ -71,8 +71,9 @@ class Blacklist extends AbstractExternalTask
 
         if ($process->isSuccessful()) {
             return TaskResult::createFailed($this, $context, sprintf(
-                "You have blacklisted keywords in your commit:\n%s",
-                $process->getOutput()
+                'You have blacklisted keywords in your commit:%s%s',
+                PHP_EOL,
+                $this->formatter->format($process)
             ));
         }
 

--- a/src/GrumPHP/Task/Grunt.php
+++ b/src/GrumPHP/Task/Grunt.php
@@ -67,7 +67,7 @@ class Grunt extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            return TaskResult::createFailed($this, $context, $process->getOutput());
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);

--- a/src/GrumPHP/Task/Gulp.php
+++ b/src/GrumPHP/Task/Gulp.php
@@ -67,7 +67,7 @@ class Gulp extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            return TaskResult::createFailed($this, $context, $process->getOutput());
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);

--- a/src/GrumPHP/Task/Make.php
+++ b/src/GrumPHP/Task/Make.php
@@ -67,7 +67,7 @@ class Make extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            return TaskResult::createFailed($this, $context, $process->getOutput());
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);

--- a/src/GrumPHP/Task/Phing.php
+++ b/src/GrumPHP/Task/Phing.php
@@ -67,7 +67,7 @@ class Phing extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            return TaskResult::createFailed($this, $context, $process->getOutput());
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);

--- a/src/GrumPHP/Task/Phpcs.php
+++ b/src/GrumPHP/Task/Phpcs.php
@@ -79,7 +79,7 @@ class Phpcs extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            return TaskResult::createFailed($this, $context, $process->getOutput());
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);

--- a/src/GrumPHP/Task/Phpspec.php
+++ b/src/GrumPHP/Task/Phpspec.php
@@ -68,7 +68,7 @@ class Phpspec extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            return TaskResult::createFailed($this, $context, $process->getOutput());
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);

--- a/src/GrumPHP/Task/Phpunit.php
+++ b/src/GrumPHP/Task/Phpunit.php
@@ -63,7 +63,7 @@ class Phpunit extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            return TaskResult::createFailed($this, $context, $process->getOutput());
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);

--- a/src/GrumPHP/Task/Robo.php
+++ b/src/GrumPHP/Task/Robo.php
@@ -67,7 +67,7 @@ class Robo extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            return TaskResult::createFailed($this, $context, $process->getOutput());
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);

--- a/src/GrumPHP/Task/SecurityChecker.php
+++ b/src/GrumPHP/Task/SecurityChecker.php
@@ -77,7 +77,7 @@ class SecurityChecker extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            return TaskResult::createFailed($this, $context, $process->getOutput());
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 
         return TaskResult::createPassed($this, $context);

--- a/src/GrumPHP/Task/Shell.php
+++ b/src/GrumPHP/Task/Shell.php
@@ -86,7 +86,7 @@ class Shell extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            throw new RuntimeException($process->getOutput());
+            throw new RuntimeException($this->formatter->format($process));
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #141, #139, #18

This PR contains some process formatters to give you better feedback on what is going wrong. The Php-cs-fixer task is also improved and will work slightly different in `RunContext`. All Formatting is handled by a php-cs-fixer formatter.