### PR TITLE
Fixes the vagrant environment by adding vagrant dir config var

### DIFF
--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -48,11 +48,14 @@ GrumPHP comes with following presets:
 - `vagrant`: All checks will run in your vagrant box.
 
 
-*Note:* When using the vagrant preset, make sure the working directory of the vagrant shell is located at your remote project path:
- 
-```sh
-echo 'cd /remote/path/to/your/project' >> ~/.bashrc
-```
+*Note:* When using the vagrant preset, make sure the working directory of the vagrant shell is set as vagrant_dir
+
+**vagrant_dir**
+
+*Default: .*
+
+This parameter will tell GrumPHP in which folder in the vagrant environment the project root is.
+This is where the grumPHP command will be executed. 
 
 **stop_on_failure**
 

--- a/resources/config/parameters.yml
+++ b/resources/config/parameters.yml
@@ -3,6 +3,7 @@ parameters:
   git_dir: .
   hooks_dir: ~
   hooks_preset: local
+  vagrant_dir: .
   tasks: []
   stop_on_failure: false
   ignore_unstaged_changes: false

--- a/resources/hooks/vagrant/commit-msg
+++ b/resources/hooks/vagrant/commit-msg
@@ -4,7 +4,7 @@ GIT_USER=$(git config user.name)
 GIT_EMAIL=$(git config user.email)
 COMMIT_MSG_FILE=$1
 
-vagrant ssh --command "(exec $(HOOK_COMMAND)  '--git-user=$GIT_USER' '--git-email=$GIT_EMAIL' '$COMMIT_MSG_FILE')"
+vagrant ssh --command "cd ${VAGRANT_DIR} && (exec $(HOOK_COMMAND)  '--git-user=$GIT_USER' '--git-email=$GIT_EMAIL' '$COMMIT_MSG_FILE')"
 
 # Validate exit code of above command
 RC=$?

--- a/resources/hooks/vagrant/pre-commit
+++ b/resources/hooks/vagrant/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-vagrant ssh --command "(exec $(HOOK_COMMAND) '--skip-success-output')"
+vagrant ssh --command "cd ${VAGRANT_DIR} && (exec $(HOOK_COMMAND) '--skip-success-output')"
 
 # Validate exit code of above command
 RC=$?

--- a/spec/GrumPHP/Configuration/GrumPHPSpec.php
+++ b/spec/GrumPHP/Configuration/GrumPHPSpec.php
@@ -50,6 +50,12 @@ class GrumPHPSpec extends ObjectBehavior
         $this->getHooksPreset()->shouldReturn('local');
     }
 
+    function it_knows_the_vagrant_dir(ContainerInterface $container)
+    {
+        $container->getParameter('vagrant_dir')->willReturn('.');
+        $this->getVagrantDir()->shouldReturn('.');
+    }
+
     function it_knows_to_stop_on_failure(ContainerInterface $container)
     {
         $container->getParameter('stop_on_failure')->willReturn(true);

--- a/src/GrumPHP/Configuration/GrumPHP.php
+++ b/src/GrumPHP/Configuration/GrumPHP.php
@@ -50,6 +50,14 @@ class GrumPHP
     /**
      * @return string
      */
+    public function getVagrantDir()
+    {
+        return $this->container->getParameter('vagrant_dir');
+    }
+
+    /**
+     * @return string
+     */
     public function getHooksPreset()
     {
         return $this->container->getParameter('hooks_preset');

--- a/src/GrumPHP/Console/Command/Git/InitCommand.php
+++ b/src/GrumPHP/Console/Command/Git/InitCommand.php
@@ -122,6 +122,7 @@ class InitCommand extends Command
     {
         $content = file_get_contents($templateFile);
         $replacements = array(
+            '${VAGRANT_DIR}' => $this->grumPHP->getVagrantDir(),
             '${HOOK_EXEC_PATH}' => $this->paths()->getGitHookExecutionPath(),
             '$(HOOK_COMMAND)' => $this->generateHookCommand('git:' . $hook),
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes? I don't have phpspec running, but updated the tests
| Documented?   | yes
| Fixed tickets | #145 

This PR solves the issue described in #145, by adding a vagrant_dir to the config parameters, where the vagrant dir of the project can be set, which is then used in the git hooks to cd to before executing GrumPHP.  
