### PR TITLE
Escape arguments we're stripping out

### DIFF
--- a/spec/GrumPHP/Formatter/PhpCsFixerFormatterSpec.php
+++ b/spec/GrumPHP/Formatter/PhpCsFixerFormatterSpec.php
@@ -6,6 +6,7 @@ use GrumPHP\Formatter\PhpCsFixerFormatter;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessUtils;
 
 /**
  * @mixin PhpCsFixerFormatter
@@ -16,7 +17,7 @@ class PhpCsFixerFormatterSpec extends ObjectBehavior
     {
         $this->shouldHaveType('GrumPHP\Formatter\PhpCsFixerFormatter');
     }
-    
+
     function it_is_a_process_formatter()
     {
         $this->shouldHaveType('GrumPHP\Formatter\ProcessFormatterInterface');
@@ -73,7 +74,12 @@ class PhpCsFixerFormatterSpec extends ObjectBehavior
 
     function it_formats_suggestions(Process $process)
     {
-        $process->getCommandLine()->willReturn('phpcsfixer \'--dry-run\' \'--format=json\' .');
+        $dryRun = ProcessUtils::escapeArgument('--dry-run');
+        $formatJson = ProcessUtils::escapeArgument('--format=json');
+
+        $command = sprintf('phpcsfixer %s %s .', $dryRun, $formatJson);
+
+        $process->getCommandLine()->willReturn($command);
         $this->formatSuggestion($process)->shouldReturn('phpcsfixer .');
     }
 

--- a/src/GrumPHP/Formatter/PhpCsFixerFormatter.php
+++ b/src/GrumPHP/Formatter/PhpCsFixerFormatter.php
@@ -3,6 +3,7 @@
 namespace GrumPHP\Formatter;
 
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessUtils;
 
 /**
  * Class PhpCsFixerFormatter
@@ -50,7 +51,12 @@ class PhpCsFixerFormatter implements ProcessFormatterInterface
      */
     public function formatSuggestion(Process $process)
     {
-        return str_replace(array("'--dry-run' ", "'--format=json' "), '', $process->getCommandLine());
+        $pattern = '%s ';
+
+        $dryrun = sprintf($pattern, ProcessUtils::escapeArgument('--dry-run'));
+        $formatJson = sprintf($pattern, ProcessUtils::escapeArgument('--format=json'));
+
+        return str_replace(array($dryrun, $formatJson), '', $process->getCommandLine());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | 

On windows, the arguments are escaped with a `"` rather than a `'`.  This fix uses the argument escaper to escape the arguments we're stripping out correctly, so that it detects and strips them out correctly.


