### PR TITLE
[FEATURE] add functionality to phpunit task --group

### DIFF
--- a/doc/tasks/phpunit.md
+++ b/doc/tasks/phpunit.md
@@ -22,7 +22,7 @@ This means that `phpunit.xml` or `phpunit.xml.dist` are automatically loaded if 
 
 **group**
 
-*Default: null*
+*Default: array()*
 
 If you wish to only run tests from a certain Group.
 `group: [fast,quick,small]`

--- a/doc/tasks/phpunit.md
+++ b/doc/tasks/phpunit.md
@@ -9,6 +9,7 @@ parameters:
     tasks:
         phpunit:
             config_file: ~
+            group: ~
 ```
 
 **config_file**
@@ -18,3 +19,10 @@ parameters:
 If your phpunit.xml file is located at an exotic location, you can specify your custom config file location with this option.
 This option is set to `null` by default.
 This means that `phpunit.xml` or `phpunit.xml.dist` are automatically loaded if one of them exist in the current directory.
+
+**group**
+
+*Default: null*
+
+If you wish to only run tests from a certain Group.
+`group: [fast,quick,small]`

--- a/spec/GrumPHP/Task/PhpunitSpec.php
+++ b/spec/GrumPHP/Task/PhpunitSpec.php
@@ -43,6 +43,7 @@ class PhpunitSpec extends ObjectBehavior
         $options = $this->getConfigurableOptions();
         $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
         $options->getDefinedOptions()->shouldContain('config_file');
+        $options->getDefinedOptions()->shouldContain('group');
     }
 
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)

--- a/src/GrumPHP/Task/Phpunit.php
+++ b/src/GrumPHP/Task/Phpunit.php
@@ -29,9 +29,11 @@ class Phpunit extends AbstractExternalTask
         $resolver = new OptionsResolver();
         $resolver->setDefaults(array(
             'config_file' => null,
+            'group' => null,
         ));
 
         $resolver->addAllowedTypes('config_file', array('null', 'string'));
+        $resolver->addAllowedTypes('group', array('null', 'array'));
 
         return $resolver;
     }
@@ -58,6 +60,9 @@ class Phpunit extends AbstractExternalTask
 
         $arguments = $this->processBuilder->createArgumentsForCommand('phpunit');
         $arguments->addOptionalArgument('--configuration=%s', $config['config_file']);
+        if(count($config['group']) > 0 ) {
+            $arguments->addOptionalArgument('--group=%s', implode(',', $config['group']));
+        }
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();

--- a/src/GrumPHP/Task/Phpunit.php
+++ b/src/GrumPHP/Task/Phpunit.php
@@ -60,7 +60,7 @@ class Phpunit extends AbstractExternalTask
 
         $arguments = $this->processBuilder->createArgumentsForCommand('phpunit');
         $arguments->addOptionalArgument('--configuration=%s', $config['config_file']);
-        if(count($config['group']) > 0 ) {
+        if (count($config['group']) > 0) {
             $arguments->addOptionalArgument('--group=%s', implode(',', $config['group']));
         }
 

--- a/src/GrumPHP/Task/Phpunit.php
+++ b/src/GrumPHP/Task/Phpunit.php
@@ -29,11 +29,11 @@ class Phpunit extends AbstractExternalTask
         $resolver = new OptionsResolver();
         $resolver->setDefaults(array(
             'config_file' => null,
-            'group' => null,
+            'group' => array(),
         ));
 
         $resolver->addAllowedTypes('config_file', array('null', 'string'));
-        $resolver->addAllowedTypes('group', array('null', 'array'));
+        $resolver->addAllowedTypes('group', array('array'));
 
         return $resolver;
     }
@@ -60,9 +60,7 @@ class Phpunit extends AbstractExternalTask
 
         $arguments = $this->processBuilder->createArgumentsForCommand('phpunit');
         $arguments->addOptionalArgument('--configuration=%s', $config['config_file']);
-        if (count($config['group']) > 0) {
-            $arguments->addOptionalArgument('--group=%s', implode(',', $config['group']));
-        }
+        $arguments->addOptionalCommaSeparatedArgument('--group=%s', $config['group']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | /
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #166 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

**About:**
Could we get an option for the phpunit task that could specify the groups the would like to run?
it would be very helpful.

**something like this:**
```yaml
# grumphp.yml
    phpunit:
      config_file: tests/phpunit.xml
      groups: [small, fast]
      metadata:
        priority: 200
```
