### PR TITLE
Fix PhpCsFixerV2 doc + using_cache option not correctly set

### DIFF
--- a/doc/tasks/php_cs_fixer2.md
+++ b/doc/tasks/php_cs_fixer2.md
@@ -7,7 +7,7 @@ It lives under the `phpcsfixer2` namespace and has following configurable parame
 # grumphp.yml
 parameters:
     tasks:
-        phpcsfixer:
+        phpcsfixer2:
             allow_risky: false
             cache_file: ~
             config: ~
@@ -20,7 +20,7 @@ parameters:
 
 **allow_risky**
 
-*Default: null*
+*Default: false*
 
 The allow_risky option allows you to set whether riskys fixer may run. 
 Risky fixer is a fixer, which could change code behaviour. 

--- a/src/GrumPHP/Task/PhpCsFixerV2.php
+++ b/src/GrumPHP/Task/PhpCsFixerV2.php
@@ -69,7 +69,7 @@ class PhpCsFixerV2 extends AbstractPhpCsFixerTask
         $arguments->addOptionalArgument('--cache-file=%s', $config['cache_file']);
         $arguments->addOptionalArgument('--config=%s', $config['config']);
         $arguments->addOptionalCommaSeparatedArgument('--rules=%s', $config['rules']);
-        $arguments->addOptionalArgument('--using-cache', $config['using_cache'] ? 'yes' : 'no');
+        $arguments->addOptionalArgument('--using-cache=%s', $config['using_cache'] ? 'yes' : 'no');
         $arguments->addOptionalArgument('--path-mode=%s', $config['path_mode']);
         $arguments->addOptionalArgument('--verbose', $config['verbose']);
         $arguments->add('fix');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | 

Without this fix cli can't be executed correctly
