### PR TITLE
Make it possible to use the raw git diff as input in the git hooks.

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -28,6 +28,9 @@ php ./vendor/bin/grumphp git:pre-commit
 php ./vendor/bin/grumphp git:commit-msg
 ```
 
+Both commands support raw git diffs as STDIN input. 
+This way it is possible to pass changes triggered by `git commit -a` from the GIT hook to the GrumPHP commands.
+
 ## Run
 
 If you want to run the tests on the full codebase, you can run the command:

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -48,11 +48,16 @@ GrumPHP comes with following presets:
 - `vagrant`: All checks will run in your vagrant box.
 
 
-*Note:* When using the vagrant preset, make sure the working directory of the vagrant shell is located at your remote project path:
+*Note:* 
+When using the vagrant preset, you are required to set the vagrant SSH home folder to your working directory. 
+This can be done by altering the `.bashrc` or `.zshrc` inside your vagrant box:
  
 ```sh
 echo 'cd /remote/path/to/your/project' >> ~/.bashrc
 ```
+
+You can also add the `.bashrc` or `.zshrc` to your vagrant provision script. 
+This way the home directory will be set for all the people who are using your vagrant box.
 
 **stop_on_failure**
 

--- a/resources/hooks/local/commit-msg
+++ b/resources/hooks/local/commit-msg
@@ -8,8 +8,9 @@
 GIT_USER=$(git config user.name)
 GIT_EMAIL=$(git config user.email)
 COMMIT_MSG_FILE=$1
+DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
 
-(cd "${HOOK_EXEC_PATH}" && exec $(HOOK_COMMAND) "--git-user=$GIT_USER" "--git-email=$GIT_EMAIL" "$COMMIT_MSG_FILE")
+(cd "${HOOK_EXEC_PATH}" && echo "${DIFF}" | exec $(HOOK_COMMAND) "--git-user=$GIT_USER" "--git-email=$GIT_EMAIL" "$COMMIT_MSG_FILE")
 
 # Validate exit code of above command
 RC=$?

--- a/resources/hooks/local/pre-commit
+++ b/resources/hooks/local/pre-commit
@@ -4,7 +4,10 @@
 # Run the hook command.
 # Note: this will be replaced by the real command during copy.
 #
-(cd "${HOOK_EXEC_PATH}" && exec $(HOOK_COMMAND) '--skip-success-output')
+
+DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
+
+(cd "${HOOK_EXEC_PATH}" && echo "${DIFF}" | exec $(HOOK_COMMAND) '--skip-success-output')
 
 # Validate exit code of above command
 RC=$?

--- a/resources/hooks/vagrant/commit-msg
+++ b/resources/hooks/vagrant/commit-msg
@@ -1,10 +1,16 @@
 #!/bin/sh
 
+#
+# Run the hook command.
+# Note: this will be replaced by the real command during copy.
+#
+
 GIT_USER=$(git config user.name)
 GIT_EMAIL=$(git config user.email)
 COMMIT_MSG_FILE=$1
+DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
 
-vagrant ssh --command "(exec $(HOOK_COMMAND)  '--git-user=$GIT_USER' '--git-email=$GIT_EMAIL' '$COMMIT_MSG_FILE')"
+vagrant ssh --command "(echo $DIFF | exec $(HOOK_COMMAND) '--git-user=$GIT_USER' '--git-email=$GIT_EMAIL' '$COMMIT_MSG_FILE')"
 
 # Validate exit code of above command
 RC=$?

--- a/resources/hooks/vagrant/commit-msg
+++ b/resources/hooks/vagrant/commit-msg
@@ -10,7 +10,15 @@ GIT_EMAIL=$(git config user.email)
 COMMIT_MSG_FILE=$1
 DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
 
-vagrant ssh --command "echo '$DIFF' | exec $(HOOK_COMMAND) '--git-user=$GIT_USER' '--git-email=$GIT_EMAIL' '$COMMIT_MSG_FILE'"
+# Copying commit message to vagrant ...
+VAGRANT_COMMIT_MSG_FILE=$(vagrant ssh --command 'mktemp -t grumphp-commitmsg.XXXXXXXXXX')
+vagrant ssh --command "cat > $VAGRANT_COMMIT_MSG_FILE" < $COMMIT_MSG_FILE
+
+# Running GrumPHP
+vagrant ssh --command "echo '$DIFF' | exec $(HOOK_COMMAND) '--git-user=$GIT_USER' '--git-email=$GIT_EMAIL' '$VAGRANT_COMMIT_MSG_FILE'"
+
+# Cleaning up commit file ...
+vagrant ssh --command "rm $VAGRANT_COMMIT_MSG_FILE"
 
 # Validate exit code of above command
 RC=$?

--- a/resources/hooks/vagrant/commit-msg
+++ b/resources/hooks/vagrant/commit-msg
@@ -8,17 +8,20 @@
 GIT_USER=$(git config user.name)
 GIT_EMAIL=$(git config user.email)
 COMMIT_MSG_FILE=$1
+COMMIT_MSG=$(cat $COMMIT_MSG_FILE)
 DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
 
-# Copying commit message to vagrant ...
-VAGRANT_COMMIT_MSG_FILE=$(vagrant ssh --command 'mktemp -t grumphp-commitmsg.XXXXXXXXXX')
-vagrant ssh --command "cat > $VAGRANT_COMMIT_MSG_FILE" < $COMMIT_MSG_FILE
-
-# Running GrumPHP
-vagrant ssh --command "echo '$DIFF' | exec $(HOOK_COMMAND) '--git-user=$GIT_USER' '--git-email=$GIT_EMAIL' '$VAGRANT_COMMIT_MSG_FILE'"
-
-# Cleaning up commit file ...
-vagrant ssh --command "rm $VAGRANT_COMMIT_MSG_FILE"
+#
+# Copy the commit message and run GrumPHP
+#
+vagrant ssh --command '$(which bash)' << COMMANDS
+  VAGRANT_COMMIT_MSG_FILE=\$(mktemp -t "grumphp-commitmsg.XXXXXXXXXX")
+  echo '$COMMIT_MSG' > \$VAGRANT_COMMIT_MSG_FILE
+  echo '$DIFF' | exec $(HOOK_COMMAND) '--ansi' --git-user='$GIT_USER' --git-email='$GIT_EMAIL' \$VAGRANT_COMMIT_MSG_FILE
+  RC=\$?
+  rm \$VAGRANT_COMMIT_MSG_FILE
+  exit \$RC
+COMMANDS
 
 # Validate exit code of above command
 RC=$?

--- a/resources/hooks/vagrant/commit-msg
+++ b/resources/hooks/vagrant/commit-msg
@@ -10,7 +10,7 @@ GIT_EMAIL=$(git config user.email)
 COMMIT_MSG_FILE=$1
 DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
 
-vagrant ssh --command "(echo $DIFF | exec $(HOOK_COMMAND) '--git-user=$GIT_USER' '--git-email=$GIT_EMAIL' '$COMMIT_MSG_FILE')"
+vagrant ssh --command "echo '$DIFF' | exec $(HOOK_COMMAND) '--git-user=$GIT_USER' '--git-email=$GIT_EMAIL' '$COMMIT_MSG_FILE'"
 
 # Validate exit code of above command
 RC=$?

--- a/resources/hooks/vagrant/pre-commit
+++ b/resources/hooks/vagrant/pre-commit
@@ -7,7 +7,12 @@
 
 DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
 
-vagrant ssh --command "echo '$DIFF' | exec $(HOOK_COMMAND) '--skip-success-output'"
+#
+# Run GrumPHP
+#
+vagrant ssh --command '$(which bash)' << COMMANDS
+  echo '$DIFF' | exec $(HOOK_COMMAND) '--ansi' '--skip-success-output'
+COMMANDS
 
 # Validate exit code of above command
 RC=$?

--- a/resources/hooks/vagrant/pre-commit
+++ b/resources/hooks/vagrant/pre-commit
@@ -1,6 +1,13 @@
 #!/bin/sh
 
-vagrant ssh --command "(exec $(HOOK_COMMAND) '--skip-success-output')"
+#
+# Run the hook command.
+# Note: this will be replaced by the real command during copy.
+#
+
+DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
+
+vagrant ssh --command "( echo "$DIFF" | exec $(HOOK_COMMAND) '--skip-success-output')"
 
 # Validate exit code of above command
 RC=$?

--- a/resources/hooks/vagrant/pre-commit
+++ b/resources/hooks/vagrant/pre-commit
@@ -7,7 +7,7 @@
 
 DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
 
-vagrant ssh --command "( echo "$DIFF" | exec $(HOOK_COMMAND) '--skip-success-output')"
+vagrant ssh --command "echo '$DIFF' | exec $(HOOK_COMMAND) '--skip-success-output'"
 
 # Validate exit code of above command
 RC=$?

--- a/spec/GrumPHP/IO/ConsoleIOSpec.php
+++ b/spec/GrumPHP/IO/ConsoleIOSpec.php
@@ -2,7 +2,7 @@
 
 namespace spec\GrumPHP\IO;
 
-use Composer\IO\ConsoleIO;
+use GrumPHP\IO\ConsoleIO;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -78,5 +78,26 @@ class ConsoleIOSpec extends ObjectBehavior
 
         $output->write('test', true)->shouldBeCalled();
         $this->writeError('test');
+    }
+
+    function it_reads_command_input()
+    {
+        $handle = $this->mockHandle('input');
+        $this->readCommandInput($handle)->shouldBe('input');
+    }
+
+    function it_knows_empty_command_input()
+    {
+        $handle = $this->mockHandle("\r\n\t\f ");
+        $this->readCommandInput($handle)->shouldBe('');
+    }
+
+    private function mockHandle($content)
+    {
+        $handle = fopen('php://memory', 'a');
+        fwrite($handle, $content);
+        rewind($handle);
+
+        return $handle;
     }
 }

--- a/spec/GrumPHP/Locator/ChangedFilesSpec.php
+++ b/spec/GrumPHP/Locator/ChangedFilesSpec.php
@@ -3,7 +3,6 @@
 namespace spec\GrumPHP\Locator;
 
 use Gitonomy\Git\Diff\Diff;
-use Gitonomy\Git\Diff\File;
 use Gitonomy\Git\WorkingCopy;
 use Gitonomy\Git\Repository;
 use GrumPHP\Locator\ChangedFiles;
@@ -47,10 +46,27 @@ class ChangedFilesSpec extends ObjectBehavior
         $workingCopy->getDiffStaged()->willReturn($diff);
         $diff->getFiles()->willReturn(array($changedFile, $movedFile, $deletedFile));
 
-        $result = $this->locate();
+        $result = $this->locateFromGitRepository();
         $result->shouldBeAnInstanceOf('GrumPHP\Collection\FilesCollection');
         $result[0]->getPathname()->shouldBe('file1.txt');
         $result[1]->getPathname()->shouldBe('file2.txt');
         $result->getIterator()->count()->shouldBe(2);
+    }
+
+    function it_will_list_all_diffed_files_from_raw_diff_input()
+    {
+        $rawDiff = 'diff --git a/file.txt b/file.txt
+new file mode 100644
+index 0000000000000000000000000000000000000000..9766475a4185a151dc9d56d614ffb9aaea3bfd42
+--- /dev/null
++++ b/file.txt
+@@ -0,0 +1 @@
++content
+';
+
+        $result = $this->locateFromRawDiffInput($rawDiff);
+        $result->shouldBeAnInstanceOf('GrumPHP\Collection\FilesCollection');
+        $result[0]->getPathname()->shouldBe('file.txt');
+        $result->getIterator()->count()->shouldBe(1);
     }
 }

--- a/src/GrumPHP/Console/Command/Git/CommitMsgCommand.php
+++ b/src/GrumPHP/Console/Command/Git/CommitMsgCommand.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Console\Helper\PathsHelper;
 use GrumPHP\Console\Helper\TaskRunnerHelper;
+use GrumPHP\IO\ConsoleIO;
 use GrumPHP\Locator\ChangedFiles;
 use GrumPHP\Task\Context\GitCommitMsgContext;
 use SplFileInfo;
@@ -63,7 +64,8 @@ class CommitMsgCommand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $files = $this->getCommittedFiles();
+        $io = new ConsoleIO($input, $output);
+        $files = $this->getCommittedFiles($io);
         $gitUser = $input->getOption('git-user');
         $gitEmail = $input->getOption('git-email');
         $commitMsgPath = $input->getArgument('commit-msg-file');
@@ -77,9 +79,13 @@ class CommitMsgCommand extends Command
     /**
      * @return FilesCollection
      */
-    protected function getCommittedFiles()
+    protected function getCommittedFiles(ConsoleIO $io)
     {
-        return $this->changedFilesLocator->locate();
+        if ($stdin = $io->readCommandInput()) {
+            return $this->changedFilesLocator->locateFromRawDiffInput($stdin);
+        }
+
+        return $this->changedFilesLocator->locateFromGitRepository();
     }
 
     /**

--- a/src/GrumPHP/Console/Command/Git/PreCommitCommand.php
+++ b/src/GrumPHP/Console/Command/Git/PreCommitCommand.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Console\Helper\PathsHelper;
 use GrumPHP\Console\Helper\TaskRunnerHelper;
+use GrumPHP\IO\ConsoleIO;
 use GrumPHP\Locator\ChangedFiles;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use Symfony\Component\Console\Command\Command;
@@ -64,7 +65,9 @@ class PreCommitCommand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $files = $this->getCommittedFiles();
+        $io = new ConsoleIO($input, $output);
+        $files = $this->getCommittedFiles($io);
+
         $context = new GitPreCommitContext($files);
         $skipSuccessOutput = (bool) $input->getOption('skip-success-output');
 
@@ -75,9 +78,13 @@ class PreCommitCommand extends Command
     /**
      * @return FilesCollection
      */
-    protected function getCommittedFiles()
+    protected function getCommittedFiles(ConsoleIO $io)
     {
-        return $this->changedFilesLocator->locate();
+        if ($stdin = $io->readCommandInput()) {
+            return $this->changedFilesLocator->locateFromRawDiffInput($stdin);
+        }
+
+        return $this->changedFilesLocator->locateFromGitRepository();
     }
 
     /**

--- a/src/GrumPHP/IO/ConsoleIO.php
+++ b/src/GrumPHP/IO/ConsoleIO.php
@@ -24,6 +24,11 @@ class ConsoleIO implements IOInterface
     private $output;
 
     /**
+     * @var string
+     */
+    private $stdin;
+
+    /**
      * ConsoleIO constructor.
      *
      * @param InputInterface  $input
@@ -89,6 +94,28 @@ class ConsoleIO implements IOInterface
     public function writeError($messages, $newline = true)
     {
         $this->doWrite($messages, $newline, true);
+    }
+
+    /**
+     * @param null|resource $handle
+     *
+     * @return string
+     */
+    public function readCommandInput($handle = STDIN)
+    {
+        if ($this->stdin !== null || ftell($handle) !== 0) {
+            return $this->stdin;
+        }
+        
+        $input = '';
+        while (!feof($handle)) {
+            $input .= fread($handle, 1024);
+        }
+
+        // When the input only consist of white space characters, we assume that there is no input.
+        $this->stdin = !preg_match('/^([\s]*)$/m', $input) ? $input : '';
+
+        return  $this->stdin;
     }
 
     /**

--- a/src/GrumPHP/Locator/ChangedFiles.php
+++ b/src/GrumPHP/Locator/ChangedFiles.php
@@ -2,6 +2,7 @@
 
 namespace GrumPHP\Locator;
 
+use Gitonomy\Git\Diff\Diff;
 use Gitonomy\Git\Diff\File;
 use Gitonomy\Git\Repository;
 use GrumPHP\Collection\FilesCollection;
@@ -30,9 +31,33 @@ class ChangedFiles
     /**
      * @return FilesCollection
      */
-    public function locate()
+    public function locateFromGitRepository()
     {
         $diff = $this->repository->getWorkingCopy()->getDiffStaged();
+
+        return $this->parseFilesFromDiff($diff);
+    }
+
+    /**
+     * @param string $rawDiff
+     *
+     * @return FilesCollection
+     */
+    public function locateFromRawDiffInput($rawDiff)
+    {
+        $diff = Diff::parse($rawDiff);
+        $diff->setRepository($this->repository);
+
+        return $this->parseFilesFromDiff($diff);
+    }
+
+    /**
+     * @param Diff $diff
+     *
+     * @return FilesCollection
+     */
+    private function parseFilesFromDiff(Diff $diff)
+    {
         $files = array();
         /** @var File $file */
         foreach ($diff->getFiles() as $file) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #144

This PR makes it possible to pass the raw git diff output to the `git:pre-commit` and `git:commit-msg` command of GrumPHP. When no raw diff input is added, the command will try to fetch the git diff through a separate git process.
This PR should also show the changed files when commiting through `git commit -a` and therefor fix #144.
