### PR TITLE
added triggered_by option for xml linter

### DIFF
--- a/doc/tasks/xmllint.md
+++ b/doc/tasks/xmllint.md
@@ -13,6 +13,7 @@ parameters:
             x_include: false
             dtd_validation: false
             scheme_validation: false
+            triggered_by: [xml]
 ```
 
 **ignore_patterns**
@@ -53,3 +54,9 @@ Both internal, external as online resources are fetched and used for validation.
 
 It is possible to validate XML against the specified XSD schemes. 
 Both internal, external as online resources are fetched and used for validation.
+
+**triggered_by**
+
+*Default: [xml]*
+
+This is a list of extensions to be sniffed. Extend it for including xsd, wsdl, and others.

--- a/spec/GrumPHP/Task/XmlLintSpec.php
+++ b/spec/GrumPHP/Task/XmlLintSpec.php
@@ -45,6 +45,7 @@ class XmlLintSpec extends AbstractLinterTaskSpec
         $options->getDefinedOptions()->shouldContain('x_include');
         $options->getDefinedOptions()->shouldContain('dtd_validation');
         $options->getDefinedOptions()->shouldContain('scheme_validation');
+        $options->getDefinedOptions()->shouldContain('triggered_by');
     }
 
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)

--- a/src/GrumPHP/Task/XmlLint.php
+++ b/src/GrumPHP/Task/XmlLint.php
@@ -41,12 +41,14 @@ class XmlLint extends AbstractLinterTask
             'x_include' => false,
             'dtd_validation' => false,
             'scheme_validation' => false,
+            'triggered_by' => array('xml'),
         ));
 
         $resolver->addAllowedTypes('load_from_net', array('bool'));
         $resolver->addAllowedTypes('x_include', array('bool'));
         $resolver->addAllowedTypes('dtd_validation', array('bool'));
         $resolver->addAllowedTypes('scheme_validation', array('bool'));
+        $resolver->addAllowedTypes('triggered_by', array('array'));
 
         return $resolver;
     }
@@ -64,12 +66,12 @@ class XmlLint extends AbstractLinterTask
      */
     public function run(ContextInterface $context)
     {
-        $files = $context->getFiles()->name('*.xml');
+        $config = $this->getConfiguration();
+        $files = $context->getFiles()->extensions($config['triggered_by']);
         if (0 === count($files)) {
             return TaskResult::createSkipped($this, $context);
         }
 
-        $config = $this->getConfiguration();
         $this->linter->setLoadFromNet($config['load_from_net']);
         $this->linter->setXInclude($config['x_include']);
         $this->linter->setDtdValidation($config['dtd_validation']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
This PR adds the option to specify the file extensions for the xml linter. Using this, it's possible to include *.xsd, *.wsdl and other extensions