### PR TITLE
Fix phpcpd in case-sensitive environments

### DIFF
--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -122,7 +122,7 @@ services:
             - {name: grumphp.task, config: phing}
 
     task.phpcpd:
-        class: GrumPHP\Task\Phpcpd
+        class: GrumPHP\Task\PhpCpd
         arguments:
           - '@config'
           - '@process_builder'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | -
| Fixed tickets | -

Seems like I sneaked in a typo in the `phpcpd` configuration which makes GrumPHP crash and burn in case-sensitive environments. Sorry about that! Maybe it would be a good idea to cover the configurations with tests somehow so CI will catch similar errors in the future?