### PR TITLE
Run PhpCsFixer tasks asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ parameters:
     hooks_preset: local
     stop_on_failure: false
     ignore_unstaged_changes: false
+    process_async_limit: 10
+    process_async_wait: 1000
     process_timeout: 60
     ascii:
         failed: grumphp-grumpy.txt

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -9,6 +9,8 @@ parameters:
     hooks_preset: local
     stop_on_failure: false
     ignore_unstaged_changes: false
+    process_async_limit: 10
+    process_async_wait: 1000
     process_timeout: 60
     ascii:
         failed: resource/grumphp-grumpy.txt
@@ -49,15 +51,15 @@ GrumPHP comes with following presets:
 - `vagrant`: All checks will run in your vagrant box.
 
 
-*Note:* 
-When using the vagrant preset, you are required to set the vagrant SSH home folder to your working directory. 
+*Note:*
+When using the vagrant preset, you are required to set the vagrant SSH home folder to your working directory.
 This can be done by altering the `.bashrc` or `.zshrc` inside your vagrant box:
- 
+
 ```sh
 echo 'cd /remote/path/to/your/project' >> ~/.bashrc
 ```
 
-You can also add the `.bashrc` or `.zshrc` to your vagrant provision script. 
+You can also add the `.bashrc` or `.zshrc` to your vagrant provision script.
 This way the home directory will be set for all the people who are using your vagrant box.
 
 **stop_on_failure**
@@ -65,7 +67,7 @@ This way the home directory will be set for all the people who are using your va
 *Default: false*
 
 This parameter will tell GrumPHP to stop running tasks when one of the tasks results in an error.
-By default GrumPHP will continue running the configured tasks. 
+By default GrumPHP will continue running the configured tasks.
 
 **ignore_unstaged_changes**
 
@@ -75,6 +77,19 @@ By enabling this option, GrumPHP will stash your unstaged changes in git before 
 This way the tasks will run with the code that is actually committed without the unstaged changes.
 Note that during the commit, the unstaged changes will be stored in git stash.
 This may mess with your working copy and result in unexpected merge conflicts.
+
+**process_async_limit**
+
+*Default: 10*
+
+This parameter controls how many asynchronous processes GrumPHP will run simultaneously. Please note
+that not all external tasks uses asynchronous processes, nor would they necessarily benefit from using it.
+
+**process_async_wait**
+
+*Default: 1000*
+
+This parameter controls how long GrumPHP will wait (in microseconds) before checking the status of all asynchronous processes.
 
 **process_timeout**
 

--- a/resources/config/parameters.yml
+++ b/resources/config/parameters.yml
@@ -6,6 +6,8 @@ parameters:
   tasks: []
   stop_on_failure: false
   ignore_unstaged_changes: false
+  process_async_limit: 10
+  process_async_wait: 1000
   process_timeout: 60
   extensions: []
   ascii:

--- a/resources/config/services.yml
+++ b/resources/config/services.yml
@@ -1,4 +1,9 @@
 services:
+    async_process_runner:
+      class: GrumPHP\Process\AsyncProcessRunner
+      arguments:
+        - '@config'
+
     config:
         class: GrumPHP\Configuration\GrumPHP
         arguments:

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -162,6 +162,7 @@ services:
         arguments:
           - '@config'
           - '@process_builder'
+          - '@async_process_runner'
           - '@formatter.php_cs_fixer'
         tags:
           - {name: grumphp.task, config: phpcsfixer}
@@ -171,6 +172,7 @@ services:
         arguments:
           - '@config'
           - '@process_builder'
+          - '@async_process_runner'
           - '@formatter.php_cs_fixer'
         tags:
           - {name: grumphp.task, config: phpcsfixer2}

--- a/spec/GrumPHP/Configuration/GrumPHPSpec.php
+++ b/spec/GrumPHP/Configuration/GrumPHPSpec.php
@@ -62,6 +62,18 @@ class GrumPHPSpec extends ObjectBehavior
         $this->ignoreUnstagedChanges()->shouldReturn(true);
     }
 
