### PR TITLE
Fixes typo in comment.

### DIFF
--- a/src/GrumPHP/Console/Command/Git/InitCommand.php
+++ b/src/GrumPHP/Console/Command/Git/InitCommand.php
@@ -82,7 +82,7 @@ class InitCommand extends Command
         $resourceHooksPath = $this->paths()->getPathWithTrailingSlash($resourceHooksPath);
         $customHooksPath = $this->paths()->getPathWithTrailingSlash($this->grumPHP->getHooksDir());
 
-        // Some git clients to not automatically create a git hooks folder.
+        // Some git clients do not automatically create a git hooks folder.
         if (!$this->filesystem->exists($gitHooksPath)) {
             $this->filesystem->mkdir($gitHooksPath);
             $output->writeln(sprintf(


### PR DESCRIPTION
Fixes a typo in a comment in `src/GrumPHP/Console/Command/Git/InitCommand.php`. 

> // Some git clients to not automatically create a git hooks folder.

should be:

> // Some git clients do not automatically create a git hooks folder.
