### PR TITLE
Fix PhpMd task

### DIFF
--- a/spec/GrumPHP/Collection/ProcessArgumentsCollectionSpec.php
+++ b/spec/GrumPHP/Collection/ProcessArgumentsCollectionSpec.php
@@ -103,4 +103,15 @@ class ProcessArgumentsCollectionSpec extends ObjectBehavior
             'file2.txt',
         ));
     }
+
+    function it_should_be_able_to_add_comma_separated_files()
+    {
+        $files = new FilesCollection(array(
+            new SplFileInfo('file1.txt'),
+            new SplFileInfo('file2.txt')
+        ));
+        $this->addCommaSeparatedFiles($files);
+
+        $this->getValues()->shouldBe(array('file1.txt,file2.txt'));
+    }
 }

--- a/src/GrumPHP/Collection/ProcessArgumentsCollection.php
+++ b/src/GrumPHP/Collection/ProcessArgumentsCollection.php
@@ -126,4 +126,18 @@ class ProcessArgumentsCollection extends ArrayCollection
             $this->add($file->getPathname());
         }
     }
+
+    /**
+     * @param FilesCollection|\SplFileInfo[] $files
+     */
+    public function addCommaSeparatedFiles(FilesCollection $files)
+    {
+        $paths = array();
+
+        foreach ($files as $file) {
+            $paths[] = $file->getPathname();
+        }
+
+        $this->add(implode(',', $paths));
+    }
 }

--- a/src/GrumPHP/Task/PhpMd.php
+++ b/src/GrumPHP/Task/PhpMd.php
@@ -61,7 +61,7 @@ class PhpMd extends AbstractExternalTask
         $config = $this->getConfiguration();
 
         $arguments = $this->processBuilder->createArgumentsForCommand('phpmd');
-        $arguments->addFiles($files);
+        $arguments->addCommaSeparatedFiles($files);
         $arguments->add('text');
         $arguments->addOptionalCommaSeparatedArgument('%s', $config['ruleset']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

[PHPMD expects multiple source files to be comma separated](https://github.com/phpmd/phpmd#using-multiple-source-files-and-folders). Currently the files are separated with spaces which makes PHPMD think that the second file is the report format it should use which results in an error (since the name of the second file is not a valid report format).

```shell
Running task  9/11: PhpMd
Aborted ...

Can't find the custom report class: path/to/the/second/File.php
```