### PR TITLE
Add an option to always execute PHPUnit

### DIFF
--- a/doc/tasks/clover_coverage.md
+++ b/doc/tasks/clover_coverage.md
@@ -1,6 +1,10 @@
 # Clover Coverage
 
-The Phpunit task will run your unit tests.
+The Clover Coverage task will run your unit tests.
+
+Note that to make sure that there is always a clover file available, you might need to
+set `always_execute` to `true` in the `phpunit` task configuration.
+
 It lives under the `clover_coverage` namespace and has following configurable parameters:
 
 ```yaml

--- a/doc/tasks/phpunit.md
+++ b/doc/tasks/phpunit.md
@@ -10,7 +10,7 @@ parameters:
         phpunit:
             config_file: ~
             group: []
-            always_execute: ~
+            always_execute: false
 ```
 
 **config_file**

--- a/doc/tasks/phpunit.md
+++ b/doc/tasks/phpunit.md
@@ -10,6 +10,7 @@ parameters:
         phpunit:
             config_file: ~
             group: []
+            always_execute: ~
 ```
 
 **config_file**
@@ -26,3 +27,9 @@ This means that `phpunit.xml` or `phpunit.xml.dist` are automatically loaded if 
 
 If you wish to only run tests from a certain Group.
 `group: [fast,quick,small]`
+
+**always_execute**
+
+*Default: false*
+
+Always run the whole test suite, even if no PHP files were changed.

--- a/src/GrumPHP/Task/Phpunit.php
+++ b/src/GrumPHP/Task/Phpunit.php
@@ -30,10 +30,12 @@ class Phpunit extends AbstractExternalTask
         $resolver->setDefaults(array(
             'config_file' => null,
             'group' => array(),
+            'always_execute' => false,
         ));
 
         $resolver->addAllowedTypes('config_file', array('null', 'string'));
         $resolver->addAllowedTypes('group', array('array'));
+        $resolver->addAllowedTypes('always_execute', array('bool'));
 
         return $resolver;
     }
@@ -51,12 +53,12 @@ class Phpunit extends AbstractExternalTask
      */
     public function run(ContextInterface $context)
     {
+        $config = $this->getConfiguration();
+        
         $files = $context->getFiles()->name('*.php');
-        if (0 === count($files)) {
+        if (0 === count($files) && !$config['always_execute']) {
             return TaskResult::createSkipped($this, $context);
         }
-
-        $config = $this->getConfiguration();
 
         $arguments = $this->processBuilder->createArgumentsForCommand('phpunit');
         $arguments->addOptionalArgument('--configuration=%s', $config['config_file']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | none

This adds an option to always run PHPUnit tests, even if no PHP files were changed. Useful by itself, but also makes sure there's always something to retrieve coverage from.

Currently, for a freshly cloned/installed project, I won't get any coverage at all, it would just break the build.

