### PR TITLE
Add whitelist_patterns option to Phpcs task

### DIFF
--- a/doc/tasks/phpcs.md
+++ b/doc/tasks/phpcs.md
@@ -11,7 +11,7 @@ parameters:
             standard: ~
             show_warnings: true
             tab_width: ~
-            whitelist_path_pattern: ~
+            whitelist_patterns: []
             ignore_patterns: []
             sniffs: []
             triggered_by: [php]
@@ -49,12 +49,12 @@ Triggers an error when there are warnings.
 By default, the standard will specify the optimal tab-width of the code. If you want to overwrite this option, you can use this configuration option.
 
 
-**whitelist_path_pattern**
+**whitelist_patterns**
 
-*Default: null*
+*Default: []*
 
-This is regex pattern that will filter files to validate. With this option you can skip files like tests. This option is used in relation with the parameter `triggered_by`.
-For exemple you can use `whitelist_path_pattern: "^src/(.*)"` to validate only files in your `src/` directory in a Symfony.
+This is a list of regex patterns that will filter files to validate. With this option you can skip files like tests. This option is used in relation with the parameter `triggered_by`.
+For exemple you can use `whitelist_patterns: ["^src/App/(.*)","^src/AppBundle/(.*)"]` to validate only files in your `src/App/` and `src/AppBundle/` directories in a Symfony.
 
 
 **ignore_patterns**

--- a/doc/tasks/phpcs.md
+++ b/doc/tasks/phpcs.md
@@ -11,6 +11,7 @@ parameters:
             standard: ~
             show_warnings: true
             tab_width: ~
+            whitelist_path_pattern: ~
             ignore_patterns: []
             sniffs: []
             triggered_by: [php]
@@ -46,6 +47,14 @@ Triggers an error when there are warnings.
 *Default: null*
 
 By default, the standard will specify the optimal tab-width of the code. If you want to overwrite this option, you can use this configuration option.
+
+
+**whitelist_path_pattern**
+
+*Default: null*
+
+This is regex pattern that will filter files to validate. With this option you can skip files like tests. This option is used in relation with the parameter `triggered_by`.
+For exemple you can use `whitelist_path_pattern: "^src/(.*)"` to validate only files in your `src/` directory in a Symfony.
 
 
 **ignore_patterns**

--- a/doc/tasks/phpcs.md
+++ b/doc/tasks/phpcs.md
@@ -54,7 +54,12 @@ By default, the standard will specify the optimal tab-width of the code. If you 
 *Default: []*
 
 This is a list of regex patterns that will filter files to validate. With this option you can skip files like tests. This option is used in relation with the parameter `triggered_by`.
-For exemple you can use `whitelist_patterns: ["^src/App/(.*)","^src/AppBundle/(.*)"]` to validate only files in your `src/App/` and `src/AppBundle/` directories in a Symfony.
+For exemple to validate only files in your `src/App/` and `src/AppBundle/` directories in a Symfony you can use 
+```yml
+whitelist_patterns: [
+  - /^src\/App\/(.*)/
+  - /^src\/AppBundle\/(.*)/
+```
 
 
 **ignore_patterns**

--- a/doc/tasks/phpcs.md
+++ b/doc/tasks/phpcs.md
@@ -56,7 +56,7 @@ By default, the standard will specify the optimal tab-width of the code. If you 
 This is a list of regex patterns that will filter files to validate. With this option you can skip files like tests. This option is used in relation with the parameter `triggered_by`.
 For exemple to validate only files in your `src/App/` and `src/AppBundle/` directories in a Symfony you can use 
 ```yml
-whitelist_patterns: [
+whitelist_patterns:
   - /^src\/App\/(.*)/
   - /^src\/AppBundle\/(.*)/
 ```

--- a/spec/GrumPHP/Collection/FilesCollectionSpec.php
+++ b/spec/GrumPHP/Collection/FilesCollectionSpec.php
@@ -74,6 +74,19 @@ class FilesCollectionSpec extends ObjectBehavior
         $files[0]->shouldBe($file1);
     }
 
