### PR TITLE
Add Doctrine ORM task

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ To make GrumPHP even more awesome, it will suggest installing some extra package
 - atoum/atoum : ~2.7
 - behat/behat : ~3.0
 - codegyre/robo : ~0.7
+- doctrine/orm: ~2.5
 - friendsofphp/php-cs-fixer : ~1|~2
 - malukenho/kawaii-gherkin : ~0.1
 - phing/phing : ~2.0
@@ -89,6 +90,7 @@ parameters:
         clover_coverage: ~
         codeception: ~
         composer: ~
+        doctrine_orm: ~
         gherkin: ~
         git_blacklist: ~
         git_commit_message: ~

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "atoum/atoum": "Lets GrumPHP run your unit tests.",
         "behat/behat": "Lets GrumPHP validate your project features.",
         "codegyre/robo": "Lets GrumPHP run your automated PHP tasks.",
+        "doctrine/orm": "Lets GrumPHP validate your Doctrine mapping files.",
         "friendsofphp/php-cs-fixer": "Lets GrumPHP automatically fix your codestyle.",
         "phing/phing": "Lets GrumPHP run your automated PHP tasks.",
         "malukenho/kawaii-gherkin": "Lets GrumPHP lint your Gherkin files.",

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -13,6 +13,7 @@ parameters:
         clover_coverage: ~
         codeception: ~
         composer: ~
+        doctrine_orm: ~
         gherkin: ~
         git_blacklist: ~
         git_commit_message: ~
@@ -47,6 +48,7 @@ Every task has it's own default configuration. It is possible to overwrite the p
 - [Clover Coverage](tasks/clover_coverage.md)
 - [Codeception](tasks/codeception.md)
 - [Composer](tasks/composer.md)
+- [Doctrine ORM](tasks/doctrine_orm.md)
 - [Gherkin](tasks/gherkin.md)
 - [Git blacklist](tasks/git_blacklist.md)
 - [Git commit message](tasks/git_commit_message.md)

--- a/doc/tasks/doctrine_orm.md
+++ b/doc/tasks/doctrine_orm.md
@@ -1,0 +1,32 @@
+# Doctrine ORM
+
+The Doctrine ORM task will validate that your Doctrine mapping files and check if the mapping is in sync with the database.
+It lives under the `doctrine` namespace and has following configurable parameters:
+
+```yaml
+# grumphp.yml
+parameters:
+    tasks:
+        doctrine_orm:
+            skip_mapping: false
+            skip_sync: false
+            triggered_by: ['php', 'xml', 'yml']
+```
+
+**skip_mapping**
+
+*Default: false*
+
+With this parameter you can skip the mapping validation check.
+
+**skip_sync**
+
+*Default: false*
+
+With this parameter you can skip checking if the mapping is in sync with the database.
+
+**triggered_by**
+
+*Default: [php, xml, yml]*
+
+This is a list of extensions that should trigger the Doctrine task.

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -52,6 +52,15 @@ services:
         tags:
             - {name: grumphp.task, config: composer}
 
+    task.doctrine_orm:
+        class: GrumPHP\Task\DoctrineOrm
+        arguments:
+          - '@config'
+          - '@process_builder'
+          - '@formatter.raw_process'
+        tags:
+          - {name: grumphp.task, config: doctrine_orm}
+
     task.git.gherkin:
         class: GrumPHP\Task\Gherkin
         arguments:

