### PR TITLE
Improve external command locator

### DIFF
--- a/spec/GrumPHP/Console/Helper/PathsHelperSpec.php
+++ b/spec/GrumPHP/Console/Helper/PathsHelperSpec.php
@@ -4,6 +4,7 @@ namespace spec\GrumPHP\Console\Helper;
 
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Console\Helper\PathsHelper;
+use GrumPHP\Locator\ExternalCommand;
 use Symfony\Component\Filesystem\Filesystem;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -13,9 +14,9 @@ use Prophecy\Argument;
  */
 class PathsHelperSpec extends ObjectBehavior
 {
-    function let(GrumPHP $config, Filesystem $fileSystem)
+    function let(GrumPHP $config, Filesystem $fileSystem, ExternalCommand $externalCommandLocator)
     {
-        $this->beConstructedWith($config, $fileSystem, '/grumphp.yml');
+        $this->beConstructedWith($config, $fileSystem, $externalCommandLocator, '/grumphp.yml');
     }
     
     function it_is_a_console_helper()

--- a/src/GrumPHP/Console/Application.php
+++ b/src/GrumPHP/Console/Application.php
@@ -128,6 +128,7 @@ class Application extends SymfonyConsole
         $helperSet->set(new Helper\PathsHelper(
             $container->get('config'),
             $container->get('filesystem'),
+            $container->get('locator.external_command'),
             $this->getDefaultConfigPath()
         ));
         $helperSet->set(new Helper\TaskRunnerHelper(
@@ -213,6 +214,7 @@ class Application extends SymfonyConsole
         try {
             $composerFile = getcwd() . DIRECTORY_SEPARATOR . 'composer.json';
             $configuration = Composer::loadConfiguration();
+            Composer::ensureProjectBinDirInSystemPath($configuration->get('bin-dir'));
             $rootPackage = Composer::loadRootPackageFromJson($composerFile, $configuration);
         } catch (RuntimeException $e) {
             $configuration = null;

--- a/src/GrumPHP/Console/Command/Git/InitCommand.php
+++ b/src/GrumPHP/Console/Command/Git/InitCommand.php
@@ -133,11 +133,13 @@ class InitCommand extends Command
      * @param $command
      *
      * @return string
+     * @throws \GrumPHP\Exception\FileNotFoundException
      */
     protected function generateHookCommand($command)
     {
+        $executable = $this->paths()->getBinCommand('grumphp', true);
         $this->processBuilder->setArguments(array(
-            $this->paths()->getBinCommand('grumphp', true),
+            $this->paths()->getRelativeProjectPath($executable),
             $command
         ));
 

--- a/src/GrumPHP/Locator/ExternalCommand.php
+++ b/src/GrumPHP/Locator/ExternalCommand.php
@@ -5,6 +5,11 @@ namespace GrumPHP\Locator;
 use GrumPHP\Exception\RuntimeException;
 use Symfony\Component\Process\ExecutableFinder;
 
+/**
+ * Class ExternalCommand
+ *
+ * @package GrumPHP\Locator
+ */
 class ExternalCommand
 {
     /**

--- a/src/GrumPHP/Util/Composer.php
+++ b/src/GrumPHP/Util/Composer.php
@@ -55,4 +55,37 @@ class Composer
 
         return $configuration;
     }
+
+    /**
+     * Composer contains some logic to prepend the current bin dir to the system PATH.
+     * To make sure this application works the same in CLI and Composer modus,
+     * we'll have to ensure that the bin path is always prefixed.
+     *
+     * @link https://github.com/composer/composer/blob/1.1/src/Composer/EventDispatcher/EventDispatcher.php#L147-L160
+     *
+     * @param string $binDir
+     */
+    public static function ensureProjectBinDirInSystemPath($binDir)
+    {
+        $pathStr = 'PATH';
+        if (!isset($_SERVER[$pathStr]) && isset($_SERVER['Path'])) {
+            $pathStr = 'Path';
+        }
+
+        if (!is_dir($binDir)) {
+            return;
+        }
+
+        // add the bin dir to the PATH to make local binaries of deps usable in scripts
+        $binDir = realpath($binDir);
+        $hasBindDirInPath = preg_match(
+            '{(^|' . PATH_SEPARATOR . ')' . preg_quote($binDir) . '($|' . PATH_SEPARATOR . ')}',
+            $_SERVER[$pathStr]
+        );
+
+        if (!$hasBindDirInPath && isset($_SERVER[$pathStr])) {
+            $_SERVER[$pathStr] = $binDir . PATH_SEPARATOR . getenv($pathStr);
+            putenv($pathStr . '=' . $_SERVER[$pathStr]);
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #140, #145

As mentioned in the fixed ticket, the project commands should have priority to the globally installed commands. To make sure that the project bin-dir is always checked first, the PATH variable is altered. This also happens while running the commands as composer plugin. 

After this PR is merged, both the composer plugin and the CLI tool will work exactly the same.
To improve the generated GIT hooks, the external commands are made relative if the command is located in the project. If the external command is not located in the project, the absolute path will be used.