### PR TITLE
Add exclude option to phpmd

### DIFF
--- a/doc/tasks/phpmd.md
+++ b/doc/tasks/phpmd.md
@@ -8,7 +8,7 @@ It lives under the `phpmd` namespace and has following configurable parameters:
 parameters:
     tasks:
         phpmd:
-            exclude: ~
+            exclude: []
             ruleset: ['cleancode', 'codesize', 'naming']
             triggered_by: ['php']
 ```

--- a/doc/tasks/phpmd.md
+++ b/doc/tasks/phpmd.md
@@ -8,21 +8,28 @@ It lives under the `phpmd` namespace and has following configurable parameters:
 parameters:
     tasks:
         phpmd:
+            exclude: ~
             ruleset: ['cleancode', 'codesize', 'naming']
             triggered_by: ['php']
 ```
+
+**exclude**
+
+*Default: []*
+
+This is a list of patterns that will be ignored by phpmd. With this option you can skip directories like tests. Leave this option blank to run phpmd for every php file.
 
 **ruleset**
 
 *Default: [cleancode,codesize,naming]*
 
-With this parameter you will be able to configure the rule/rulesets you want to use. You can use the standard 
+With this parameter you will be able to configure the rule/rulesets you want to use. You can use the standard
 sets provided by PhpMd or you can configure your own xml configuration as described in the [PhpMd Documentation](https://phpmd.org/documentation/creating-a-ruleset.html)
 
-The full list of rules/rulesets can be found at [PhpMd Rules](https://phpmd.org/rules/index.html) 
+The full list of rules/rulesets can be found at [PhpMd Rules](https://phpmd.org/rules/index.html)
 
 **triggered_by**
 
 *Default: [php]*
 
-This is a list of extensions to be sniffed. 
+This is a list of extensions to be sniffed.

--- a/spec/GrumPHP/Task/PhpMdSpec.php
+++ b/spec/GrumPHP/Task/PhpMdSpec.php
@@ -42,6 +42,7 @@ class PhpMdSpec extends ObjectBehavior
     {
         $options = $this->getConfigurableOptions();
         $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
+        $options->getDefinedOptions()->shouldContain('exclude');
         $options->getDefinedOptions()->shouldContain('ruleset');
         $options->getDefinedOptions()->shouldContain('triggered_by');
     }

--- a/src/GrumPHP/Task/PhpMd.php
+++ b/src/GrumPHP/Task/PhpMd.php
@@ -66,8 +66,7 @@ class PhpMd extends AbstractExternalTask
         $arguments->addCommaSeparatedFiles($files);
         $arguments->add('text');
         $arguments->addOptionalCommaSeparatedArgument('%s', $config['ruleset']);
-        $arguments->add('--exclude');
-        $arguments->addOptionalCommaSeparatedArgument('%s', $config['exclude']);
+        $arguments->addOptionalCommaSeparatedArgument('--exclude %s', $config['exclude']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();

--- a/src/GrumPHP/Task/PhpMd.php
+++ b/src/GrumPHP/Task/PhpMd.php
@@ -29,10 +29,12 @@ class PhpMd extends AbstractExternalTask
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults(array(
+            'exclude' => array(),
             'ruleset' => array('cleancode', 'codesize', 'naming'),
             'triggered_by' => array('php')
         ));
 
+        $resolver->addAllowedTypes('exclude', array('array'));
         $resolver->addAllowedTypes('ruleset', array('array'));
         $resolver->addAllowedTypes('triggered_by', array('array'));
 
@@ -64,6 +66,8 @@ class PhpMd extends AbstractExternalTask
         $arguments->addCommaSeparatedFiles($files);
         $arguments->add('text');
         $arguments->addOptionalCommaSeparatedArgument('%s', $config['ruleset']);
+        $arguments->add('--exclude');
+        $arguments->addOptionalCommaSeparatedArgument('%s', $config['exclude']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();

--- a/src/GrumPHP/Task/PhpMd.php
+++ b/src/GrumPHP/Task/PhpMd.php
@@ -66,7 +66,8 @@ class PhpMd extends AbstractExternalTask
         $arguments->addCommaSeparatedFiles($files);
         $arguments->add('text');
         $arguments->addOptionalCommaSeparatedArgument('%s', $config['ruleset']);
-        $arguments->addOptionalCommaSeparatedArgument('--exclude %s', $config['exclude']);
+        $arguments->addOptionalArgument('--exclude', !empty($config['exclude']));
+        $arguments->addOptionalCommaSeparatedArgument('%s', $config['exclude']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | -

Use phpmd's `--exclude` option to exclude directories from the task.