--- a/spec/GrumPHP/Task/DoctrineOrmSpec.php
+++ b/spec/GrumPHP/Task/DoctrineOrmSpec.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace spec\GrumPHP\Task;
+
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
+use GrumPHP\Process\ProcessBuilder;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\DoctrineOrm;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Process\Process;
+
+/**
+ * @mixin DoctrineOrm
+ */
+class DoctrineOrmSpec extends ObjectBehavior
+{
+
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
+    {
+        $grumPHP->getTaskConfiguration('doctrine_orm')->willReturn(array());
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Task\DoctrineOrm');
+    }
+
+    function it_should_have_a_name()
+    {
+        $this->getName()->shouldBe('doctrine_orm');
+    }
+
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
+        $options->getDefinedOptions()->shouldContain('skip_mapping');
+        $options->getDefinedOptions()->shouldContain('skip_sync');
+        $options->getDefinedOptions()->shouldContain('triggered_by');
+    }
+
+    function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_run_in_run_context(RunContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder, ContextInterface $context)
+    {
+        $processBuilder->buildProcess('doctrine')->shouldNotBeCalled();
+        $processBuilder->buildProcess()->shouldNotBeCalled();
+        $context->getFiles()->willReturn(new FilesCollection());
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
+        $result->getResultCode()->shouldBe(TaskResult::SKIPPED);
+    }
+
+    function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
+    {
+        $arguments = new ProcessArgumentsCollection();
+        $processBuilder->createArgumentsForCommand('doctrine')->willReturn($arguments);
+        $processBuilder->buildProcess($arguments)->willReturn($process);
+
+        $process->run()->shouldBeCalled();
+        $process->isSuccessful()->willReturn(true);
+
+        $context->getFiles()->willReturn(new FilesCollection(array(
+            new SplFileInfo('test.php', '.', 'test.php')
+        )));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_throws_exception_if_the_process_fails(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
+    {
+        $arguments = new ProcessArgumentsCollection();
+        $processBuilder->createArgumentsForCommand('doctrine')->willReturn($arguments);
+        $processBuilder->buildProcess($arguments)->willReturn($process);
+
+        $process->run()->shouldBeCalled();
+        $process->isSuccessful()->willReturn(false);
+
+        $context->getFiles()->willReturn(new FilesCollection(array(
+            new SplFileInfo('test.php', '.', 'test.php')
+        )));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
+        $result->isPassed()->shouldBe(false);
+    }
+}

--- a/src/GrumPHP/Task/DoctrineOrm.php
+++ b/src/GrumPHP/Task/DoctrineOrm.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace GrumPHP\Task;
+
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * DoctrineOrm task
+ */
+class DoctrineOrm extends AbstractExternalTask
+{
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'doctrine_orm';
+    }
+
+    /**
+     * @return OptionsResolver
+     */
+    public function getConfigurableOptions()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults(array(
+            'skip_mapping' => false,
+            'skip_sync' => false,
+            'triggered_by' => array('php', 'xml', 'yml'),
+        ));
+
+        $resolver->addAllowedTypes('skip_mapping', array('bool'));
+        $resolver->addAllowedTypes('skip_sync', array('bool'));
+        $resolver->addAllowedTypes('triggered_by', array('array'));
+
+        return $resolver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canRunInContext(ContextInterface $context)
+    {
+        return ($context instanceof GitPreCommitContext || $context instanceof RunContext);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(ContextInterface $context)
+    {
+        $config = $this->getConfiguration();
+        $files = $context->getFiles()->extensions($config['triggered_by']);
+
+        if (0 === count($files)) {
+            return TaskResult::createSkipped($this, $context);
+        }
+
+        $arguments = $this->processBuilder->createArgumentsForCommand('doctrine');
+        $arguments->add('orm:validate-schema');
+        $arguments->addOptionalArgument('--skip-mapping', $config['skip_mapping']);
+        $arguments->addOptionalArgument('--skip-sync', $config['skip_sync']);
+
+        $process = $this->processBuilder->buildProcess($arguments);
+
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}


### PR DESCRIPTION
This task makes it possible to validate mappings for Doctrine ORM. By default it'll only validate the mapping and the entity classes, but it's also possible to have it check that the database is in sync. Skipping it by default is personal preference, but I have no problem changing that :)

| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | -

- [x] Is the README.md file updated?
- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpspec tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?

