### PR TITLE
Configurable process timeout parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ parameters:
     hooks_preset: local
     stop_on_failure: false
     ignore_unstaged_changes: false
+    process_timeout: 60
     ascii:
         failed: grumphp-grumpy.txt
         succeeded: grumphp-happy.txt

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -9,6 +9,7 @@ parameters:
     hooks_preset: local
     stop_on_failure: false
     ignore_unstaged_changes: false
+    process_timeout: 60
     ascii:
         failed: resource/grumphp-grumpy.txt
         succeeded: resource/grumphp-happy.txt
@@ -69,6 +70,15 @@ By enabling this option, GrumPHP will stash your unstaged changes in git before 
 This way the tasks will run with the code that is actually committed without the unstaged changes.
 Note that during the commit, the unstaged changes will be stored in git stash.
 This may mess with your working copy and result in unexpected merge conflicts.
+
+**process_timeout**
+
+*Default: 60*
+
+GrumPHP uses the Symfony Process component to run external tasks.
+The component will trigger a timeout after 60 seconds by default.
+If you've got tools that run more then 60 seconds, you can increase this parameter.
+It is also possible to disable the timeout by setting the value to `null`.
 
 **ascii**
 

--- a/resources/config/parameters.yml
+++ b/resources/config/parameters.yml
@@ -6,6 +6,7 @@ parameters:
   tasks: []
   stop_on_failure: false
   ignore_unstaged_changes: false
+  process_timeout: 60
   extensions: []
   ascii:
     failed: grumphp-grumpy.txt

--- a/resources/config/services.yml
+++ b/resources/config/services.yml
@@ -18,6 +18,7 @@ services:
     process_builder:
       class: GrumPHP\Process\ProcessBuilder
       arguments:
+        - '@config'
         - '@locator.external_command'
 
     git.repository:

--- a/spec/GrumPHP/Configuration/GrumPHPSpec.php
+++ b/spec/GrumPHP/Configuration/GrumPHPSpec.php
@@ -62,6 +62,15 @@ class GrumPHPSpec extends ObjectBehavior
         $this->ignoreUnstagedChanges()->shouldReturn(true);
     }
 
+    function it_configures_the_symfony_process_timeout(ContainerInterface $container)
+    {
+        $container->getParameter('process_timeout')->willReturn(null);
+        $this->getProcessTimeout()->shouldReturn(null);
+
+        $container->getParameter('process_timeout')->willReturn(120);
+        $this->getProcessTimeout()->shouldReturn(120.0);
+    }
+
     function it_should_return_empty_ascii_location_for_unknown_resources(ContainerInterface $container)
     {
         $container->getParameter('ascii')->willReturn(array());

--- a/spec/GrumPHP/Process/ProcessBuilderSpec.php
+++ b/spec/GrumPHP/Process/ProcessBuilderSpec.php
@@ -3,6 +3,7 @@
 namespace spec\GrumPHP\Process;
 
 use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\ExternalCommand;
 use GrumPHP\Process\ProcessBuilder;
 use PhpSpec\Exception\Example\FailureException;
@@ -14,9 +15,10 @@ use Prophecy\Argument;
  */
 class ProcessBuilderSpec extends ObjectBehavior
 {
-    function let(ExternalCommand $externalCommandLocator)
+    function let(GrumPHP $config, ExternalCommand $externalCommandLocator)
     {
-        $this->beConstructedWith($externalCommandLocator);
+        $this->beConstructedWith($config, $externalCommandLocator);
+        $config->getProcessTimeout()->willReturn(60);
     }
 
     function it_is_initializable()
@@ -41,6 +43,18 @@ class ProcessBuilderSpec extends ObjectBehavior
 
         $process->shouldHaveType('Symfony\Component\Process\Process');
         $process->getCommandLine()->shouldBeQuoted('/usr/bin/grumphp');
+    }
+
+    function it_should_be_possible_to_configure_the_process_timeout(
+        GrumPHP $config,
+        ExternalCommand $externalCommandLocator
+    )
+    {
+        $config->getProcessTimeout()->willReturn(120);
+
+        $arguments = new ProcessArgumentsCollection(array('/usr/bin/grumphp'));
+        $process = $this->buildProcess($arguments);
+        $process->getTimeout()->shouldBe(120.0);
     }
 
     function getMatchers()

--- a/src/GrumPHP/Configuration/GrumPHP.php
+++ b/src/GrumPHP/Configuration/GrumPHP.php
@@ -72,6 +72,19 @@ class GrumPHP
     }
 
     /**
+     * @return float|null
+     */
+    public function getProcessTimeout()
+    {
+        $timeout = $this->container->getParameter('process_timeout');
+        if (null === $timeout) {
+            return null;
+        }
+
+        return (float) $timeout;
+    }
+
+    /**
      * @return array
      */
     public function getRegisteredTasks()

--- a/src/GrumPHP/Process/ProcessBuilder.php
+++ b/src/GrumPHP/Process/ProcessBuilder.php
@@ -3,6 +3,7 @@
 namespace GrumPHP\Process;
 
 use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Locator\ExternalCommand;
 use Symfony\Component\Process\Process;
 use \Symfony\Component\Process\ProcessBuilder as SymfonyProcessBuilder;
@@ -21,13 +22,20 @@ class ProcessBuilder
     private $externalCommandLocator;
 
     /**
+     * @var GrumPHP
+     */
+    private $config;
+
+    /**
      * ProcessBuilder constructor.
      *
+     * @param GrumPHP         $config
      * @param ExternalCommand $externalCommandLocator
      */
-    public function __construct(ExternalCommand $externalCommandLocator)
+    public function __construct(GrumPHP $config, ExternalCommand $externalCommandLocator)
     {
         $this->externalCommandLocator = $externalCommandLocator;
+        $this->config = $config;
     }
 
     /**
@@ -50,6 +58,7 @@ class ProcessBuilder
     public function buildProcess(ProcessArgumentsCollection $arguments)
     {
         $builder = SymfonyProcessBuilder::create($arguments->getValues());
+        $builder->setTimeout($this->config->getProcessTimeout());
 
         return $builder->getProcess();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #149 

This PR makes it possible to configure the process timeout globally. If your task is taking a long time to run, this setting might be a life saver!