+    function it_should_filter_by_paths(SplFileInfo $file1, SplFileInfo $file2)
+    {
+        $file1->getRelativePathname()->willReturn('path1/file.php');
+        $file2->getRelativePathname()->willReturn('path2/file.png');
+
+        $result = $this->paths(['path1', 'path2']);
+        $result->shouldBeAnInstanceOf('GrumPHP\Collection\FilesCollection');
+        $result->count()->shouldBe(2);
+        $files = $result->toArray();
+        $files[0]->shouldBe($file1);
+        $files[1]->shouldBe($file2);
+    }
+
     function it_should_filter_by_not_path(SplFileInfo $file1, SplFileInfo $file2)
     {
         $file1->getRelativePathname()->willReturn('path1/file.php');

--- a/spec/GrumPHP/Task/PhpcsSpec.php
+++ b/spec/GrumPHP/Task/PhpcsSpec.php
@@ -47,6 +47,7 @@ class PhpcsSpec extends ObjectBehavior
         $options->getDefinedOptions()->shouldContain('show_warnings');
         $options->getDefinedOptions()->shouldContain('tab_width');
         $options->getDefinedOptions()->shouldContain('encoding');
+        $options->getDefinedOptions()->shouldContain('whitelist_patterns');
         $options->getDefinedOptions()->shouldContain('ignore_patterns');
         $options->getDefinedOptions()->shouldContain('sniffs');
         $options->getDefinedOptions()->shouldContain('triggered_by');

--- a/src/GrumPHP/Collection/FilesCollection.php
+++ b/src/GrumPHP/Collection/FilesCollection.php
@@ -73,6 +73,22 @@ class FilesCollection extends ArrayCollection
     }
 
     /**
+     * Filter by paths
+     *
+     * $collection->paths(array('/^spec\/','/^src\/'))
+     *
+     * @param array $patterns
+     *
+     * @return FilesCollection
+     */
+    public function paths(array $patterns)
+    {
+        $filter = new Iterator\PathFilterIterator($this->getIterator(), $patterns, array());
+
+        return new FilesCollection(iterator_to_array($filter));
+    }
+
+    /**
      * Adds rules that filenames must not match.
      *
      * You can use patterns (delimited with / sign) or simple strings.

--- a/src/GrumPHP/Collection/FilesCollection.php
+++ b/src/GrumPHP/Collection/FilesCollection.php
@@ -67,15 +67,13 @@ class FilesCollection extends ArrayCollection
      */
     public function path($pattern)
     {
-        $filter = new Iterator\PathFilterIterator($this->getIterator(), [$pattern], []);
-
-        return new FilesCollection(iterator_to_array($filter));
+        return $this->paths([$pattern]);
     }
 
     /**
      * Filter by paths
      *
-     * $collection->paths(array('/^spec\/','/^src\/'))
+     * $collection->paths(['/^spec\/','/^src\/'])
      *
      * @param array $patterns
      *
@@ -83,7 +81,7 @@ class FilesCollection extends ArrayCollection
      */
     public function paths(array $patterns)
     {
-        $filter = new Iterator\PathFilterIterator($this->getIterator(), $patterns, array());
+        $filter = new Iterator\PathFilterIterator($this->getIterator(), $patterns, []);
 
         return new FilesCollection(iterator_to_array($filter));
     }

--- a/src/GrumPHP/Task/Phpcs.php
+++ b/src/GrumPHP/Task/Phpcs.php
@@ -68,12 +68,12 @@ class Phpcs extends AbstractExternalTask
         /** @var array $extensions */
         $extensions = $config['triggered_by'];
 
-        if (0 === count($whitelistPatterns)) {
-            $files = $context->getFiles()->extensions($extensions);
-        } else {
-            array_walk($whitelistPatterns, array($this, 'escapePatternDirectorySeparator'), $extensions);
-            $files = $context->getFiles()->paths($whitelistPatterns);
+        /** @var \GrumPHP\Collection\FilesCollection $files */
+        $files = $context->getFiles();
+        if (0 !== count($whitelistPatterns)) {
+            $files = $files->paths($whitelistPatterns);
         }
+        $files = $files->extensions($extensions);
 
         if (0 === count($files)) {
             return TaskResult::createSkipped($this, $context);
@@ -95,17 +95,5 @@ class Phpcs extends AbstractExternalTask
         }
 
         return TaskResult::createPassed($this, $context);
-    }
-
-    /**
-     * @param string $pattern
-     * @param int $index
-     * @param array $extensions
-     */
-    protected function escapePatternDirectorySeparator(&$pattern, $index, $extensions)
-    {
-        $pattern = str_replace('/', '\\/', $pattern);
-        $pattern = '/'.$pattern.'(%s)$/i';
-        $pattern = sprintf($pattern, implode('|', $extensions));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master for features and deprecations |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes/no |
| Documented? | yes |
| Fixed tickets | #158 |

This PR add a new `whitelist_patterns`option to `Phpcs` task. It will be used to filter files to be validated.

Example for a Symfony, validate PHP files only in `src/` directory

``` yml
phpcs:
    standard: "./vendor/leaphub/phpcs-symfony2-standard/leaphub/phpcs/Symfony2/"
    show_warnings: true
    whitelist_patterns: ["^src/(.*)"]
    triggered_by: [php]
```
