### PR TITLE
Fix triggered_by config for PhpCpd task

### DIFF
--- a/src/GrumPHP/Task/PhpCpd.php
+++ b/src/GrumPHP/Task/PhpCpd.php
@@ -69,10 +69,14 @@ class PhpCpd extends AbstractExternalTask
         }
 
         $arguments = $this->processBuilder->createArgumentsForCommand('phpcpd');
+        $extensions = array_map(function ($extension) {
+            return sprintf('*.%s', $extension);
+        }, $config['triggered_by']);
 
         $arguments->addArgumentArray('--exclude=%s', $config['exclude']);
         $arguments->addRequiredArgument('--min-lines=%u', $config['min_lines']);
         $arguments->addRequiredArgument('--min-tokens=%u', $config['min_tokens']);
+        $arguments->addOptionalCommaSeparatedArgument('--names=%s', $extensions);
         $arguments->addOptionalArgument('--fuzzy', $config['fuzzy']);
         $arguments->add($config['directory']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets |

Currently (thanks to me) the `triggered_by` option isn't really doing anything so let's (ab?)use phpcpd's own `--names` parameter :)