+    function it_configures_the_process_async_limit(ContainerInterface $container)
+    {
+        $container->getParameter('process_async_limit')->willReturn(5);
+        $this->getProcessAsyncLimit()->shouldReturn(5);
+    }
+
+    function it_configures_the_process_async_wait_time(ContainerInterface $container)
+    {
+        $container->getParameter('process_async_wait')->willReturn(0);
+        $this->getProcessAsyncWaitTime()->shouldReturn(0);
+    }
+
     function it_configures_the_symfony_process_timeout(ContainerInterface $container)
     {
         $container->getParameter('process_timeout')->willReturn(null);

--- a/spec/GrumPHP/Process/AsyncProcessRunnerSpec.php
+++ b/spec/GrumPHP/Process/AsyncProcessRunnerSpec.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace spec\GrumPHP\Process;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Process\AsyncProcessRunner;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Prophet;
+
+/**
+ * @mixin AsyncProcessRunner
+ */
+class AsyncProcessRunnerSpec extends ObjectBehavior
+{
+    public function let(GrumPHP $grumPHP) {
+        $this->beConstructedWith($grumPHP);
+
+        $grumPHP->getProcessAsyncWaitTime()->willReturn(0);
+        $grumPHP->getProcessAsyncLimit()->willReturn(5);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('GrumPHP\Process\AsyncProcessRunner');
+    }
+
+    function it_should_be_able_to_run_processes()
+    {
+        $prophet = new Prophet();
+        $processes = array();
+
+        for ($i = 0; $i < 20; $i++) {
+            $process = $prophet->prophesize('Symfony\Component\Process\Process');
+
+            $process->started = false;
+            $process->terminated = false;
+
+            $process->start()->will(function () use ($process) {
+                $process->started = true;
+            })->shouldBeCalledTimes(1);
+
+            $process->isTerminated()->will(function () use ($process) {
+                if (!$process->terminated) {
+                    $process->terminated = true;
+                    return false;
+                }
+
+                return true;
+            })->shouldBeCalledTimes(2);
+
+            // The number of times isStarted() is called starts at 3
+            // and increases by 2 after each chunk of five processes.
+            $process->isStarted()->will(function () use ($process) {
+                return $process->started;
+            })->shouldBeCalledTimes(floor($i / 5) * 2 + 3);
+
+            $processes[] = $process->reveal();
+        }
+
+        $this->run($processes);
+        $prophet->checkPredictions();
+    }
+}

--- a/spec/GrumPHP/Task/PhpCsFixerSpec.php
+++ b/spec/GrumPHP/Task/PhpCsFixerSpec.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Formatter\PhpCsFixerFormatter;
+use GrumPHP\Process\AsyncProcessRunner;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
@@ -23,7 +24,7 @@ use Symfony\Component\Process\Process;
 class PhpCsFixerSpec extends ObjectBehavior
 {
 
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, PhpCsFixerFormatter $formatter)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, AsyncProcessRunner $processRunner, PhpCsFixerFormatter $formatter)
     {
         $grumPHP->getTaskConfiguration('phpcsfixer')->willReturn(array());
 
@@ -31,7 +32,7 @@ class PhpCsFixerSpec extends ObjectBehavior
         $formatter->formatSuggestion(Argument::any())->willReturn('');
         $formatter->formatErrorMessage(Argument::cetera())->willReturn('');
 
-        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->beConstructedWith($grumPHP, $processBuilder, $processRunner, $formatter);
     }
 
     function it_is_initializable()
@@ -106,6 +107,7 @@ class PhpCsFixerSpec extends ObjectBehavior
 
     function it_runs_the_suite_for_changed_files(
         ProcessBuilder $processBuilder,
+        AsyncProcessRunner $processRunner,
         Process $process,
         ContextInterface $context,
         PhpCsFixerFormatter $formatter
@@ -121,8 +123,8 @@ class PhpCsFixerSpec extends ObjectBehavior
             return $args->contains($file1) || $args->contains($file2);
         }))->willReturn($process);
 
