### PR TITLE
Added new feature: GIT Conflict task

### DIFF
--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -14,6 +14,7 @@ parameters:
         gherkin: ~
         git_blacklist: ~
         git_commit_message: ~
+        git_conflict: ~
         grunt: ~
         gulp: ~
         jsonlint: ~
@@ -43,6 +44,7 @@ Every task has it's own default configuration. It is possible to overwrite the p
 - [Gherkin](tasks/gherkin.md)
 - [Git blacklist](tasks/git_blacklist.md)
 - [Git commit message](tasks/git_commit_message.md)
+- [Git conflict](tasks/git_conflict.md)
 - [Grunt](tasks/grunt.md)
 - [Gulp](tasks/gulp.md)
 - [JsonLint](tasks/jsonlint.md)

--- a/doc/tasks/git_conflict.md
+++ b/doc/tasks/git_conflict.md
@@ -1,0 +1,11 @@
+# Git Conflict
+
+The Git Conflict task gives you the power to never commit a merge conflict again. It uses internal git commands to determine if there are any merge conflicts in your current repository.
+It lives under the `git_conflict` namespace and has following configurable parameters:
+
+```yaml
+# grumphp.yml
+parameters:
+    tasks:
+        git_conflict: ~
+```

--- a/spec/GrumPHP/Task/Git/ConflictSpec.php
+++ b/spec/GrumPHP/Task/Git/ConflictSpec.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace spec\GrumPHP\Task\Git;
+
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
+use GrumPHP\Process\ProcessBuilder;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Git\Conflict;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Process\Process;
+
+/**
+ * @mixin Conflict
+ */
+class ConflictSpec extends ObjectBehavior
+{
+
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
+    {
+        $grumPHP->getTaskConfiguration('git_conflict')->willReturn(array());
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Task\Git\Conflict');
+    }
+
+    function it_should_have_a_name()
+    {
+        $this->getName()->shouldBe('git_conflict');
+    }
+
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
+        $options->getDefinedOptions()->shouldBe(array());
+    }
+
+    function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_lists_nothing_when_there_are_no_files(ContextInterface $context)
+    {
+        $context->getFiles()->willReturn(new FilesCollection());
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
+        $result->getResultCode()->shouldBe(TaskResult::SKIPPED);
+    }
+
+    function it_lists_files_with_merge_conflicts(ProcessBuilder $processBuilder, ContextInterface $context, Process $process)
+    {
+        $arguments = new ProcessArgumentsCollection();
+        $processBuilder->createArgumentsForCommand('git')->willReturn($arguments);
+        $processBuilder->buildProcess($arguments)->willReturn($process);
+
+        $context->getFiles()->willReturn(new FilesCollection(array(
+            new SplFileInfo('file1.php', '.', 'file1.php'),
+        )));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
+        $result->isPassed()->shouldBe(true);
+    }
+}

--- a/src/GrumPHP/Task/Git/Conflict.php
+++ b/src/GrumPHP/Task/Git/Conflict.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace GrumPHP\Task\Git;
+
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\AbstractExternalTask;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Git Blacklist Task
+ *
+ * @package GrumPHP\Task\Git
+ */
+class Conflict extends AbstractExternalTask
+{
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'git_conflict';
+    }
+
+    /**
+     * @return OptionsResolver
+     */
+    public function getConfigurableOptions()
+    {
+        return new OptionsResolver();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canRunInContext(ContextInterface $context)
+    {
+        return ($context instanceof GitPreCommitContext);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(ContextInterface $context)
+    {
+        $files = $context->getFiles();
+
+        if (0 === count($files)) {
+            return TaskResult::createSkipped($this, $context);
+        }
+
+        $arguments = $this->processBuilder->createArgumentsForCommand('git');
+        $arguments->add('diff');
+        $arguments->add('--name-only');
+        $arguments->add('--diff-filter=U');
+        $arguments->addFiles($files);
+
+        $process = $this->processBuilder->buildProcess($arguments);
+        $process->run();
+
+        if ($process->isSuccessful()) {
+            return TaskResult::createFailed($this, $context, sprintf(
+                'You have merge conflicts in the following files, please resolve them before you can continue%s%s',
+                PHP_EOL,
+                $this->formatter->format($process)
+            ));
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}

--- a/src/GrumPHP/Task/Git/Conflict.php
+++ b/src/GrumPHP/Task/Git/Conflict.php
@@ -9,7 +9,7 @@ use GrumPHP\Task\Context\GitPreCommitContext;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * Git Blacklist Task
+ * Git Conflict Task
  *
  * @package GrumPHP\Task\Git
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes

A friend of mine @cafferata came up with this idea. Implement a new task which checks if your current working directory (repository) has any merge conflicts. It's a simple task and there's nothing special to it. I though it was a good idea, so I implemented it. Got the GIT command out of [StackOverflow](http://stackoverflow.com/questions/3065650/whats-the-simplest-way-to-git-a-list-of-conflicted-files)

What do you guys think of this idea? Maybe we can make this idea better?
