### PR TITLE
Upgrade phpcsfixer task to stick to v2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpspec/phpspec": "~2.5",
         "phpspec/prophecy": "~1.6",
         "squizlabs/php_codesniffer": "~2.3",
-        "friendsofphp/php-cs-fixer": "~1",
+        "friendsofphp/php-cs-fixer": "~2.0",
         "phpunit/phpunit": "^4.8",
         "sensiolabs/security-checker": "^3.0"
     },

--- a/doc/tasks/php_cs_fixer.md
+++ b/doc/tasks/php_cs_fixer.md
@@ -8,41 +8,31 @@ It lives under the `phpcsfixer` namespace and has following configurable paramet
 parameters:
     tasks:
         phpcsfixer:
-            config_file: ~
             config: ~
-            fixers: []
-            level: ~
+            pathMode: override
+            rules: []
             verbose: true
 ```
 
-**config_file**
+**config**
 
 *Default: null*
 
 You can specify the path to the `.php_cs` file.
 
+**pathMode**
 
-**config**
+*Default: override*
 
-*Default: 'default'*
-
-There such predefined configs for codestyle checks: `default`, `magento`, `sf23`.
-If you want to run a particular config, specify it with this option.
+You can specify the path mode.
 
 
-**fixers**
+**rules**
 
 *Default: array()*
 
-There are a lot of fixers which you can apply to your code. You can specify an array of them in this config.
-The full list of fixers you can find [here](https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage).
-
-
-**level**
-
-*Default: null*
-
-Fixers are grouped by levels: `psr0`, `psr1`, `psr2` you can specify a group instead of applying them separately.
+There are a lot of rules which you can apply to your code. You can specify an array of them in this config.
+The full list of rules you can find [here](https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage).
 
 
 **verbose**

--- a/spec/GrumPHP/Task/PhpCsFixerSpec.php
+++ b/spec/GrumPHP/Task/PhpCsFixerSpec.php
@@ -49,9 +49,8 @@ class PhpCsFixerSpec extends ObjectBehavior
         $options = $this->getConfigurableOptions();
         $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
         $options->getDefinedOptions()->shouldContain('config');
-        $options->getDefinedOptions()->shouldContain('config_file');
-        $options->getDefinedOptions()->shouldContain('fixers');
-        $options->getDefinedOptions()->shouldContain('level');
+        $options->getDefinedOptions()->shouldContain('pathMode');
+        $options->getDefinedOptions()->shouldContain('rules');
         $options->getDefinedOptions()->shouldContain('verbose');
     }
 
@@ -83,7 +82,7 @@ class PhpCsFixerSpec extends ObjectBehavior
         RunContext $context,
         PhpCsFixerFormatter $formatter
     ) {
-        $grumPHP->getTaskConfiguration('phpcsfixer')->willReturn(array('config_file' => '.php_cs'));
+        $grumPHP->getTaskConfiguration('phpcsfixer')->willReturn(array('config' => '.php_cs'));
         $formatter->resetCounter()->shouldBeCalled();
 
         $context->getFiles()->willReturn(new FilesCollection(array(

--- a/src/GrumPHP/Task/PhpCsFixer.php
+++ b/src/GrumPHP/Task/PhpCsFixer.php
@@ -37,16 +37,14 @@ class PhpCsFixer extends AbstractExternalTask
         $resolver = new OptionsResolver();
         $resolver->setDefaults(array(
             'config' => null,
-            'config_file' => null,
-            'fixers' => array(),
-            'level' => null,
+            'pathMode' => 'override',
+            'rules' => array(),
             'verbose' => true,
         ));
 
         $resolver->addAllowedTypes('config', array('null', 'string'));
-        $resolver->addAllowedTypes('config_file', array('null', 'string'));
-        $resolver->addAllowedTypes('fixers', array('array'));
-        $resolver->addAllowedTypes('level', array('null', 'string'));
+        $resolver->addAllowedTypes('pathMode', array('string'));
+        $resolver->addAllowedTypes('rules', array('array'));
         $resolver->addAllowedTypes('verbose', array('bool'));
 
         return $resolver;
@@ -76,14 +74,13 @@ class PhpCsFixer extends AbstractExternalTask
         $arguments = $this->processBuilder->createArgumentsForCommand('php-cs-fixer');
         $arguments->add('--format=json');
         $arguments->add('--dry-run');
-        $arguments->addOptionalArgument('--level=%s', $config['level']);
         $arguments->addOptionalArgument('--config=%s', $config['config']);
-        $arguments->addOptionalArgument('--config-file=%s', $config['config_file']);
+        $arguments->addOptionalArgument('--path-mode=%s', $config['pathMode']);
         $arguments->addOptionalArgument('--verbose', $config['verbose']);
-        $arguments->addOptionalCommaSeparatedArgument('--fixers=%s', $config['fixers']);
+        $arguments->addOptionalCommaSeparatedArgument('--rules=%s', $config['rules']);
         $arguments->add('fix');
 
-        if ($context instanceof RunContext && $config['config_file'] !== null) {
+        if ($context instanceof RunContext && $config['config'] !== null) {
             return $this->runOnAllFiles($context, $arguments);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | yes/no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | 

As the PHPCsFixer project released a first v2.0.0-alpha version, I propose this PR in order to be ready when the final v2.0 will be released.

We should wait for the final v2.0 before the merge of this PR,but I prefer to submit it in a proactive way.