-        $process->run()->shouldBeCalled();
-        $process->isSuccessful()->willReturn(true);
+        $processRunner->run(Argument::type('array'))->shouldBeCalled();
+    $process->isSuccessful()->willReturn(true);
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -131,6 +133,7 @@ class PhpCsFixerSpec extends ObjectBehavior
 
     function it_throws_exception_if_the_process_fails(
         ProcessBuilder $processBuilder,
+        AsyncProcessRunner $processRunner,
         Process $process,
         ContextInterface $context,
         PhpCsFixerFormatter $formatter
@@ -141,8 +144,8 @@ class PhpCsFixerSpec extends ObjectBehavior
         $processBuilder->createArgumentsForCommand('php-cs-fixer')->willReturn($arguments);
         $processBuilder->buildProcess(Argument::type('GrumPHP\Collection\ProcessArgumentsCollection'))->willReturn($process);
 
-        $process->run()->shouldBeCalled();
-        $process->isSuccessful()->willReturn(false);
+        $processRunner->run(Argument::type('array'))->shouldBeCalled();
+    $process->isSuccessful()->willReturn(false);
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('file1.php', '.', 'file1.php'),

--- a/spec/GrumPHP/Task/PhpCsFixerV2Spec.php
+++ b/spec/GrumPHP/Task/PhpCsFixerV2Spec.php
@@ -6,6 +6,7 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Formatter\PhpCsFixerFormatter;
+use GrumPHP\Process\AsyncProcessRunner;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
@@ -23,7 +24,7 @@ use Symfony\Component\Process\Process;
 class PhpCsFixerV2Spec extends ObjectBehavior
 {
 
-    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, PhpCsFixerFormatter $formatter)
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, AsyncProcessRunner $processRunner, PhpCsFixerFormatter $formatter)
     {
         $grumPHP->getTaskConfiguration('phpcsfixer2')->willReturn(array());
 
@@ -31,7 +32,7 @@ class PhpCsFixerV2Spec extends ObjectBehavior
         $formatter->formatSuggestion(Argument::any())->willReturn('');
         $formatter->formatErrorMessage(Argument::cetera())->willReturn('');
 
-        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->beConstructedWith($grumPHP, $processBuilder, $processRunner, $formatter);
     }
 
     function it_is_initializable()
@@ -108,6 +109,7 @@ class PhpCsFixerV2Spec extends ObjectBehavior
 
     function it_runs_the_suite_for_changed_files(
         ProcessBuilder $processBuilder,
+        AsyncProcessRunner $processRunner,
         Process $process,
         ContextInterface $context,
         PhpCsFixerFormatter $formatter
@@ -123,8 +125,8 @@ class PhpCsFixerV2Spec extends ObjectBehavior
             return $args->contains($file1) || $args->contains($file2);
         }))->willReturn($process);
 
-        $process->run()->shouldBeCalled();
-        $process->isSuccessful()->willReturn(true);
+        $processRunner->run(Argument::type('array'))->shouldBeCalled();
+    $process->isSuccessful()->willReturn(true);
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -133,6 +135,7 @@ class PhpCsFixerV2Spec extends ObjectBehavior
 
     function it_throws_exception_if_the_process_fails(
         ProcessBuilder $processBuilder,
+        AsyncProcessRunner $processRunner,
         Process $process,
         ContextInterface $context,
         PhpCsFixerFormatter $formatter
@@ -143,8 +146,8 @@ class PhpCsFixerV2Spec extends ObjectBehavior
         $processBuilder->createArgumentsForCommand('php-cs-fixer')->willReturn($arguments);
         $processBuilder->buildProcess(Argument::type('GrumPHP\Collection\ProcessArgumentsCollection'))->willReturn($process);
 
-        $process->run()->shouldBeCalled();
-        $process->isSuccessful()->willReturn(false);
+        $processRunner->run(Argument::type('array'))->shouldBeCalled();
+    $process->isSuccessful()->willReturn(false);
 
         $context->getFiles()->willReturn(new FilesCollection(array(
             new SplFileInfo('file1.php', '.', 'file1.php'),

--- a/src/GrumPHP/Configuration/GrumPHP.php
+++ b/src/GrumPHP/Configuration/GrumPHP.php
@@ -73,6 +73,22 @@ class GrumPHP
     }
 
     /**
+     * @return int
+     */
+    public function getProcessAsyncLimit()
+    {
+        return (int) $this->container->getParameter('process_async_limit');
+    }
+
+    /**
+     * @return int
+     */
+    public function getProcessAsyncWaitTime()
+    {
+        return (int) $this->container->getParameter('process_async_wait');
+    }
+
+    /**
      * @return float|null
      */
     public function getProcessTimeout()

--- a/src/GrumPHP/Process/AsyncProcessRunner.php
+++ b/src/GrumPHP/Process/AsyncProcessRunner.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace GrumPHP\Process;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Runner\TaskResult;
+use Symfony\Component\Process\Process;
+
+/**
+ * Class AsyncProcessRunner
+ *
+ * @package GrumPHP\Process
+ */
+class AsyncProcessRunner
+{
+    /**
+     * @var GrumPHP
+     */
+    private $config;
+
+    /**
+     * @var array
+     */
+    private $processes;
+
+    /**
+     * @var int
+     */
+    private $running;
+
+    /**
+     * AsyncProcessRunner constructor.
+     *
+     * @param GrumPHP $config
+     */
+    public function __construct(GrumPHP $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @param Process[] $processes
+     */
+    public function run(array $processes)
+    {
+        $this->processes = $processes;
+        $this->running = 0;
+        $sleepDuration = $this->config->getProcessAsyncWaitTime();
+
+        while ($this->watchProcesses()) {
+            usleep($sleepDuration);
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    private function watchProcesses()
+    {
+        foreach ($this->processes as $key => $process) {
+            $isTerminated = $this->handleProcess($process);
+
+            if ($isTerminated) {
+                unset($this->processes[$key]);
+            }
+        }
+
+        return count($this->processes) !== 0;
+    }
+
+    /**
+     * @return bool
+     */
+    private function handleProcess(Process $process)
+    {
+        if ($process->isStarted()) {
+            if ($process->isTerminated()) {
+                $this->running--;
+                return true;
+            }
+
+            return false;
+        }
+
+        // Only start a new process if we haven't reached the limit yet.
+        if ($this->running < $this->config->getProcessAsyncLimit()) {
+            $process->start();
+            $this->running++;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | -

PhpCsFixer takes quite some time when running it on changed files, and this is of course because GrumPHP needs to run one process per file. Symfony's Process component supports running processes asynchronously, so I thought why not give it a spin!

The following benchmark is performed on 23 files with PhpCsFixerV2 as the only task. The former is GrumPHP 0.9.6 and the latter is with this PR. From 10s to 2s is pretty sweet!

```shell
$ time ./vendor/bin/grumphp run
GrumPHP is sniffing your code!
Running task 1/1: PhpCsFixerV2

real    0m10.478s
user    0m1.734s
sys     0m8.297s
```

```shell
$ time ./vendor/bin/grumphp run
GrumPHP is sniffing your code!
Running task 1/1: PhpCsFixerV2

real    0m2.350s
user    0m1.563s
sys     0m7.078s
```

The `array_chunk()` and extra `foreach` loop is there because I don't like the idea of potentially kicking off hundreds of `php-cs-fixer` processes at the same time. Right now the size of each chuck is hardcoded to ten, maybe something worth making configurable?