### PR TITLE
Removed support for php 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,9 @@ cache:
 
 matrix:
   include:
-    - php: 5.3
-    - php: 5.3
-      env: DEPENDENCIES='low'
     - php: 5.4
+    - php: 5.4
+      env: DEPENDENCIES='low'
     - php: 5.5
     - php: 5.6
     - php: 5.6

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Since GrumPHP is just a CLI tool, these commands can be triggered:
 
 ## Compatibility
 
-GrumPHP works with PHP 5.3 or above, and is also tested to work with HHVM.
+GrumPHP works with PHP 5.4 or above, and is also tested to work with HHVM.
 
 This package has been tested with following git clients:
 

--- a/bin/grumphp
+++ b/bin/grumphp
@@ -3,12 +3,12 @@
 
 define('GRUMPHP_PATH', realpath(__DIR__ . '/..'));
 
-$autoloadLocations = array(
+$autoloadLocations = [
     getcwd() . '/vendor/autoload.php',
     getcwd() . '/../../autoload.php',
     __DIR__ . '/../vendor/autoload.php',
     __DIR__ . '/../../../autoload.php',
-);
+];
 
 $loaded = false;
 foreach ($autoloadLocations as $autoload) {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "composer-plugin",
     "license": "MIT",
     "require": {
-        "php": ">=5.3.6",
+        "php": ">=5.4.0",
         "composer-plugin-api": "~1.0",
         "composer/composer": "^1.0",
         "doctrine/collections": "~1.2",

--- a/spec/GrumPHP/Collection/FilesCollectionSpec.php
+++ b/spec/GrumPHP/Collection/FilesCollectionSpec.php
@@ -20,7 +20,7 @@ class FilesCollectionSpec extends ObjectBehavior
     function let(SplFileInfo $file1, SplFileInfo $file2)
     {
         $this->tempFile = tempnam(sys_get_temp_dir(), 'phpspec');
-        $this->beConstructedWith(array($file1, $file2));
+        $this->beConstructedWith([$file1, $file2]);
     }
 
     function letgo()
@@ -137,7 +137,7 @@ class FilesCollectionSpec extends ObjectBehavior
         $file1->getPathname()->willReturn('path1/file.php');
         $file2->getPathname()->willReturn('path2/file.php');
 
-        $iterator = new \ArrayIterator(array($file1->getWrappedObject()));
+        $iterator = new \ArrayIterator([$file1->getWrappedObject()]);
         $result = $this->filterByFileList($iterator);
         $result->count()->shouldBe(1);
         $files = $result->toArray();
@@ -149,7 +149,7 @@ class FilesCollectionSpec extends ObjectBehavior
         $file1->getFilename()->willReturn('file.php');
         $file2->getFilename()->willReturn('file.jpg');
 
-        $result = $this->extensions(array('php', 'js'));
+        $result = $this->extensions(['php', 'js']);
         $result->count()->shouldBe(1);
         $files = $result->toArray();
         $files[0]->shouldBe($file1);
@@ -160,7 +160,7 @@ class FilesCollectionSpec extends ObjectBehavior
         $file1->getFilename()->willReturn('file.php');
         $file2->getFilename()->willReturn('file.jpg');
 
-        $result = $this->extensions(array());
+        $result = $this->extensions([]);
         $result->count()->shouldBe(0);
     }
 }

--- a/spec/GrumPHP/Collection/LintErrorsCollectionSpec.php
+++ b/spec/GrumPHP/Collection/LintErrorsCollectionSpec.php
@@ -14,9 +14,9 @@ class LintErrorsCollectionSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith(array(
+        $this->beConstructedWith([
             new LintError(LintError::TYPE_ERROR, 'error', 'file.txt', 1),
-        ));
+        ]);
     }
 
     function it_is_initializable()

--- a/spec/GrumPHP/Collection/ProcessArgumentsCollectionSpec.php
+++ b/spec/GrumPHP/Collection/ProcessArgumentsCollectionSpec.php
@@ -28,58 +28,58 @@ class ProcessArgumentsCollectionSpec extends ObjectBehavior
     function it_should_be_able_to_add_optional_argument()
     {
         $this->addOptionalArgument('--argument=%s', null);
-        $this->getValues()->shouldBe(array());
+        $this->getValues()->shouldBe([]);
 
         $this->addOptionalArgument('--argument=%s', 'value');
-        $this->getValues()->shouldBe(array('--argument=value'));
+        $this->getValues()->shouldBe(['--argument=value']);
     }
 
     function it_should_be_able_to_add_optional_argument_with_separated_value()
     {
         $this->addOptionalArgumentWithSeparatedValue('--argument', null);
-        $this->getValues()->shouldBe(array());
+        $this->getValues()->shouldBe([]);
 
         $this->addOptionalArgumentWithSeparatedValue('--argument', 'value');
-        $this->getValues()->shouldBe(array('--argument', 'value'));
+        $this->getValues()->shouldBe(['--argument', 'value']);
     }
 
     function it_should_be_able_to_add_optional_comma_separated_argument()
     {
-        $this->addOptionalCommaSeparatedArgument('--argument=%s', array());
-        $this->getValues()->shouldBe(array());
+        $this->addOptionalCommaSeparatedArgument('--argument=%s', []);
+        $this->getValues()->shouldBe([]);
 
-        $this->addOptionalCommaSeparatedArgument('--argument=%s', array(1, 2));
-        $this->getValues()->shouldBe(array('--argument=1,2'));
+        $this->addOptionalCommaSeparatedArgument('--argument=%s', [1, 2]);
+        $this->getValues()->shouldBe(['--argument=1,2']);
     }
 
     function it_should_be_able_to_add_an_argument_array()
     {
-        $this->addArgumentArray('--item=%s', array(1, 2));
-        $this->getValues()->shouldBe(array(
+        $this->addArgumentArray('--item=%s', [1, 2]);
+        $this->getValues()->shouldBe([
             '--item=1',
             '--item=2',
-        ));
+        ]);
     }
 
     function it_should_be_able_to_add_an_argument_array_with_separated_values()
     {
-        $this->addArgumentArrayWithSeparatedValue('--item', array(1, 2));
-        $this->getValues()->shouldBe(array(
+        $this->addArgumentArrayWithSeparatedValue('--item', [1, 2]);
+        $this->getValues()->shouldBe([
             '--item',
             1,
             '--item',
             2,
-        ));
+        ]);
     }
 
     function it_should_be_able_to_add_separated_argument_array()
     {
-        $this->addSeparatedArgumentArray('--item', array(1, 2));
-        $this->getValues()->shouldBe(array(
+        $this->addSeparatedArgumentArray('--item', [1, 2]);
+        $this->getValues()->shouldBe([
             '--item',
             1,
             2,
-        ));
+        ]);
     }
 
     function it_should_be_able_to_add_required_argument()
@@ -87,31 +87,31 @@ class ProcessArgumentsCollectionSpec extends ObjectBehavior
         $this->shouldThrow('GrumPHP\Exception\InvalidArgumentException')->duringAddRequiredArgument('--argument=%s', false);
 
         $this->addRequiredArgument('--argument=%s', 'value');
-        $this->getValues()->shouldBe(array('--argument=value'));
+        $this->getValues()->shouldBe(['--argument=value']);
     }
 
     function it_should_be_able_to_add_files()
     {
-        $files = new FilesCollection(array(
+        $files = new FilesCollection([
             new SplFileInfo('file1.txt'),
             new SplFileInfo('file2.txt')
-        ));
+        ]);
         $this->addFiles($files);
 
-        $this->getValues()->shouldBe(array(
+        $this->getValues()->shouldBe([
             'file1.txt',
             'file2.txt',
-        ));
+        ]);
     }
 
     function it_should_be_able_to_add_comma_separated_files()
     {
-        $files = new FilesCollection(array(
+        $files = new FilesCollection([
             new SplFileInfo('file1.txt'),
             new SplFileInfo('file2.txt')
-        ));
+        ]);
         $this->addCommaSeparatedFiles($files);
 
-        $this->getValues()->shouldBe(array('file1.txt,file2.txt'));
+        $this->getValues()->shouldBe(['file1.txt,file2.txt']);
     }
 }

--- a/spec/GrumPHP/Collection/TaskResultCollectionSpec.php
+++ b/spec/GrumPHP/Collection/TaskResultCollectionSpec.php
@@ -92,11 +92,11 @@ class TaskResultCollectionSpec extends ObjectBehavior
         $this->add(TaskResult::createPassed($aTask, $aContext));
         $this->add(TaskResult::createFailed($aTask, $aContext, 'another failed message'));
 
-        $this->getAllMessages()->shouldReturn(array(
+        $this->getAllMessages()->shouldReturn([
             'failed message',
             null,
             'another failed message',
-        ));
+        ]);
     }
 
     function it_has_failed_if_it_contains_failed_task_result(TaskInterface $task, ContextInterface $context)

--- a/spec/GrumPHP/Collection/TasksCollectionSpec.php
+++ b/spec/GrumPHP/Collection/TasksCollectionSpec.php
@@ -16,7 +16,7 @@ class TasksCollectionSpec extends ObjectBehavior
 {
     public function let(TaskInterface $task1, TaskInterface $task2)
     {
-        $this->beConstructedWith(array($task1, $task2));
+        $this->beConstructedWith([$task1, $task2]);
     }
 
     function it_is_initializable()
@@ -43,15 +43,15 @@ class TasksCollectionSpec extends ObjectBehavior
 
     function it_should_sort_on_priority(TaskInterface $task1, TaskInterface $task2, TaskInterface $task3, GrumPHP $grumPHP)
     {
-        $this->beConstructedWith(array($task1, $task2, $task3));
+        $this->beConstructedWith([$task1, $task2, $task3]);
 
         $task1->getName()->willReturn('task1');
         $task2->getName()->willReturn('task2');
         $task3->getName()->willReturn('task3');
 
-        $grumPHP->getTaskMetadata('task1')->willReturn(array('priority' => 100));
-        $grumPHP->getTaskMetadata('task2')->willReturn(array('priority' => 200));
-        $grumPHP->getTaskMetadata('task3')->willReturn(array('priority' => 100));
+        $grumPHP->getTaskMetadata('task1')->willReturn(['priority' => 100]);
+        $grumPHP->getTaskMetadata('task2')->willReturn(['priority' => 200]);
+        $grumPHP->getTaskMetadata('task3')->willReturn(['priority' => 100]);
 
         $result = $this->sortByPriority($grumPHP);
         $result->shouldBeAnInstanceOf('GrumPHP\Collection\TasksCollection');

--- a/spec/GrumPHP/Configuration/GrumPHPSpec.php
+++ b/spec/GrumPHP/Configuration/GrumPHPSpec.php
@@ -85,36 +85,36 @@ class GrumPHPSpec extends ObjectBehavior
 
     function it_should_return_empty_ascii_location_for_unknown_resources(ContainerInterface $container)
     {
-        $container->getParameter('ascii')->willReturn(array());
+        $container->getParameter('ascii')->willReturn([]);
         $this->getAsciiContentPath('success')->shouldReturn(null);
     }
 
     function it_should_return_the_ascii_location_for_known_resources(ContainerInterface $container)
     {
-        $container->getParameter('ascii')->willReturn(array('success' => 'success'));
+        $container->getParameter('ascii')->willReturn(['success' => 'success']);
         $this->getAsciiContentPath('success')->shouldReturn('success');
     }
 
     function it_should_know_all_registered_tasks(ContainerInterface $container)
     {
-        $container->getParameter('grumphp.tasks.registered')->willReturn(array('phpspec'));
+        $container->getParameter('grumphp.tasks.registered')->willReturn(['phpspec']);
 
-        $this->getRegisteredTasks()->shouldBe(array('phpspec'));
+        $this->getRegisteredTasks()->shouldBe(['phpspec']);
     }
 
     function it_should_know_task_configuration(ContainerInterface $container)
     {
-        $container->getParameter('grumphp.tasks.configuration')->willReturn(array('phpspec' => array()));
+        $container->getParameter('grumphp.tasks.configuration')->willReturn(['phpspec' => []]);
 
-        $this->getTaskConfiguration('phpspec')->shouldReturn(array());
+        $this->getTaskConfiguration('phpspec')->shouldReturn([]);
         $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringGetTaskConfiguration('phpunit');
     }
 
     function it_should_know_task_metadata(ContainerInterface $container)
     {
-        $container->getParameter('grumphp.tasks.metadata')->willReturn(array('phpspec' => array()));
+        $container->getParameter('grumphp.tasks.metadata')->willReturn(['phpspec' => []]);
 
-        $this->getTaskMetadata('phpspec')->shouldReturn(array());
+        $this->getTaskMetadata('phpspec')->shouldReturn([]);
         $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringGetTaskMetadata('phpunit');
     }
 
@@ -122,10 +122,10 @@ class GrumPHPSpec extends ObjectBehavior
     {
         $container->getParameter('grumphp.tasks.metadata')
             ->willReturn(
-                array(
-                    'phpspec' => array('blocking' => true),
-                    'phpunit' => array('blocking' => false),
-                )
+                [
+                    'phpspec' => ['blocking' => true],
+                    'phpunit' => ['blocking' => false],
+                ]
             );
         $this->isBlockingTask('phpunit')->shouldReturn(false);
         $this->isBlockingTask('phpspec')->shouldReturn(true);

--- a/spec/GrumPHP/Event/RunnerFailedEventSpec.php
+++ b/spec/GrumPHP/Event/RunnerFailedEventSpec.php
@@ -55,9 +55,9 @@ class RunnerFailedEventSpec extends ObjectBehavior
         $this->beConstructedWith($tasks, $context, $taskResults);
 
         $this->getMessages()->shouldReturn(
-            array(
+            [
                 'message 1',
-            )
+            ]
         );
     }
 

--- a/spec/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriberSpec.php
+++ b/spec/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriberSpec.php
@@ -27,7 +27,7 @@ class StashUnstagedChangesSubscriberSpec extends ObjectBehavior
         $grumPHP->ignoreUnstagedChanges()->willReturn(true);
         $repository->getWorkingCopy()->willReturn($workingCopy);
         $workingCopy->getDiffPending()->willReturn($unstaged);
-        $unstaged->getFiles()->willReturn(array('file1.php'));
+        $unstaged->getFiles()->willReturn(['file1.php']);
 
         $this->beConstructedWith($grumPHP, $repository, $io);
     }
@@ -71,7 +71,7 @@ class StashUnstagedChangesSubscriberSpec extends ObjectBehavior
     function it_should_not_run_when_there_are_no_unstaged_changes(Repository $repository, Diff $unstaged)
     {
         $event = new RunnerEvent(new TasksCollection(), new RunContext(new FilesCollection()), new TaskResultCollection());
-        $unstaged->getFiles()->willReturn(array());
+        $unstaged->getFiles()->willReturn([]);
 
         $this->saveStash($event);
         $this->popStash($event);

--- a/spec/GrumPHP/Formatter/PhpCsFixerFormatterSpec.php
+++ b/spec/GrumPHP/Formatter/PhpCsFixerFormatterSpec.php
@@ -38,33 +38,33 @@ class PhpCsFixerFormatterSpec extends ObjectBehavior
 
     function it_handles_invalid_file_formats(Process $process)
     {
-        $json = $this->parseJson(array('invalid'));
+        $json = $this->parseJson(['invalid']);
         $process->getOutput()->willReturn($json);
         $this->format($process)->shouldStartWith('Invalid file: ');
     }
 
     function it_formats_php_cs_fixer_json_output_for_single_file(Process $process)
     {
-        $json = $this->parseJson(array(
-            array('name' => 'name1', ),
-        ));
+        $json = $this->parseJson([
+            ['name' => 'name1',],
+        ]);
         $process->getOutput()->willReturn($json);
         $this->format($process)->shouldBe('1) name1');
     }
 
     function it_formats_php_cs_fixer_json_output_for_multiple_files(Process $process)
     {
-        $json = $this->parseJson(array(
-            array('name' => 'name1', ),
-            array('name' => 'name2', 'appliedFixers' => array('fixer1', 'fixer2')),
-        ));
+        $json = $this->parseJson([
+            ['name' => 'name1',],
+            ['name' => 'name2', 'appliedFixers' => ['fixer1', 'fixer2']],
+        ]);
         $process->getOutput()->willReturn($json);
         $this->format($process)->shouldBe('1) name1' . PHP_EOL . '2) name2 (fixer1,fixer2)');
     }
 
     function it_should_be_possible_to_reset_the_counter(Process $process)
     {
-        $json = $this->parseJson(array(array('name' => 'name1')));
+        $json = $this->parseJson([['name' => 'name1']]);
         $process->getOutput()->willReturn($json);
 
         $this->format($process)->shouldBe('1) name1');
@@ -85,7 +85,7 @@ class PhpCsFixerFormatterSpec extends ObjectBehavior
 
     function it_formats_the_error_message()
     {
-        $this->formatErrorMessage(array('message1'), array('message2'))->shouldBeString();
+        $this->formatErrorMessage(['message1'], ['message2'])->shouldBeString();
     }
 
     /**
@@ -95,6 +95,6 @@ class PhpCsFixerFormatterSpec extends ObjectBehavior
      */
     private function parseJson(array $files)
     {
-        return json_encode(array('files' => $files));
+        return json_encode(['files' => $files]);
     }
 }

--- a/spec/GrumPHP/Formatter/PhpcsFormatterSpec.php
+++ b/spec/GrumPHP/Formatter/PhpcsFormatterSpec.php
@@ -38,15 +38,15 @@ class PhpcsFormatterSpec extends ObjectBehavior
 
     function it_formats_phpcs_json_output_for_single_file(Process $process, ProcessBuilder $processBuilder)
     {
-        $json = $this->parseJson(array(
-            '/var/www/Classes/Command/CacheCommandController.php' => array('messages' => array(array('fixable' => true),),),
-        ));
+        $json = $this->parseJson([
+            '/var/www/Classes/Command/CacheCommandController.php' => ['messages' => [['fixable' => true],],],
+        ]);
 
         $arguments = new ProcessArgumentsCollection();
         $process->getOutput()->willReturn($this->getExampleData() . $json);
         $this->format($process)->shouldBe($this->getExampleData());
 
-        $this->getSuggestedFilesFromJson(json_decode($json, true))->shouldBe(array('/var/www/Classes/Command/CacheCommandController.php'));
+        $this->getSuggestedFilesFromJson(json_decode($json, true))->shouldBe(['/var/www/Classes/Command/CacheCommandController.php']);
 
         $processBuilder->buildProcess($arguments)->willReturn($process);
         $process->getCommandLine()->willReturn("'phpcbf' '--standard=PSR2' '--ignore=spec/*Spec.php,test/*.php' '/var/www/Classes/Command/CacheCommandController.php'");
@@ -60,16 +60,16 @@ class PhpcsFormatterSpec extends ObjectBehavior
 
     function it_formats_phpcs_json_output_for_multiple_files(Process $process, ProcessBuilder $processBuilder)
     {
-        $json = $this->parseJson(array(
-            '/var/www/Classes/Command/CacheCommandController.php' => array('messages' => array(array('fixable' => true),),),
-            '/var/www/Classes/Command/DebugCommandController.php' => array('messages' => array(array('fixable' => false),),),
-        ));
+        $json = $this->parseJson([
+            '/var/www/Classes/Command/CacheCommandController.php' => ['messages' => [['fixable' => true],],],
+            '/var/www/Classes/Command/DebugCommandController.php' => ['messages' => [['fixable' => false],],],
+        ]);
 
-        $arguments = new ProcessArgumentsCollection(array('phpcbf'));
+        $arguments = new ProcessArgumentsCollection(['phpcbf']);
         $process->getOutput()->willReturn($this->getExampleData() . $json);
         $this->format($process)->shouldBe($this->getExampleData());
 
-        $this->getSuggestedFilesFromJson(json_decode($json, true))->shouldBe(array('/var/www/Classes/Command/CacheCommandController.php'));
+        $this->getSuggestedFilesFromJson(json_decode($json, true))->shouldBe(['/var/www/Classes/Command/CacheCommandController.php']);
 
         $processBuilder->buildProcess($arguments)->willReturn($process);
         $process->getCommandLine()->willReturn("'phpcbf' '--standard=PSR2' '--ignore=spec/*Spec.php,test/*.php' '/var/www/Classes/Command/CacheCommandController.php'");
@@ -97,12 +97,12 @@ class PhpcsFormatterSpec extends ObjectBehavior
                 }
             }
         }
-        return PHP_EOL . json_encode(array(
-            'totals' => array(
+        return PHP_EOL . json_encode([
+            'totals' => [
                 'fixable' => $fixable
-            ),
+            ],
             'files' => $files
-        ));
+        ]);
     }
 
     private function getExampleData()

--- a/spec/GrumPHP/Locator/ChangedFilesSpec.php
+++ b/spec/GrumPHP/Locator/ChangedFilesSpec.php
@@ -44,7 +44,7 @@ class ChangedFilesSpec extends ObjectBehavior
 
         $repository->getWorkingCopy()->willReturn($workingCopy);
         $workingCopy->getDiffStaged()->willReturn($diff);
-        $diff->getFiles()->willReturn(array($changedFile, $movedFile, $deletedFile));
+        $diff->getFiles()->willReturn([$changedFile, $movedFile, $deletedFile]);
 
         $result = $this->locateFromGitRepository();
         $result->shouldBeAnInstanceOf('GrumPHP\Collection\FilesCollection');

--- a/spec/GrumPHP/Locator/ConfigurationFileSpec.php
+++ b/spec/GrumPHP/Locator/ConfigurationFileSpec.php
@@ -42,11 +42,11 @@ class ConfigurationFileSpec extends ObjectBehavior
 
     function it_should_use_the_config_file_configured_in_the_composer_file(Filesystem $filesystem, PackageInterface $package)
     {
-        $package->getExtra()->willReturn(array(
-            'grumphp' => array(
+        $package->getExtra()->willReturn([
+            'grumphp' => [
                 'config-default-path' => '/composer/exotic/path/grumphp.yml'
-            )
-        ));
+            ]
+        ]);
 
         $filesystem->exists($this->pathArgument('/composer/grumphp.yml'))->willReturn(true);
         $filesystem->exists('/composer/exotic/path/grumphp.yml')->willReturn(true);
@@ -57,11 +57,11 @@ class ConfigurationFileSpec extends ObjectBehavior
 
     function it_should_use_the_config_file_configured_in_the_composer_file_and_fall_back_on_dist(Filesystem $filesystem, PackageInterface $package)
     {
-        $package->getExtra()->willReturn(array(
-            'grumphp' => array(
+        $package->getExtra()->willReturn([
+            'grumphp' => [
                 'config-default-path' => '/composer/exotic/path/grumphp.yml'
-            )
-        ));
+            ]
+        ]);
 
         $filesystem->exists($this->pathArgument('/composer/grumphp.yml'))->willReturn(true);
         $filesystem->exists('/composer/exotic/path/grumphp.yml')->willReturn(false);
@@ -73,11 +73,11 @@ class ConfigurationFileSpec extends ObjectBehavior
 
     function it_should_always_return_absolute_paths(Filesystem $filesystem, PackageInterface $package)
     {
-        $package->getExtra()->willReturn(array(
-            'grumphp' => array(
+        $package->getExtra()->willReturn([
+            'grumphp' => [
                 'config-default-path' => 'exotic/path/grumphp.yml'
-            )
-        ));
+            ]
+        ]);
 
         $filesystem->exists($this->pathArgument('/composer/grumphp.yml'))->willReturn(true);
         $filesystem->exists($this->pathArgument('exotic/path/grumphp.yml'))->willReturn(true);
@@ -88,7 +88,7 @@ class ConfigurationFileSpec extends ObjectBehavior
 
     function it_should_locate_config_file_on_empty_composer_configuration(Filesystem $filesystem, PackageInterface $package)
     {
-        $package->getExtra()->willReturn(array());
+        $package->getExtra()->willReturn([]);
 
         $filesystem->exists($this->pathArgument('/composer/grumphp.yml'))->willReturn(true);
         $filesystem->isAbsolutePath($this->pathArgument('/composer/grumphp.yml'))->willReturn(true);
@@ -98,7 +98,7 @@ class ConfigurationFileSpec extends ObjectBehavior
 
     private function pathRegex($expected)
     {
-        return '#^' . str_replace(array('.', '/'), array('\.', '[\\\/]{1}'), $expected) . '$#i';
+        return '#^' . str_replace(['.', '/'], ['\.', '[\\\/]{1}'], $expected) . '$#i';
     }
 
     private function pathArgument($expected)

--- a/spec/GrumPHP/Locator/ExternalCommandSpec.php
+++ b/spec/GrumPHP/Locator/ExternalCommandSpec.php
@@ -24,13 +24,13 @@ class ExternalCommandSpec extends ObjectBehavior
 
     function it_throws_exception_when_external_command_is_not_found(ExecutableFinder $executableFinder)
     {
-        $executableFinder->find('test', null, array('bin'))->willReturn(false);
+        $executableFinder->find('test', null, ['bin'])->willReturn(false);
         $this->shouldThrow('GrumPHP\Exception\RuntimeException')->duringLocate('test');
     }
 
     function it_locates_external_commands(ExecutableFinder $executableFinder)
     {
-        $executableFinder->find('test', null, array('bin'))->willReturn('bin/test');
+        $executableFinder->find('test', null, ['bin'])->willReturn('bin/test');
         $this->locate('test')->shouldEqual('bin/test');
     }
 }

--- a/spec/GrumPHP/Locator/RegisteredFilesSpec.php
+++ b/spec/GrumPHP/Locator/RegisteredFilesSpec.php
@@ -24,7 +24,7 @@ class RegisteredFilesSpec extends ObjectBehavior
 
     function it_will_list_all_diffed_files(Repository $repository)
     {
-        $files = array('file1.txt', 'file2.txt');
+        $files = ['file1.txt', 'file2.txt'];
         $repository->run('ls-files')->willReturn(implode(PHP_EOL, $files));
 
         $result = $this->locate();

--- a/spec/GrumPHP/Process/AsyncProcessRunnerSpec.php
+++ b/spec/GrumPHP/Process/AsyncProcessRunnerSpec.php
@@ -27,7 +27,7 @@ class AsyncProcessRunnerSpec extends ObjectBehavior
     function it_should_be_able_to_run_processes()
     {
         $prophet = new Prophet();
-        $processes = array();
+        $processes = [];
 
         for ($i = 0; $i < 20; $i++) {
             $process = $prophet->prophesize('Symfony\Component\Process\Process');

--- a/spec/GrumPHP/Process/ProcessBuilderSpec.php
+++ b/spec/GrumPHP/Process/ProcessBuilderSpec.php
@@ -40,7 +40,7 @@ class ProcessBuilderSpec extends ObjectBehavior
 
     function it_should_build_process_based_on_process_arguments()
     {
-        $arguments = new ProcessArgumentsCollection(array('/usr/bin/grumphp'));
+        $arguments = new ProcessArgumentsCollection(['/usr/bin/grumphp']);
         $process = $this->buildProcess($arguments);
 
         $process->shouldHaveType('Symfony\Component\Process\Process');
@@ -55,7 +55,7 @@ class ProcessBuilderSpec extends ObjectBehavior
     {
         $config->getProcessTimeout()->willReturn(120);
 
-        $arguments = new ProcessArgumentsCollection(array('/usr/bin/grumphp'));
+        $arguments = new ProcessArgumentsCollection(['/usr/bin/grumphp']);
         $process = $this->buildProcess($arguments);
         $process->getTimeout()->shouldBe(120.0);
     }
@@ -69,14 +69,14 @@ class ProcessBuilderSpec extends ObjectBehavior
         $command = '/usr/bin/grumphp';
         $io->write(PHP_EOL . 'Command: ' . ProcessUtils::escapeArgument($command), true)->shouldBeCalled();
 
-        $arguments = new ProcessArgumentsCollection(array($command));
+        $arguments = new ProcessArgumentsCollection([$command]);
         $process = $this->buildProcess($arguments);
 
     }
 
     function getMatchers()
     {
-        return array(
+        return [
             'beQuoted' => function ($subject, $string) {
                 $regex = sprintf('{^([\'"])%s\1$}', preg_quote($string));
                 if (!preg_match($regex, $subject)) {
@@ -88,6 +88,6 @@ class ProcessBuilderSpec extends ObjectBehavior
 
                 return true;
             }
-        );
+        ];
     }
 }

--- a/spec/GrumPHP/Runner/TaskResultSpec.php
+++ b/spec/GrumPHP/Runner/TaskResultSpec.php
@@ -16,7 +16,7 @@ class TaskResultSpec extends ObjectBehavior
 
     function it_creates_passed_task(TaskInterface $task, ContextInterface $context)
     {
-        $this->beConstructedThrough('createPassed', array($task, $context));
+        $this->beConstructedThrough('createPassed', [$task, $context]);
 
         $this->getTask()->shouldBe($task);
         $this->getResultCode()->shouldBe(TaskResult::PASSED);
@@ -26,7 +26,7 @@ class TaskResultSpec extends ObjectBehavior
 
     function it_creates_failed_task(TaskInterface $task, ContextInterface $context)
     {
-        $this->beConstructedThrough('createFailed', array($task, $context, self::FAILED_TASK_MESSAGE));
+        $this->beConstructedThrough('createFailed', [$task, $context, self::FAILED_TASK_MESSAGE]);
 
         $this->getTask()->shouldBe($task);
         $this->getResultCode()->shouldBe(TaskResult::FAILED);
@@ -36,7 +36,7 @@ class TaskResultSpec extends ObjectBehavior
 
     function it_creates_skipped_task(TaskInterface $task, ContextInterface $context)
     {
-        $this->beConstructedThrough('createSkipped', array($task, $context));
+        $this->beConstructedThrough('createSkipped', [$task, $context]);
 
         $this->getTask()->shouldBe($task);
         $this->getResultCode()->shouldBe(TaskResult::SKIPPED);
@@ -45,19 +45,19 @@ class TaskResultSpec extends ObjectBehavior
 
     function it_should_be_a_blocking_task_if_it_is_a_failed_task(TaskInterface $task, ContextInterface $context)
     {
-        $this->beConstructedThrough('createFailed', array($task, $context, self::FAILED_TASK_MESSAGE));
+        $this->beConstructedThrough('createFailed', [$task, $context, self::FAILED_TASK_MESSAGE]);
         $this->isBlocking()->shouldBe(true);
     }
 
     function it_should_not_be_a_blocking_task_if_it_is_a_passed_task(TaskInterface $task, ContextInterface $context)
     {
-        $this->beConstructedThrough('createPassed', array($task, $context, self::FAILED_TASK_MESSAGE));
+        $this->beConstructedThrough('createPassed', [$task, $context, self::FAILED_TASK_MESSAGE]);
         $this->isBlocking()->shouldBe(false);
     }
 
     function it_should_not_be_a_blocking_task_if_it_is_a_non_blocking_failed_task(TaskInterface $task, ContextInterface $context)
     {
-        $this->beConstructedThrough('createNonBlockingFailed', array($task, $context, self::FAILED_TASK_MESSAGE));
+        $this->beConstructedThrough('createNonBlockingFailed', [$task, $context, self::FAILED_TASK_MESSAGE]);
         $this->isBlocking()->shouldBe(false);
     }
 }

--- a/spec/GrumPHP/Runner/TaskRunnerSpec.php
+++ b/spec/GrumPHP/Runner/TaskRunnerSpec.php
@@ -36,8 +36,8 @@ class TaskRunnerSpec extends ObjectBehavior
         $task2->run($context)->willReturn(TaskResult::createPassed($task2->getWrappedObject(), $context->getWrappedObject()));
 
         $grumPHP->stopOnFailure()->willReturn(false);
-        $grumPHP->getTaskMetadata('task1')->willReturn(array('priority' => 0));
-        $grumPHP->getTaskMetadata('task2')->willReturn(array('priority' => 0));
+        $grumPHP->getTaskMetadata('task1')->willReturn(['priority' => 0]);
+        $grumPHP->getTaskMetadata('task2')->willReturn(['priority' => 0]);
         $grumPHP->isBlockingTask('task1')->willReturn(true);
         $grumPHP->isBlockingTask('task2')->willReturn(true);
 
@@ -52,14 +52,14 @@ class TaskRunnerSpec extends ObjectBehavior
 
     function it_holds_tasks(TaskInterface $task1, TaskInterface $task2)
     {
-        $this->getTasks()->toArray()->shouldEqual(array($task1, $task2));
+        $this->getTasks()->toArray()->shouldEqual([$task1, $task2]);
     }
 
     function it_does_not_add_the_same_task_twice(TaskInterface $task1, TaskInterface $task2)
     {
         $this->addTask($task1);
 
-        $this->getTasks()->toArray()->shouldEqual(array($task1, $task2));
+        $this->getTasks()->toArray()->shouldEqual([$task1, $task2]);
     }
 
     function it_runs_all_tasks(TaskInterface $task1, TaskInterface $task2, ContextInterface $context)
@@ -177,7 +177,7 @@ class TaskRunnerSpec extends ObjectBehavior
 
     public function getMatchers()
     {
-        return array(
+        return [
             'containFailedTaskResult' => function ($taskResultCollection) {
                 return $taskResultCollection->exists(function ($key, $taskResult) {
                     return TaskResult::FAILED === $taskResult->getResultCode();
@@ -188,6 +188,6 @@ class TaskRunnerSpec extends ObjectBehavior
                     return TaskResult::NONBLOCKING_FAILED === $taskResult->getResultCode();
                 });
             },
-        );
+        ];
     }
 }

--- a/spec/GrumPHP/Task/AntSpec.php
+++ b/spec/GrumPHP/Task/AntSpec.php
@@ -24,7 +24,7 @@ class AntSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('ant')->willReturn(array());
+        $grumPHP->getTaskConfiguration('ant')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -77,9 +77,9 @@ class AntSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -98,9 +98,9 @@ class AntSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/AtoumSpec.php
+++ b/spec/GrumPHP/Task/AtoumSpec.php
@@ -24,7 +24,7 @@ class AtoumSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('atoum')->willReturn(array());
+        $grumPHP->getTaskConfiguration('atoum')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -81,9 +81,9 @@ class AtoumSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -99,9 +99,9 @@ class AtoumSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/BehatSpec.php
+++ b/spec/GrumPHP/Task/BehatSpec.php
@@ -24,7 +24,7 @@ class BehatSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('behat')->willReturn(array());
+        $grumPHP->getTaskConfiguration('behat')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -78,9 +78,9 @@ class BehatSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -99,9 +99,9 @@ class BehatSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/CloverCoverageSpec.php
+++ b/spec/GrumPHP/Task/CloverCoverageSpec.php
@@ -19,7 +19,7 @@ class CloverCoverageSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, Filesystem $filesystem)
     {
-        $grumPHP->getTaskConfiguration('clover_coverage')->willReturn(array());
+        $grumPHP->getTaskConfiguration('clover_coverage')->willReturn([]);
         $this->beConstructedWith($grumPHP, $filesystem);
     }
 
@@ -58,9 +58,9 @@ class CloverCoverageSpec extends ObjectBehavior
 
     function it_runs_the_suite_but_fails_when_file_doesnt_exists(GrumPHP $grumPHP, GitCommitMsgContext $context, Filesystem $filesystem)
     {
-        $grumPHP->getTaskConfiguration('clover_coverage')->willReturn(array(
+        $grumPHP->getTaskConfiguration('clover_coverage')->willReturn([
             'clover_file' => 'foo.bar',
-        ));
+        ]);
         $filesystem->exists('foo.bar')->willReturn(false);
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -70,10 +70,10 @@ class CloverCoverageSpec extends ObjectBehavior
     function it_runs_the_suite(GrumPHP $grumPHP, GitCommitMsgContext $context, Filesystem $filesystem)
     {
         $filename = dirname(dirname(dirname(__DIR__))) . '/test/fixtures/clover_coverage/60-percent-coverage.xml';
-        $grumPHP->getTaskConfiguration('clover_coverage')->willReturn(array(
+        $grumPHP->getTaskConfiguration('clover_coverage')->willReturn([
             'clover_file' => $filename,
             'level' => 50,
-        ));
+        ]);
         $filesystem->exists($filename)->willReturn(true);
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -83,10 +83,10 @@ class CloverCoverageSpec extends ObjectBehavior
     function it_runs_the_suite_but_not_reaching_coverage(GrumPHP $grumPHP, GitCommitMsgContext $context, Filesystem $filesystem)
     {
         $filename = dirname(dirname(dirname(__DIR__))) . '/test/fixtures/clover_coverage/60-percent-coverage.xml';
-        $grumPHP->getTaskConfiguration('clover_coverage')->willReturn(array(
+        $grumPHP->getTaskConfiguration('clover_coverage')->willReturn([
             'clover_file' => $filename,
             'level' => 100,
-        ));
+        ]);
         $filesystem->exists($filename)->willReturn(true);
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/CodeceptionSpec.php
+++ b/spec/GrumPHP/Task/CodeceptionSpec.php
@@ -24,7 +24,7 @@ class CodeceptionSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('codeception')->willReturn(array());
+        $grumPHP->getTaskConfiguration('codeception')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -78,9 +78,9 @@ class CodeceptionSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -99,9 +99,9 @@ class CodeceptionSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/ComposerScriptSpec.php
+++ b/spec/GrumPHP/Task/ComposerScriptSpec.php
@@ -24,7 +24,7 @@ class ComposerScriptSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('composer_script')->willReturn(array('script' => 'test'));
+        $grumPHP->getTaskConfiguration('composer_script')->willReturn(['script' => 'test']);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -77,9 +77,9 @@ class ComposerScriptSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -98,9 +98,9 @@ class ComposerScriptSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/ComposerSpec.php
+++ b/spec/GrumPHP/Task/ComposerSpec.php
@@ -24,7 +24,7 @@ class ComposerSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('composer')->willReturn(array());
+        $grumPHP->getTaskConfiguration('composer')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -81,9 +81,9 @@ class ComposerSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('composer.json', '.', 'composer.json')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -102,9 +102,9 @@ class ComposerSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('composer.json', '.', 'composer.json')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -119,10 +119,10 @@ class ComposerSpec extends ObjectBehavior
     )
     {
         $composerFile = tempnam(sys_get_temp_dir(), 'grumphp-composer');
-        $grumPHP->getTaskConfiguration('composer')->willReturn(array(
+        $grumPHP->getTaskConfiguration('composer')->willReturn([
             'file' => str_replace('\\', '/', $composerFile),
             'no_local_repository' => true
-        ));
+        ]);
 
         file_put_contents($composerFile, '{"repositories": [{"type": "path", "url": "/"}]}');
 
@@ -133,9 +133,9 @@ class ComposerSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo($composerFile, '.', $composerFile)
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -153,10 +153,10 @@ class ComposerSpec extends ObjectBehavior
     )
     {
         $composerFile = tempnam(sys_get_temp_dir(), 'grumphp-composer');
-        $grumPHP->getTaskConfiguration('composer')->willReturn(array(
+        $grumPHP->getTaskConfiguration('composer')->willReturn([
             'file' => str_replace('\\', '/', $composerFile),
             'no_local_repository' => true
-        ));
+        ]);
 
         file_put_contents($composerFile, '{"repositories": [{"type": "vcs", "url": "/"}]}');
 
@@ -167,9 +167,9 @@ class ComposerSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo($composerFile, '.', $composerFile)
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/DoctrineOrmSpec.php
+++ b/spec/GrumPHP/Task/DoctrineOrmSpec.php
@@ -24,7 +24,7 @@ class DoctrineOrmSpec extends ObjectBehavior
 
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('doctrine_orm')->willReturn(array());
+        $grumPHP->getTaskConfiguration('doctrine_orm')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -77,9 +77,9 @@ class DoctrineOrmSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -95,9 +95,9 @@ class DoctrineOrmSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/GherkinSpec.php
+++ b/spec/GrumPHP/Task/GherkinSpec.php
@@ -24,7 +24,7 @@ class GherkinSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('gherkin')->willReturn(array());
+        $grumPHP->getTaskConfiguration('gherkin')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -76,9 +76,9 @@ class GherkinSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.feature', '.', 'test.feature')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -97,9 +97,9 @@ class GherkinSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.feature', '.', 'test.feature')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/Git/BlacklistSpec.php
+++ b/spec/GrumPHP/Task/Git/BlacklistSpec.php
@@ -26,7 +26,7 @@ class BlacklistSpec extends ObjectBehavior
 
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter, ConsoleIO $consoleIO)
     {
-        $grumPHP->getTaskConfiguration('git_blacklist')->willReturn(array());
+        $grumPHP->getTaskConfiguration('git_blacklist')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter, $consoleIO);
     }
 
@@ -69,9 +69,9 @@ class BlacklistSpec extends ObjectBehavior
         $processBuilder->createArgumentsForCommand('git')->shouldNotBeCalled();
         $processBuilder->buildProcess()->shouldNotBeCalled();
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('file1.php', '.', 'file1.php'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -84,8 +84,8 @@ class BlacklistSpec extends ObjectBehavior
         Process $process,
         ContextInterface $context
     ) {
-        $grumPHP->getTaskConfiguration('git_blacklist')->willReturn(array(
-            'keywords'=>array('var_dump('))
+        $grumPHP->getTaskConfiguration('git_blacklist')->willReturn([
+            'keywords'=> ['var_dump(']]
         );
 
         $arguments = new ProcessArgumentsCollection();
@@ -97,9 +97,9 @@ class BlacklistSpec extends ObjectBehavior
         // Assume that blacklisted keywords was not found by `git grep` process
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('file1.php', '.', 'file1.php'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -112,8 +112,8 @@ class BlacklistSpec extends ObjectBehavior
         Process $process,
         ContextInterface $context
     ) {
-        $grumPHP->getTaskConfiguration('git_blacklist')->willReturn(array(
-            'keywords'=>array('var_dump('))
+        $grumPHP->getTaskConfiguration('git_blacklist')->willReturn([
+            'keywords'=> ['var_dump(']]
         );
 
         $arguments = new ProcessArgumentsCollection();
@@ -123,9 +123,9 @@ class BlacklistSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('file1.php', '.', 'file1.php'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/Git/CommitMessageSpec.php
+++ b/spec/GrumPHP/Task/Git/CommitMessageSpec.php
@@ -16,9 +16,9 @@ class CommitMessageSpec extends ObjectBehavior
     function let(GrumPHP $grumPHP)
     {
         $this->beConstructedWith($grumPHP);
-        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn(array(
-            'matchers' => array('test', '*es*', 'te[s][t]', '/^te(.*)/', '/(.*)st$/', '/t(e|a)st/', 'TEST')
-        ));
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'matchers' => ['test', '*es*', 'te[s][t]', '/^te(.*)/', '/(.*)st$/', '/t(e|a)st/', 'TEST']
+        ]);
     }
 
     function it_should_have_a_name()
@@ -70,10 +70,10 @@ class CommitMessageSpec extends ObjectBehavior
 
     function it_runs_with_additional_modifiers(GrumPHP $grumPHP, GitCommitMsgContext $context)
     {
-        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn(array(
-            'matchers' => array('/.*ümlaut/'),
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'matchers' => ['/.*ümlaut/'],
             'additional_modifiers' => 'u',
-        ));
+        ]);
 
         $context->getCommitMessage()->willReturn('message containing ümlaut');
 

--- a/spec/GrumPHP/Task/Git/ConflictSpec.php
+++ b/spec/GrumPHP/Task/Git/ConflictSpec.php
@@ -23,7 +23,7 @@ class ConflictSpec extends ObjectBehavior
 
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('git_conflict')->willReturn(array());
+        $grumPHP->getTaskConfiguration('git_conflict')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -41,7 +41,7 @@ class ConflictSpec extends ObjectBehavior
     {
         $options = $this->getConfigurableOptions();
         $options->shouldBeAnInstanceOf('Symfony\Component\OptionsResolver\OptionsResolver');
-        $options->getDefinedOptions()->shouldBe(array());
+        $options->getDefinedOptions()->shouldBe([]);
     }
 
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
@@ -64,9 +64,9 @@ class ConflictSpec extends ObjectBehavior
         $processBuilder->createArgumentsForCommand('git')->willReturn($arguments);
         $processBuilder->buildProcess($arguments)->willReturn($process);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('file1.php', '.', 'file1.php'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/GruntSpec.php
+++ b/spec/GrumPHP/Task/GruntSpec.php
@@ -24,7 +24,7 @@ class GruntSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('grunt')->willReturn(array());
+        $grumPHP->getTaskConfiguration('grunt')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -77,9 +77,9 @@ class GruntSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.js', '.', 'test.js')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -98,9 +98,9 @@ class GruntSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.js', '.', 'test.js')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/GulpSpec.php
+++ b/spec/GrumPHP/Task/GulpSpec.php
@@ -24,7 +24,7 @@ class GulpSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('gulp')->willReturn(array());
+        $grumPHP->getTaskConfiguration('gulp')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -77,9 +77,9 @@ class GulpSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.js', '.', 'test.js')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -98,9 +98,9 @@ class GulpSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.js', '.', 'test.js')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/JsonLintSpec.php
+++ b/spec/GrumPHP/Task/JsonLintSpec.php
@@ -23,7 +23,7 @@ class JsonLintSpec extends AbstractLinterTaskSpec
 {
     function let(GrumPHP $grumPHP, JsonLinter $linter)
     {
-        $grumPHP->getTaskConfiguration('jsonlint')->willReturn(array());
+        $grumPHP->getTaskConfiguration('jsonlint')->willReturn([]);
         $this->beConstructedWith($grumPHP, $linter);
     }
 
@@ -71,9 +71,9 @@ class JsonLintSpec extends AbstractLinterTaskSpec
         $linter->setDetectKeyConflicts(false)->shouldBeCalled();
         $linter->lint(Argument::type('SplFileInfo'))->willReturn(new LintErrorsCollection());
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('file.json', '.', 'file.json'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -84,13 +84,13 @@ class JsonLintSpec extends AbstractLinterTaskSpec
     {
         $linter->isInstalled()->willReturn(true);
         $linter->setDetectKeyConflicts(false)->shouldBeCalled();
-        $linter->lint(Argument::type('SplFileInfo'))->willReturn(new LintErrorsCollection(array(
+        $linter->lint(Argument::type('SplFileInfo'))->willReturn(new LintErrorsCollection([
             new JsonLintError(LintError::TYPE_ERROR, 0, 'error', 'file.json', 1, 1)
-        )));
+        ]));
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('file.json', '.', 'file.json'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/MakeSpec.php
+++ b/spec/GrumPHP/Task/MakeSpec.php
@@ -24,7 +24,7 @@ class MakeSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('make')->willReturn(array());
+        $grumPHP->getTaskConfiguration('make')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -77,9 +77,9 @@ class MakeSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
         $result->isPassed()->shouldBe(true);
@@ -97,9 +97,9 @@ class MakeSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/NpmScriptSpec.php
+++ b/spec/GrumPHP/Task/NpmScriptSpec.php
@@ -24,7 +24,7 @@ class NpmScriptSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('npm_script')->willReturn(array('script' => 'test', 'working_directory' => './'));
+        $grumPHP->getTaskConfiguration('npm_script')->willReturn(['script' => 'test', 'working_directory' => './']);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -78,9 +78,9 @@ class NpmScriptSpec extends ObjectBehavior
         $process->setWorkingDirectory(getcwd())->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.js', '.', 'test.js')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -100,9 +100,9 @@ class NpmScriptSpec extends ObjectBehavior
         $process->setWorkingDirectory(getcwd())->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.js', '.', 'test.js')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/PhingSpec.php
+++ b/spec/GrumPHP/Task/PhingSpec.php
@@ -24,7 +24,7 @@ class PhingSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('phing')->willReturn(array());
+        $grumPHP->getTaskConfiguration('phing')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -77,9 +77,9 @@ class PhingSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -98,9 +98,9 @@ class PhingSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/Php7ccSpec.php
+++ b/spec/GrumPHP/Task/Php7ccSpec.php
@@ -24,7 +24,7 @@ class Php7ccSpec extends ObjectBehavior
 
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('php7cc')->willReturn(array());
+        $grumPHP->getTaskConfiguration('php7cc')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -77,9 +77,9 @@ class Php7ccSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -95,9 +95,9 @@ class Php7ccSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/PhpCpdSpec.php
+++ b/spec/GrumPHP/Task/PhpCpdSpec.php
@@ -24,7 +24,7 @@ class PhpCpdSpec extends ObjectBehavior
 
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('phpcpd')->willReturn(array());
+        $grumPHP->getTaskConfiguration('phpcpd')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -80,9 +80,9 @@ class PhpCpdSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -98,9 +98,9 @@ class PhpCpdSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/PhpCsFixerSpec.php
+++ b/spec/GrumPHP/Task/PhpCsFixerSpec.php
@@ -26,7 +26,7 @@ class PhpCsFixerSpec extends ObjectBehavior
 
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, AsyncProcessRunner $processRunner, PhpCsFixerFormatter $formatter)
     {
-        $grumPHP->getTaskConfiguration('phpcsfixer')->willReturn(array());
+        $grumPHP->getTaskConfiguration('phpcsfixer')->willReturn([]);
 
         $formatter->format(Argument::any())->willReturn('');
         $formatter->formatSuggestion(Argument::any())->willReturn('');
@@ -84,13 +84,13 @@ class PhpCsFixerSpec extends ObjectBehavior
         RunContext $context,
         PhpCsFixerFormatter $formatter
     ) {
-        $grumPHP->getTaskConfiguration('phpcsfixer')->willReturn(array('config_file' => '.php_cs'));
+        $grumPHP->getTaskConfiguration('phpcsfixer')->willReturn(['config_file' => '.php_cs']);
         $formatter->resetCounter()->shouldBeCalled();
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             $file1 = new SplFileInfo('file1.php', '.', 'file1.php'),
             $file2 = new SplFileInfo('file2.php', '.', 'file2.php'),
-        )));
+        ]));
 
         $processBuilder->createArgumentsForCommand('php-cs-fixer')->willReturn(new ProcessArgumentsCollection());
         $processBuilder->buildProcess(Argument::that(function (ProcessArgumentsCollection $args) use ($file1, $file2) {
@@ -113,10 +113,10 @@ class PhpCsFixerSpec extends ObjectBehavior
         PhpCsFixerFormatter $formatter
     ) {
         $formatter->resetCounter()->shouldBeCalled();
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             $file1 = new SplFileInfo('file1.php', '.', 'file1.php'),
             $file2 = new SplFileInfo('file2.php', '.', 'file2.php'),
-        )));
+        ]));
 
         $processBuilder->createArgumentsForCommand('php-cs-fixer')->willReturn(new ProcessArgumentsCollection());
         $processBuilder->buildProcess(Argument::that(function (ProcessArgumentsCollection $args) use ($file1, $file2) {
@@ -147,9 +147,9 @@ class PhpCsFixerSpec extends ObjectBehavior
         $processRunner->run(Argument::type('array'))->shouldBeCalled();
     $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('file1.php', '.', 'file1.php'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/PhpCsFixerV2Spec.php
+++ b/spec/GrumPHP/Task/PhpCsFixerV2Spec.php
@@ -26,7 +26,7 @@ class PhpCsFixerV2Spec extends ObjectBehavior
 
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, AsyncProcessRunner $processRunner, PhpCsFixerFormatter $formatter)
     {
-        $grumPHP->getTaskConfiguration('phpcsfixer2')->willReturn(array());
+        $grumPHP->getTaskConfiguration('phpcsfixer2')->willReturn([]);
 
         $formatter->format(Argument::any())->willReturn('');
         $formatter->formatSuggestion(Argument::any())->willReturn('');
@@ -86,13 +86,13 @@ class PhpCsFixerV2Spec extends ObjectBehavior
         RunContext $context,
         PhpCsFixerFormatter $formatter
     ) {
-        $grumPHP->getTaskConfiguration('phpcsfixer2')->willReturn(array('config' => '.php_cs'));
+        $grumPHP->getTaskConfiguration('phpcsfixer2')->willReturn(['config' => '.php_cs']);
         $formatter->resetCounter()->shouldBeCalled();
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             $file1 = new SplFileInfo('file1.php', '.', 'file1.php'),
             $file2 = new SplFileInfo('file2.php', '.', 'file2.php'),
-        )));
+        ]));
 
         $processBuilder->createArgumentsForCommand('php-cs-fixer')->willReturn(new ProcessArgumentsCollection());
         $processBuilder->buildProcess(Argument::that(function (ProcessArgumentsCollection $args) use ($file1, $file2) {
@@ -115,10 +115,10 @@ class PhpCsFixerV2Spec extends ObjectBehavior
         PhpCsFixerFormatter $formatter
     ) {
         $formatter->resetCounter()->shouldBeCalled();
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             $file1 = new SplFileInfo('file1.php', '.', 'file1.php'),
             $file2 = new SplFileInfo('file2.php', '.', 'file2.php'),
-        )));
+        ]));
 
         $processBuilder->createArgumentsForCommand('php-cs-fixer')->willReturn(new ProcessArgumentsCollection());
         $processBuilder->buildProcess(Argument::that(function (ProcessArgumentsCollection $args) use ($file1, $file2) {
@@ -149,9 +149,9 @@ class PhpCsFixerV2Spec extends ObjectBehavior
         $processRunner->run(Argument::type('array'))->shouldBeCalled();
     $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('file1.php', '.', 'file1.php'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/PhpLintSpec.php
+++ b/spec/GrumPHP/Task/PhpLintSpec.php
@@ -19,7 +19,7 @@ class PhpLintSpec extends ObjectBehavior
 
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('phplint')->willReturn(array());
+        $grumPHP->getTaskConfiguration('phplint')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -61,9 +61,9 @@ class PhpLintSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -79,9 +79,9 @@ class PhpLintSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/PhpMdSpec.php
+++ b/spec/GrumPHP/Task/PhpMdSpec.php
@@ -24,7 +24,7 @@ class PhpMdSpec extends ObjectBehavior
 
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('phpmd')->willReturn(array());
+        $grumPHP->getTaskConfiguration('phpmd')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -77,9 +77,9 @@ class PhpMdSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -95,9 +95,9 @@ class PhpMdSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/PhpcsSpec.php
+++ b/spec/GrumPHP/Task/PhpcsSpec.php
@@ -25,7 +25,7 @@ class PhpcsSpec extends ObjectBehavior
 
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, PhpcsFormatter $formatter)
     {
-        $grumPHP->getTaskConfiguration('phpcs')->willReturn(array());
+        $grumPHP->getTaskConfiguration('phpcs')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -83,9 +83,9 @@ class PhpcsSpec extends ObjectBehavior
 
         $process->run()->shouldNotBeCalled();
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
           new SplFileInfo('file1.txt', '.', 'file1.txt'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -102,10 +102,10 @@ class PhpcsSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('file1.php', '.', 'file1.php'),
             new SplFileInfo('file2.php', '.', 'file2.php'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -125,9 +125,9 @@ class PhpcsSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('file1.php', '.', 'file1.php'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/PhpspecSpec.php
+++ b/spec/GrumPHP/Task/PhpspecSpec.php
@@ -25,7 +25,7 @@ class PhpspecSpec extends ObjectBehavior
 
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('phpspec')->willReturn(array());
+        $grumPHP->getTaskConfiguration('phpspec')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -77,9 +77,9 @@ class PhpspecSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -95,9 +95,9 @@ class PhpspecSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/PhpunitSpec.php
+++ b/spec/GrumPHP/Task/PhpunitSpec.php
@@ -24,7 +24,7 @@ class PhpunitSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('phpunit')->willReturn(array());
+        $grumPHP->getTaskConfiguration('phpunit')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -70,9 +70,9 @@ class PhpunitSpec extends ObjectBehavior
 
     function it_runs_if_there_are_no_files_but_always_execute_is_passed(GrumPHP $grumPHP, Process $process, ProcessBuilder $processBuilder, ContextInterface $context)
     {
-        $grumPHP->getTaskConfiguration('phpunit')->willReturn(array(
+        $grumPHP->getTaskConfiguration('phpunit')->willReturn([
             'always_execute' => true,
-        ));
+        ]);
 
         $arguments = new ProcessArgumentsCollection();
         $processBuilder->createArgumentsForCommand('phpunit')->willReturn($arguments);
@@ -97,9 +97,9 @@ class PhpunitSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -115,9 +115,9 @@ class PhpunitSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/RoboSpec.php
+++ b/spec/GrumPHP/Task/RoboSpec.php
@@ -24,7 +24,7 @@ class RoboSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('robo')->willReturn(array());
+        $grumPHP->getTaskConfiguration('robo')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -77,9 +77,9 @@ class RoboSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -98,9 +98,9 @@ class RoboSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/SecurityCheckerSpec.php
+++ b/spec/GrumPHP/Task/SecurityCheckerSpec.php
@@ -24,7 +24,7 @@ class SecurityCheckerSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('securitychecker')->willReturn(array());
+        $grumPHP->getTaskConfiguration('securitychecker')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -64,7 +64,7 @@ class SecurityCheckerSpec extends ObjectBehavior
         ProcessBuilder $processBuilder,
         ContextInterface $context
     ) {
-        $grumPHP->getTaskConfiguration('securitychecker')->willReturn(array('run_always' => false));
+        $grumPHP->getTaskConfiguration('securitychecker')->willReturn(['run_always' => false]);
 
         $processBuilder->createArgumentsForCommand('security-checker')->shouldNotBeCalled();
         $processBuilder->buildProcess()->shouldNotBeCalled();
@@ -81,7 +81,7 @@ class SecurityCheckerSpec extends ObjectBehavior
         Process $process,
         ContextInterface $context
     ) {
-        $grumPHP->getTaskConfiguration('securitychecker')->willReturn(array('run_always' => true));
+        $grumPHP->getTaskConfiguration('securitychecker')->willReturn(['run_always' => true]);
 
         $arguments = new ProcessArgumentsCollection();
         $processBuilder->createArgumentsForCommand('security-checker')->willReturn($arguments);
@@ -102,7 +102,7 @@ class SecurityCheckerSpec extends ObjectBehavior
         Process $process,
         ContextInterface $context
     ) {
-        $grumPHP->getTaskConfiguration('securitychecker')->willReturn(array('run_always' => false));
+        $grumPHP->getTaskConfiguration('securitychecker')->willReturn(['run_always' => false]);
 
         $arguments = new ProcessArgumentsCollection();
         $processBuilder->createArgumentsForCommand('security-checker')->willReturn($arguments);
@@ -111,9 +111,9 @@ class SecurityCheckerSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('composer.lock', '.', 'composer.lock')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -132,9 +132,9 @@ class SecurityCheckerSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('composer.lock', '.', 'composer.lock')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/ShellSpec.php
+++ b/spec/GrumPHP/Task/ShellSpec.php
@@ -24,9 +24,9 @@ class ShellSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
-        $grumPHP->getTaskConfiguration('shell')->willReturn(array(
-            'scripts' => array('script.sh')
-        ));
+        $grumPHP->getTaskConfiguration('shell')->willReturn([
+            'scripts' => ['script.sh']
+        ]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
     }
 
@@ -78,9 +78,9 @@ class ShellSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -99,9 +99,9 @@ class ShellSpec extends ObjectBehavior
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/XmlLintSpec.php
+++ b/spec/GrumPHP/Task/XmlLintSpec.php
@@ -23,7 +23,7 @@ class XmlLintSpec extends AbstractLinterTaskSpec
 {
     function let(GrumPHP $grumPHP, XmlLinter $linter)
     {
-        $grumPHP->getTaskConfiguration('xmllint')->willReturn(array());
+        $grumPHP->getTaskConfiguration('xmllint')->willReturn([]);
         $this->beConstructedWith($grumPHP, $linter);
     }
 
@@ -79,9 +79,9 @@ class XmlLintSpec extends AbstractLinterTaskSpec
         $linter->setSchemeValidation(false)->shouldBeCalled();
         $linter->lint(Argument::type('SplFileInfo'))->willReturn(new LintErrorsCollection());
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('file.xml', '.', 'file.xml'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -95,13 +95,13 @@ class XmlLintSpec extends AbstractLinterTaskSpec
         $linter->setXInclude(false)->shouldBeCalled();
         $linter->setDtdValidation(false)->shouldBeCalled();
         $linter->setSchemeValidation(false)->shouldBeCalled();
-        $linter->lint(Argument::type('SplFileInfo'))->willReturn(new LintErrorsCollection(array(
+        $linter->lint(Argument::type('SplFileInfo'))->willReturn(new LintErrorsCollection([
             new XmlLintError(LintError::TYPE_ERROR, 0, 'error', 'file.xml', 1, 1)
-        )));
+        ]));
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('file.xml', '.', 'file.xml'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/spec/GrumPHP/Task/YamlLintSpec.php
+++ b/spec/GrumPHP/Task/YamlLintSpec.php
@@ -23,7 +23,7 @@ class YamlLintSpec extends AbstractLinterTaskSpec
 {
     function let(GrumPHP $grumPHP, YamlLinter $linter)
     {
-        $grumPHP->getTaskConfiguration('yamllint')->willReturn(array());
+        $grumPHP->getTaskConfiguration('yamllint')->willReturn([]);
         $this->beConstructedWith($grumPHP, $linter);
     }
 
@@ -74,9 +74,9 @@ class YamlLintSpec extends AbstractLinterTaskSpec
         $linter->setExceptionOnInvalidType(false)->shouldBeCalled();
         $linter->lint(Argument::type('SplFileInfo'))->willReturn(new LintErrorsCollection());
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('file.yaml', '.', 'file.yaml'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');
@@ -88,13 +88,13 @@ class YamlLintSpec extends AbstractLinterTaskSpec
         $linter->isInstalled()->willReturn(true);
         $linter->setObjectSupport(false)->shouldBeCalled();
         $linter->setExceptionOnInvalidType(false)->shouldBeCalled();
-        $linter->lint(Argument::type('SplFileInfo'))->willReturn(new LintErrorsCollection(array(
+        $linter->lint(Argument::type('SplFileInfo'))->willReturn(new LintErrorsCollection([
             new YamlLintError(LintError::TYPE_ERROR, 0, 'error', 'file.yaml', 1, 1)
-        )));
+        ]));
 
-        $context->getFiles()->willReturn(new FilesCollection(array(
+        $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('file.yaml', '.', 'file.yaml'),
-        )));
+        ]));
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf('GrumPHP\Runner\TaskResultInterface');

--- a/src/GrumPHP/Collection/FilesCollection.php
+++ b/src/GrumPHP/Collection/FilesCollection.php
@@ -31,7 +31,7 @@ class FilesCollection extends ArrayCollection
      */
     public function name($pattern)
     {
-        $filter = new Iterator\FilenameFilterIterator($this->getIterator(), array($pattern), array());
+        $filter = new Iterator\FilenameFilterIterator($this->getIterator(), [$pattern], []);
 
         return new FilesCollection(iterator_to_array($filter));
     }
@@ -51,7 +51,7 @@ class FilesCollection extends ArrayCollection
      */
     public function notName($pattern)
     {
-        $filter = new Iterator\FilenameFilterIterator($this->getIterator(), array(), array($pattern));
+        $filter = new Iterator\FilenameFilterIterator($this->getIterator(), [], [$pattern]);
 
         return new FilesCollection(iterator_to_array($filter));
     }
@@ -67,7 +67,7 @@ class FilesCollection extends ArrayCollection
      */
     public function path($pattern)
     {
-        $filter = new Iterator\PathFilterIterator($this->getIterator(), array($pattern), array());
+        $filter = new Iterator\PathFilterIterator($this->getIterator(), [$pattern], []);
 
         return new FilesCollection(iterator_to_array($filter));
     }
@@ -85,7 +85,7 @@ class FilesCollection extends ArrayCollection
      */
     public function notPath($pattern)
     {
-        $filter = new Iterator\PathFilterIterator($this->getIterator(), array(), array($pattern));
+        $filter = new Iterator\PathFilterIterator($this->getIterator(), [], [$pattern]);
 
         return new FilesCollection(iterator_to_array($filter));
     }
@@ -120,7 +120,7 @@ class FilesCollection extends ArrayCollection
     public function size($size)
     {
         $comparator = new Comparator\NumberComparator($size);
-        $filter = new Iterator\SizeRangeFilterIterator($this->getIterator(), array($comparator));
+        $filter = new Iterator\SizeRangeFilterIterator($this->getIterator(), [$comparator]);
 
         return new FilesCollection(iterator_to_array($filter));
     }
@@ -144,7 +144,7 @@ class FilesCollection extends ArrayCollection
     public function date($date)
     {
         $comparator = new Comparator\DateComparator($date);
-        $filter = new Iterator\DateRangeFilterIterator($this->getIterator(), array($comparator));
+        $filter = new Iterator\DateRangeFilterIterator($this->getIterator(), [$comparator]);
 
         return new FilesCollection(iterator_to_array($filter));
     }
@@ -163,7 +163,7 @@ class FilesCollection extends ArrayCollection
      */
     public function filter(\Closure $closure)
     {
-        $filter = new Iterator\CustomFilterIterator($this->getIterator(), array($closure));
+        $filter = new Iterator\CustomFilterIterator($this->getIterator(), [$closure]);
 
         return new FilesCollection(iterator_to_array($filter));
     }

--- a/src/GrumPHP/Collection/LintErrorsCollection.php
+++ b/src/GrumPHP/Collection/LintErrorsCollection.php
@@ -16,7 +16,7 @@ class LintErrorsCollection extends ArrayCollection
      */
     public function __toString()
     {
-        $errors = array();
+        $errors = [];
         foreach ($this->getIterator() as $error) {
             $errors[] = $error->__toString();
         }

--- a/src/GrumPHP/Collection/ProcessArgumentsCollection.php
+++ b/src/GrumPHP/Collection/ProcessArgumentsCollection.php
@@ -19,7 +19,7 @@ class ProcessArgumentsCollection extends ArrayCollection
      */
     public static function forExecutable($executable)
     {
-        return new ProcessArgumentsCollection(array($executable));
+        return new ProcessArgumentsCollection([$executable]);
     }
 
     /**
@@ -132,7 +132,7 @@ class ProcessArgumentsCollection extends ArrayCollection
      */
     public function addCommaSeparatedFiles(FilesCollection $files)
     {
-        $paths = array();
+        $paths = [];
 
         foreach ($files as $file) {
             $paths[] = $file->getPathname();

--- a/src/GrumPHP/Collection/TaskResultCollection.php
+++ b/src/GrumPHP/Collection/TaskResultCollection.php
@@ -61,7 +61,7 @@ class TaskResultCollection extends ArrayCollection
      */
     public function getAllMessages()
     {
-        $messages = array();
+        $messages = [];
 
         foreach ($this as $taskResult) {
             $messages[] = $taskResult->getMessage();

--- a/src/GrumPHP/Collection/TasksCollection.php
+++ b/src/GrumPHP/Collection/TasksCollection.php
@@ -41,7 +41,7 @@ class TasksCollection extends ArrayCollection
         $stableSortIndex = PHP_INT_MAX;
         foreach ($this->getIterator() as $task) {
             $metadata = $grumPHP->getTaskMetadata($task->getName());
-            $priorityQueue->insert($task, array($metadata['priority'], $stableSortIndex--));
+            $priorityQueue->insert($task, [$metadata['priority'], $stableSortIndex--]);
         }
 
         return new TasksCollection(array_values(iterator_to_array($priorityQueue)));

--- a/src/GrumPHP/Composer/GrumPHPPlugin.php
+++ b/src/GrumPHP/Composer/GrumPHPPlugin.php
@@ -67,13 +67,13 @@ class GrumPHPPlugin implements PluginInterface, EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             PackageEvents::POST_PACKAGE_INSTALL => 'postPackageInstall',
             PackageEvents::POST_PACKAGE_UPDATE => 'postPackageUpdate',
             PackageEvents::PRE_PACKAGE_UNINSTALL => 'prePackageUninstall',
             ScriptEvents::POST_INSTALL_CMD => 'runScheduledTasks',
             ScriptEvents::POST_UPDATE_CMD => 'runScheduledTasks',
-        );
+        ];
     }
 
     /**
@@ -184,7 +184,7 @@ class GrumPHPPlugin implements PluginInterface, EventSubscriberInterface
         $commandLocator = new ExternalCommand($config->get('bin-dir'), new ExecutableFinder());
         $executable = $commandLocator->locate('grumphp');
 
-        $builder = new ProcessBuilder(array($executable, $command, '--no-interaction'));
+        $builder = new ProcessBuilder([$executable, $command, '--no-interaction']);
         $process = $builder->getProcess();
 
         // Check executable which is running:

--- a/src/GrumPHP/Configuration/Compiler/ExtensionCompilerPass.php
+++ b/src/GrumPHP/Configuration/Compiler/ExtensionCompilerPass.php
@@ -20,7 +20,7 @@ class ExtensionCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $extensions = $container->getParameter('extensions');
-        $extensions = is_array($extensions) ? $extensions : array();
+        $extensions = is_array($extensions) ? $extensions : [];
         foreach ($extensions as $extensionClass) {
             if (!class_exists($extensionClass)) {
                 throw new RuntimeException(sprintf('Invalid extension class specified: %s', $extensionClass));

--- a/src/GrumPHP/Configuration/Compiler/TaskCompilerPass.php
+++ b/src/GrumPHP/Configuration/Compiler/TaskCompilerPass.php
@@ -27,9 +27,9 @@ class TaskCompilerPass implements CompilerPassInterface
         $taggedServices = $container->findTaggedServiceIds(self::TAG_GRUMPHP_TASK);
         $configuration = $container->getParameter('tasks');
 
-        $tasksRegistered = array();
-        $tasksMetadata = array();
-        $tasksConfiguration = array();
+        $tasksRegistered = [];
+        $tasksMetadata = [];
+        $tasksConfiguration = [];
         foreach ($taggedServices as $id => $tags) {
             $taskTag = $this->getTaskTag($tags);
             $configKey = $taskTag['config'];
@@ -45,7 +45,7 @@ class TaskCompilerPass implements CompilerPassInterface
             }
 
             // Load configuration and metadata:
-            $taskConfig = is_array($configuration[$configKey]) ? $configuration[$configKey] : array();
+            $taskConfig = is_array($configuration[$configKey]) ? $configuration[$configKey] : [];
             $tasksMetadata[$configKey] = $this->parseTaskMetadata($taskConfig);
 
             // The metadata can't be part of the actual configuration.
@@ -54,7 +54,7 @@ class TaskCompilerPass implements CompilerPassInterface
             $tasksConfiguration[$configKey] = $taskConfig;
 
             // Add the task to the task runner:
-            $definition->addMethodCall('addTask', array(new Reference($id)));
+            $definition->addMethodCall('addTask', [new Reference($id)]);
         }
 
         sort($tasksRegistered);
@@ -72,7 +72,7 @@ class TaskCompilerPass implements CompilerPassInterface
     private function getTaskTag(array $tags)
     {
         $resolver = new OptionsResolver();
-        $resolver->setRequired(array('config'));
+        $resolver->setRequired(['config']);
 
         return $resolver->resolve(current($tags));
     }
@@ -85,12 +85,12 @@ class TaskCompilerPass implements CompilerPassInterface
     private function parseTaskMetadata($configuration)
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'priority' => 0,
             'blocking' => true,
-        ));
+        ]);
 
-        $metadata = isset($configuration['metadata']) ? $configuration['metadata'] : array();
+        $metadata = isset($configuration['metadata']) ? $configuration['metadata'] : [];
 
         return $resolver->resolve($metadata);
     }

--- a/src/GrumPHP/Console/Application.php
+++ b/src/GrumPHP/Console/Application.php
@@ -151,7 +151,7 @@ class Application extends SymfonyConsole
 
         // Load cli options:
         $input = new ArgvInput();
-        $configPath = $input->getParameterOption(array('--config', '-c'), $this->getDefaultConfigPath());
+        $configPath = $input->getParameterOption(['--config', '-c'], $this->getDefaultConfigPath());
 
         // Build the service container:
         $this->container = ContainerFactory::buildFromConfiguration($configPath);

--- a/src/GrumPHP/Console/Command/ConfigureCommand.php
+++ b/src/GrumPHP/Console/Command/ConfigureCommand.php
@@ -133,42 +133,42 @@ class ConfigureCommand extends Command
         );
         $question = new ConfirmationQuestion($questionString, true);
         if (!$helper->ask($input, $output, $question)) {
-            return array();
+            return [];
         }
 
         // Search for git_dir
         $default = $this->guessGitDir();
         $questionString = $this->createQuestionString('In which folder is GIT initialized?', $default);
         $question = new Question($questionString, $default);
-        $question->setValidator(array($this, 'pathValidator'));
+        $question->setValidator([$this, 'pathValidator']);
         $gitDir = $helper->ask($input, $output, $question);
 
         // Search for bin_dir
         $default = $this->guessBinDir();
         $questionString = $this->createQuestionString('Where can we find the executables?', $default);
         $question = new Question($questionString, $default);
-        $question->setValidator(array($this, 'pathValidator'));
+        $question->setValidator([$this, 'pathValidator']);
         $binDir = $helper->ask($input, $output, $question);
 
         // Search tasks
         $question = new ChoiceQuestion(
             'Which tasks do you want to run?',
             $this->getAvailableTasks($this->config),
-            array()
+            []
         );
         $question->setMultiselect(true);
         $tasks = $helper->ask($input, $output, $question);
 
         // Build configuration
-        return array(
-            'parameters' => array(
+        return [
+            'parameters' => [
                 'git_dir' => $gitDir,
                 'bin_dir' => $binDir,
                 'tasks' => array_map(function ($task) {
                     return null;
                 }, array_flip($tasks)),
-            )
-        );
+            ]
+        ];
     }
 
     /**
@@ -230,7 +230,7 @@ class ConfigureCommand extends Command
     {
         $defaultGitDir = $this->config->getGitDir();
         try {
-            $topLevel = $this->repository->run('rev-parse', array('--show-toplevel'));
+            $topLevel = $this->repository->run('rev-parse', ['--show-toplevel']);
         } catch (Exception $e) {
             return $defaultGitDir;
         }

--- a/src/GrumPHP/Console/Command/Git/DeInitCommand.php
+++ b/src/GrumPHP/Console/Command/Git/DeInitCommand.php
@@ -19,10 +19,10 @@ class DeInitCommand extends Command
     /**
      * @var array
      */
-    protected static $hooks = array(
+    protected static $hooks = [
         'pre-commit',
         'commit-msg',
-    );
+    ];
 
     /**
      * @var GrumPHP

--- a/src/GrumPHP/Console/Command/Git/InitCommand.php
+++ b/src/GrumPHP/Console/Command/Git/InitCommand.php
@@ -21,10 +21,10 @@ class InitCommand extends Command
     /**
      * @var array
      */
-    public static $hooks = array(
+    public static $hooks = [
         'pre-commit',
         'commit-msg',
-    );
+    ];
 
     /**
      * @var GrumPHP
@@ -121,10 +121,10 @@ class InitCommand extends Command
     protected function parseHookBody($hook, $templateFile)
     {
         $content = file_get_contents($templateFile);
-        $replacements = array(
+        $replacements = [
             '${HOOK_EXEC_PATH}' => $this->paths()->getGitHookExecutionPath(),
             '$(HOOK_COMMAND)' => $this->generateHookCommand('git:' . $hook),
-        );
+        ];
 
         return str_replace(array_keys($replacements), array_values($replacements), $content);
     }
@@ -138,10 +138,10 @@ class InitCommand extends Command
     protected function generateHookCommand($command)
     {
         $executable = $this->paths()->getBinCommand('grumphp', true);
-        $this->processBuilder->setArguments(array(
+        $this->processBuilder->setArguments([
             $this->paths()->getRelativeProjectPath($executable),
             $command
-        ));
+        ]);
 
         if ($configFile = $this->useExoticConfigFile()) {
             $this->processBuilder->add(sprintf('--config=%s', $configFile));

--- a/src/GrumPHP/Event/RunnerFailedEvent.php
+++ b/src/GrumPHP/Event/RunnerFailedEvent.php
@@ -14,7 +14,7 @@ class RunnerFailedEvent extends RunnerEvent
      */
     public function getMessages()
     {
-        $messages = array();
+        $messages = [];
 
         foreach ($this->getTaskResults() as $taskResult) {
             if (null !== $taskResult->getMessage()) {

--- a/src/GrumPHP/Event/Subscriber/ProgressSubscriber.php
+++ b/src/GrumPHP/Event/Subscriber/ProgressSubscriber.php
@@ -50,12 +50,12 @@ class ProgressSubscriber implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             RunnerEvents::RUNNER_RUN => 'startProgress',
             TaskEvents::TASK_RUN => 'advanceProgress',
             RunnerEvents::RUNNER_COMPLETE => 'finishProgress',
             RunnerEvents::RUNNER_FAILED => 'finishProgress',
-        );
+        ];
     }
 
     /**

--- a/src/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriber.php
+++ b/src/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriber.php
@@ -65,12 +65,12 @@ class StashUnstagedChangesSubscriber implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(
-            RunnerEvents::RUNNER_RUN => array('saveStash', 10000),
-            RunnerEvents::RUNNER_COMPLETE => array('popStash', -10000),
-            RunnerEvents::RUNNER_FAILED => array('popStash', -10000),
-            ConsoleEvents::EXCEPTION => array('handleErrors', -10000),
-        );
+        return [
+            RunnerEvents::RUNNER_RUN => ['saveStash', 10000],
+            RunnerEvents::RUNNER_COMPLETE => ['popStash', -10000],
+            RunnerEvents::RUNNER_FAILED => ['popStash', -10000],
+            ConsoleEvents::EXCEPTION => ['handleErrors', -10000],
+        ];
     }
 
     /**
@@ -128,7 +128,7 @@ class StashUnstagedChangesSubscriber implements EventSubscriberInterface
 
         try {
             $this->io->write('<fg=yellow>Detected unstaged changes... Stashing them!</fg=yellow>');
-            $this->repository->run('stash', array('save', '--quiet', '--keep-index', uniqid('grumphp')));
+            $this->repository->run('stash', ['save', '--quiet', '--keep-index', uniqid('grumphp')]);
         } catch (Exception $e) {
             // No worries ...
             $this->io->write(sprintf('<fg=red>Failed stashing changes: %s</fg=red>', $e->getMessage()));
@@ -150,7 +150,7 @@ class StashUnstagedChangesSubscriber implements EventSubscriberInterface
 
         try {
             $this->io->write('<fg=yellow>Reapplying unstaged changes from stash.</fg=yellow>');
-            $this->repository->run('stash', array('pop', '--quiet'));
+            $this->repository->run('stash', ['pop', '--quiet']);
         } catch (Exception $e) {
             throw new RuntimeException(
                 'The stashed changes could not be applied. Please run `git stash pop` manually!'

--- a/src/GrumPHP/Formatter/GitBlacklistFormatter.php
+++ b/src/GrumPHP/Formatter/GitBlacklistFormatter.php
@@ -77,9 +77,9 @@ class GitBlacklistFormatter implements ProcessFormatterInterface
             return $line;
         }
 
-        $positionsWordColor = array();
-        $positionsResetColor = array();
-        $parts = array();
+        $positionsWordColor = [];
+        $positionsResetColor = [];
+        $parts = [];
         $lastPos = 0;
 
         //iterate over all WORD_COLORs and save the positions into $positionsWordColor

--- a/src/GrumPHP/Formatter/PhpCsFixerFormatter.php
+++ b/src/GrumPHP/Formatter/PhpCsFixerFormatter.php
@@ -56,7 +56,7 @@ class PhpCsFixerFormatter implements ProcessFormatterInterface
         $dryrun = sprintf($pattern, ProcessUtils::escapeArgument('--dry-run'));
         $formatJson = sprintf($pattern, ProcessUtils::escapeArgument('--format=json'));
 
-        return str_replace(array($dryrun, $formatJson), '', $process->getCommandLine());
+        return str_replace([$dryrun, $formatJson], '', $process->getCommandLine());
     }
 
     /**
@@ -81,7 +81,7 @@ class PhpCsFixerFormatter implements ProcessFormatterInterface
      */
     private function formatJsonResponse(array $json)
     {
-        $formatted = array();
+        $formatted = [];
         foreach ($json['files'] as $file) {
             if (!is_array($file) || !isset($file['name'])) {
                 $formatted[] = 'Invalid file: ' . print_r($file, true);

--- a/src/GrumPHP/Formatter/PhpcsFormatter.php
+++ b/src/GrumPHP/Formatter/PhpcsFormatter.php
@@ -21,7 +21,7 @@ class PhpcsFormatter implements ProcessFormatterInterface
     /**
      * @var string[]
      */
-    protected $suggestedFiles = array();
+    protected $suggestedFiles = [];
 
     /**
      * @param Process $process
@@ -57,7 +57,7 @@ class PhpcsFormatter implements ProcessFormatterInterface
      */
     public function getSuggestedFilesFromJson(array $json)
     {
-        $suggestedFiles = array();
+        $suggestedFiles = [];
         if (!isset($json['totals']) || $json['totals']['fixable'] == 0) {
             return $suggestedFiles;
         }

--- a/src/GrumPHP/Linter/Xml/XmlLinter.php
+++ b/src/GrumPHP/Linter/Xml/XmlLinter.php
@@ -149,11 +149,11 @@ class XmlLinter implements LinterInterface
      */
     private function registerXmlStreamContext()
     {
-        libxml_set_streams_context(stream_context_create(array(
-            'http' => array(
+        libxml_set_streams_context(stream_context_create([
+            'http' => [
                 'user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:43.0) Gecko/20100101 Firefox/43.0'
-            )
-        )));
+            ]
+        ]));
     }
 
     /**
@@ -205,7 +205,7 @@ class XmlLinter implements LinterInterface
      */
     private function validateInternalSchemes(SplFileInfo $file, DOMDocument $document)
     {
-        $schemas = array();
+        $schemas = [];
         $attributes = $document->documentElement->attributes;
 
         if ($schemaLocation = $attributes->getNamedItemNS(self::XSI_NAMESPACE, 'schemaLocation')) {

--- a/src/GrumPHP/Locator/ChangedFiles.php
+++ b/src/GrumPHP/Locator/ChangedFiles.php
@@ -58,7 +58,7 @@ class ChangedFiles
      */
     private function parseFilesFromDiff(Diff $diff)
     {
-        $files = array();
+        $files = [];
         /** @var File $file */
         foreach ($diff->getFiles() as $file) {
             if ($file->isDeletion()) {

--- a/src/GrumPHP/Locator/ExternalCommand.php
+++ b/src/GrumPHP/Locator/ExternalCommand.php
@@ -45,7 +45,7 @@ class ExternalCommand
     public function locate($command, $forceUnix = false)
     {
         // Search executable:
-        $executable = $this->executableFinder->find($command, null, array($this->binDir));
+        $executable = $this->executableFinder->find($command, null, [$this->binDir]);
         if (!$executable) {
             throw new RuntimeException(
                 sprintf('The executable for "%s" could not be found.', $command)

--- a/src/GrumPHP/Locator/RegisteredFiles.php
+++ b/src/GrumPHP/Locator/RegisteredFiles.php
@@ -34,7 +34,7 @@ class RegisteredFiles
         $allFiles = trim($this->repository->run('ls-files'));
         $filePaths = preg_split("/\r\n|\n|\r/", $allFiles);
 
-        $files = array();
+        $files = [];
         foreach ($filePaths as $file) {
             $files[] = new SplFileInfo($file, dirname($file), $file);
         }

--- a/src/GrumPHP/Task/AbstractLinterTask.php
+++ b/src/GrumPHP/Task/AbstractLinterTask.php
@@ -42,11 +42,11 @@ abstract class AbstractLinterTask implements TaskInterface
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
-            'ignore_patterns' => array(),
-        ));
+        $resolver->setDefaults([
+            'ignore_patterns' => [],
+        ]);
 
-        $resolver->addAllowedTypes('ignore_patterns', array('array'));
+        $resolver->addAllowedTypes('ignore_patterns', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/AbstractPhpCsFixerTask.php
+++ b/src/GrumPHP/Task/AbstractPhpCsFixerTask.php
@@ -90,8 +90,8 @@ abstract class AbstractPhpCsFixerTask implements TaskInterface
         $process->run();
 
         if (!$process->isSuccessful()) {
-            $messages = array($this->formatter->format($process));
-            $suggestions = array($this->formatter->formatSuggestion($process));
+            $messages = [$this->formatter->format($process)];
+            $suggestions = [$this->formatter->formatSuggestion($process)];
             $errorMessage = $this->formatter->formatErrorMessage($messages, $suggestions);
 
             return TaskResult::createFailed($this, $context, $errorMessage);
@@ -113,8 +113,8 @@ abstract class AbstractPhpCsFixerTask implements TaskInterface
         FilesCollection $files
     ) {
         $hasErrors = false;
-        $messages = array();
-        $suggestions = array();
+        $messages = [];
+        $suggestions = [];
 
         foreach ($files as $file) {
             $fileArguments = new ProcessArgumentsCollection($arguments->getValues());

--- a/src/GrumPHP/Task/Ant.php
+++ b/src/GrumPHP/Task/Ant.php
@@ -27,15 +27,15 @@ class Ant extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
-            'triggered_by' => array('php'),
+        $resolver->setDefaults([
+            'triggered_by' => ['php'],
             'build_file' => null,
             'task' => null,
-        ));
+        ]);
 
-        $resolver->addAllowedTypes('triggered_by', array('array'));
-        $resolver->addAllowedTypes('build_file', array('null', 'string'));
-        $resolver->addAllowedTypes('task', array('null', 'string'));
+        $resolver->addAllowedTypes('triggered_by', ['array']);
+        $resolver->addAllowedTypes('build_file', ['null', 'string']);
+        $resolver->addAllowedTypes('task', ['null', 'string']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Atoum.php
+++ b/src/GrumPHP/Task/Atoum.php
@@ -27,23 +27,23 @@ class Atoum extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'config_file' => null,
             'bootstrap_file' => null,
-            'directories' => array(),
-            'files' => array(),
-            'namespaces' => array(),
-            'methods' => array(),
-            'tags' => array(),
-        ));
+            'directories' => [],
+            'files' => [],
+            'namespaces' => [],
+            'methods' => [],
+            'tags' => [],
+        ]);
 
-        $resolver->addAllowedTypes('config_file', array('null', 'string'));
-        $resolver->addAllowedTypes('bootstrap_file', array('null', 'string'));
-        $resolver->addAllowedTypes('directories', array('array'));
-        $resolver->addAllowedTypes('files', array('array'));
-        $resolver->addAllowedTypes('namespaces', array('array'));
-        $resolver->addAllowedTypes('methods', array('array'));
-        $resolver->addAllowedTypes('tags', array('array'));
+        $resolver->addAllowedTypes('config_file', ['null', 'string']);
+        $resolver->addAllowedTypes('bootstrap_file', ['null', 'string']);
+        $resolver->addAllowedTypes('directories', ['array']);
+        $resolver->addAllowedTypes('files', ['array']);
+        $resolver->addAllowedTypes('namespaces', ['array']);
+        $resolver->addAllowedTypes('methods', ['array']);
+        $resolver->addAllowedTypes('tags', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Behat.php
+++ b/src/GrumPHP/Task/Behat.php
@@ -27,17 +27,17 @@ class Behat extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'config' => null,
             'format' => null,
             'suite' => null,
             'stop_on_failure' => false,
-        ));
+        ]);
 
-        $resolver->addAllowedTypes('config', array('null', 'string'));
-        $resolver->addAllowedTypes('format', array('null', 'string'));
-        $resolver->addAllowedTypes('suite', array('null', 'string'));
-        $resolver->addAllowedTypes('stop_on_failure', array('bool'));
+        $resolver->addAllowedTypes('config', ['null', 'string']);
+        $resolver->addAllowedTypes('format', ['null', 'string']);
+        $resolver->addAllowedTypes('suite', ['null', 'string']);
+        $resolver->addAllowedTypes('stop_on_failure', ['bool']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/CloverCoverage.php
+++ b/src/GrumPHP/Task/CloverCoverage.php
@@ -64,12 +64,12 @@ class CloverCoverage implements TaskInterface
         $resolver->setDefined('clover_file');
         $resolver->setDefined('level');
 
-        $resolver->addAllowedTypes('clover_file', array('string'));
-        $resolver->addAllowedTypes('level', array('int', 'float'));
+        $resolver->addAllowedTypes('clover_file', ['string']);
+        $resolver->addAllowedTypes('level', ['int', 'float']);
 
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'level' => 100,
-        ));
+        ]);
 
         $resolver->setRequired('clover_file');
 

--- a/src/GrumPHP/Task/Codeception.php
+++ b/src/GrumPHP/Task/Codeception.php
@@ -29,17 +29,17 @@ class Codeception extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'config_file' => null,
             'suite' => null,
             'test'  => null,
             'fail_fast' => false
-        ));
+        ]);
 
-        $resolver->addAllowedTypes('config_file', array('null', 'string'));
-        $resolver->addAllowedTypes('suite', array('null', 'string'));
-        $resolver->addAllowedTypes('test', array('null', 'string'));
-        $resolver->addAllowedTypes('fail_fast', array('bool'));
+        $resolver->addAllowedTypes('config_file', ['null', 'string']);
+        $resolver->addAllowedTypes('suite', ['null', 'string']);
+        $resolver->addAllowedTypes('test', ['null', 'string']);
+        $resolver->addAllowedTypes('fail_fast', ['bool']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Composer.php
+++ b/src/GrumPHP/Task/Composer.php
@@ -30,7 +30,7 @@ class Composer extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'file' => './composer.json',
             'no_check_all' => false,
             'no_check_lock' => false,
@@ -38,15 +38,15 @@ class Composer extends AbstractExternalTask
             'no_local_repository' => false,
             'with_dependencies' => false,
             'strict' => false
-        ));
+        ]);
 
-        $resolver->addAllowedTypes('file', array('string'));
-        $resolver->addAllowedTypes('no_check_all', array('bool'));
-        $resolver->addAllowedTypes('no_check_lock', array('bool'));
-        $resolver->addAllowedTypes('no_check_publish', array('bool'));
-        $resolver->addAllowedTypes('no_local_repository', array('bool'));
-        $resolver->addAllowedTypes('with_dependencies', array('bool'));
-        $resolver->addAllowedTypes('strict', array('bool'));
+        $resolver->addAllowedTypes('file', ['string']);
+        $resolver->addAllowedTypes('no_check_all', ['bool']);
+        $resolver->addAllowedTypes('no_check_lock', ['bool']);
+        $resolver->addAllowedTypes('no_check_publish', ['bool']);
+        $resolver->addAllowedTypes('no_local_repository', ['bool']);
+        $resolver->addAllowedTypes('with_dependencies', ['bool']);
+        $resolver->addAllowedTypes('strict', ['bool']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/ComposerScript.php
+++ b/src/GrumPHP/Task/ComposerScript.php
@@ -27,15 +27,15 @@ class ComposerScript extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'working_directory' => null,
             'script' => null,
-            'triggered_by' => array('php', 'phtml')
-        ));
+            'triggered_by' => ['php', 'phtml']
+        ]);
 
-        $resolver->addAllowedTypes('working_directory', array('null', 'string'));
-        $resolver->addAllowedTypes('script', array('string'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
+        $resolver->addAllowedTypes('working_directory', ['null', 'string']);
+        $resolver->addAllowedTypes('script', ['string']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/DoctrineOrm.php
+++ b/src/GrumPHP/Task/DoctrineOrm.php
@@ -28,15 +28,15 @@ class DoctrineOrm extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'skip_mapping' => false,
             'skip_sync' => false,
-            'triggered_by' => array('php', 'xml', 'yml'),
-        ));
+            'triggered_by' => ['php', 'xml', 'yml'],
+        ]);
 
-        $resolver->addAllowedTypes('skip_mapping', array('bool'));
-        $resolver->addAllowedTypes('skip_sync', array('bool'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
+        $resolver->addAllowedTypes('skip_mapping', ['bool']);
+        $resolver->addAllowedTypes('skip_sync', ['bool']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Gherkin.php
+++ b/src/GrumPHP/Task/Gherkin.php
@@ -27,14 +27,14 @@ class Gherkin extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'directory' => 'features',
             'align' => null,
-        ));
+        ]);
 
-        $resolver->addAllowedTypes('directory', array('string'));
-        $resolver->addAllowedTypes('align', array('null', 'string'));
-        $resolver->addAllowedValues('align', array(null, 'left', 'right'));
+        $resolver->addAllowedTypes('directory', ['string']);
+        $resolver->addAllowedTypes('align', ['null', 'string']);
+        $resolver->addAllowedValues('align', [null, 'left', 'right']);
 
         return $resolver;
     }
@@ -53,7 +53,7 @@ class Gherkin extends AbstractExternalTask
     public function run(ContextInterface $context)
     {
         $config = $this->getConfiguration();
-        $files = $context->getFiles()->extensions(array('feature'));
+        $files = $context->getFiles()->extensions(['feature']);
         if (0 === count($files)) {
             return TaskResult::createSkipped($this, $context);
         }

--- a/src/GrumPHP/Task/Git/Blacklist.php
+++ b/src/GrumPHP/Task/Git/Blacklist.php
@@ -56,13 +56,13 @@ class Blacklist extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
-            'keywords' => array(),
-            'triggered_by' => array('php')
-        ));
+        $resolver->setDefaults([
+            'keywords' => [],
+            'triggered_by' => ['php']
+        ]);
 
-        $resolver->addAllowedTypes('keywords', array('array'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
+        $resolver->addAllowedTypes('keywords', ['array']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Git/CommitMessage.php
+++ b/src/GrumPHP/Task/Git/CommitMessage.php
@@ -50,17 +50,17 @@ class CommitMessage implements TaskInterface
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'case_insensitive' => true,
             'multiline' => true,
-            'matchers' => array(),
+            'matchers' => [],
             'additional_modifiers' => ''
-        ));
+        ]);
 
-        $resolver->addAllowedTypes('case_insensitive', array('bool'));
-        $resolver->addAllowedTypes('multiline', array('bool'));
-        $resolver->addAllowedTypes('matchers', array('array'));
-        $resolver->addAllowedTypes('additional_modifiers', array('string'));
+        $resolver->addAllowedTypes('case_insensitive', ['bool']);
+        $resolver->addAllowedTypes('multiline', ['bool']);
+        $resolver->addAllowedTypes('matchers', ['array']);
+        $resolver->addAllowedTypes('additional_modifiers', ['string']);
 
         return $resolver;
     }
@@ -82,7 +82,7 @@ class CommitMessage implements TaskInterface
     {
         $config = $this->getConfiguration();
         $commitMessage = $context->getCommitMessage();
-        $exceptions = array();
+        $exceptions = [];
 
         foreach ($config['matchers'] as $rule) {
             try {
@@ -119,7 +119,7 @@ class CommitMessage implements TaskInterface
         }
 
         $additionalModifiersArray = array_filter(str_split((string) $config['additional_modifiers']));
-        array_map(array($regex, 'addPatternModifier'), $additionalModifiersArray);
+        array_map([$regex, 'addPatternModifier'], $additionalModifiersArray);
 
         if (!preg_match((string) $regex, $commitMessage)) {
             throw new RuntimeException(

--- a/src/GrumPHP/Task/Grunt.php
+++ b/src/GrumPHP/Task/Grunt.php
@@ -27,15 +27,15 @@ class Grunt extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'grunt_file' => null,
             'task' => null,
-            'triggered_by' => array('js', 'jsx', 'coffee', 'ts', 'less', 'sass', 'scss')
-        ));
+            'triggered_by' => ['js', 'jsx', 'coffee', 'ts', 'less', 'sass', 'scss']
+        ]);
 
-        $resolver->addAllowedTypes('grunt_file', array('null', 'string'));
-        $resolver->addAllowedTypes('task', array('null', 'string'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
+        $resolver->addAllowedTypes('grunt_file', ['null', 'string']);
+        $resolver->addAllowedTypes('task', ['null', 'string']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Gulp.php
+++ b/src/GrumPHP/Task/Gulp.php
@@ -27,15 +27,15 @@ class Gulp extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'gulp_file' => null,
             'task' => null,
-            'triggered_by' => array('js', 'jsx', 'coffee', 'ts', 'less', 'sass', 'scss')
-        ));
+            'triggered_by' => ['js', 'jsx', 'coffee', 'ts', 'less', 'sass', 'scss']
+        ]);
 
-        $resolver->addAllowedTypes('gulp_file', array('null', 'string'));
-        $resolver->addAllowedTypes('task', array('null', 'string'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
+        $resolver->addAllowedTypes('gulp_file', ['null', 'string']);
+        $resolver->addAllowedTypes('task', ['null', 'string']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/JsonLint.php
+++ b/src/GrumPHP/Task/JsonLint.php
@@ -36,11 +36,11 @@ class JsonLint extends AbstractLinterTask
     public function getConfigurableOptions()
     {
         $resolver = parent::getConfigurableOptions();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'detect_key_conflicts' => false,
-        ));
+        ]);
 
-        $resolver->addAllowedTypes('detect_key_conflicts', array('bool'));
+        $resolver->addAllowedTypes('detect_key_conflicts', ['bool']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Make.php
+++ b/src/GrumPHP/Task/Make.php
@@ -27,15 +27,15 @@ class Make extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'make_file' => null,
             'task' => null,
-            'triggered_by' => array('php')
-        ));
+            'triggered_by' => ['php']
+        ]);
 
-        $resolver->addAllowedTypes('make_file', array('null', 'string'));
-        $resolver->addAllowedTypes('task', array('null', 'string'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
+        $resolver->addAllowedTypes('make_file', ['null', 'string']);
+        $resolver->addAllowedTypes('task', ['null', 'string']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/NpmScript.php
+++ b/src/GrumPHP/Task/NpmScript.php
@@ -27,15 +27,15 @@ class NpmScript extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'script' => null,
-            'triggered_by' => array('js', 'jsx', 'coffee', 'ts', 'less', 'sass', 'scss'),
+            'triggered_by' => ['js', 'jsx', 'coffee', 'ts', 'less', 'sass', 'scss'],
             'working_directory' => './',
-        ));
+        ]);
 
-        $resolver->addAllowedTypes('script', array('string'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
-        $resolver->addAllowedTypes('working_directory', array('string'));
+        $resolver->addAllowedTypes('script', ['string']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
+        $resolver->addAllowedTypes('working_directory', ['string']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Phing.php
+++ b/src/GrumPHP/Task/Phing.php
@@ -27,15 +27,15 @@ class Phing extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'build_file' => null,
             'task' => null,
-            'triggered_by' => array('php')
-        ));
+            'triggered_by' => ['php']
+        ]);
 
-        $resolver->addAllowedTypes('build_file', array('null', 'string'));
-        $resolver->addAllowedTypes('task', array('null', 'string'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
+        $resolver->addAllowedTypes('build_file', ['null', 'string']);
+        $resolver->addAllowedTypes('task', ['null', 'string']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Php7cc.php
+++ b/src/GrumPHP/Task/Php7cc.php
@@ -27,15 +27,15 @@ class Php7cc extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
-            'exclude' => array(),
+        $resolver->setDefaults([
+            'exclude' => [],
             'level' => null,
-            'triggered_by' => array('php')
-        ));
+            'triggered_by' => ['php']
+        ]);
 
-        $resolver->addAllowedTypes('exclude', array('array'));
-        $resolver->addAllowedTypes('level', array('null', 'string'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
+        $resolver->addAllowedTypes('exclude', ['array']);
+        $resolver->addAllowedTypes('level', ['null', 'string']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/PhpCpd.php
+++ b/src/GrumPHP/Task/PhpCpd.php
@@ -28,21 +28,21 @@ class PhpCpd extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'directory' => '.',
-            'exclude' => array('vendor'),
+            'exclude' => ['vendor'],
             'fuzzy' => false,
             'min_lines' => 5,
             'min_tokens' => 70,
-            'triggered_by' => array('php'),
-        ));
+            'triggered_by' => ['php'],
+        ]);
 
-        $resolver->addAllowedTypes('directory', array('string'));
-        $resolver->addAllowedTypes('exclude', array('array'));
-        $resolver->addAllowedTypes('fuzzy', array('bool'));
-        $resolver->addAllowedTypes('min_lines', array('int'));
-        $resolver->addAllowedTypes('min_tokens', array('int'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
+        $resolver->addAllowedTypes('directory', ['string']);
+        $resolver->addAllowedTypes('exclude', ['array']);
+        $resolver->addAllowedTypes('fuzzy', ['bool']);
+        $resolver->addAllowedTypes('min_lines', ['int']);
+        $resolver->addAllowedTypes('min_tokens', ['int']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/PhpCsFixer.php
+++ b/src/GrumPHP/Task/PhpCsFixer.php
@@ -26,19 +26,19 @@ class PhpCsFixer extends AbstractPhpCsFixerTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'config' => null,
             'config_file' => null,
-            'fixers' => array(),
+            'fixers' => [],
             'level' => null,
             'verbose' => true,
-        ));
+        ]);
 
-        $resolver->addAllowedTypes('config', array('null', 'string'));
-        $resolver->addAllowedTypes('config_file', array('null', 'string'));
-        $resolver->addAllowedTypes('fixers', array('array'));
-        $resolver->addAllowedTypes('level', array('null', 'string'));
-        $resolver->addAllowedTypes('verbose', array('bool'));
+        $resolver->addAllowedTypes('config', ['null', 'string']);
+        $resolver->addAllowedTypes('config_file', ['null', 'string']);
+        $resolver->addAllowedTypes('fixers', ['array']);
+        $resolver->addAllowedTypes('level', ['null', 'string']);
+        $resolver->addAllowedTypes('verbose', ['bool']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/PhpCsFixerV2.php
+++ b/src/GrumPHP/Task/PhpCsFixerV2.php
@@ -26,25 +26,25 @@ class PhpCsFixerV2 extends AbstractPhpCsFixerTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'allow_risky' => false,
             'cache_file' => null,
             'config' => null,
-            'rules' => array(),
+            'rules' => [],
             'using_cache' => true,
             'path_mode' => null,
             'verbose' => true,
-        ));
+        ]);
 
-        $resolver->addAllowedTypes('allow_risky', array('bool'));
-        $resolver->addAllowedTypes('cache_file', array('null', 'string'));
-        $resolver->addAllowedTypes('config', array('null', 'string'));
-        $resolver->addAllowedTypes('rules', array('array'));
-        $resolver->addAllowedTypes('using_cache', array('bool'));
-        $resolver->addAllowedTypes('path_mode', array('null', 'string'));
-        $resolver->addAllowedTypes('verbose', array('bool'));
+        $resolver->addAllowedTypes('allow_risky', ['bool']);
+        $resolver->addAllowedTypes('cache_file', ['null', 'string']);
+        $resolver->addAllowedTypes('config', ['null', 'string']);
+        $resolver->addAllowedTypes('rules', ['array']);
+        $resolver->addAllowedTypes('using_cache', ['bool']);
+        $resolver->addAllowedTypes('path_mode', ['null', 'string']);
+        $resolver->addAllowedTypes('verbose', ['bool']);
 
-        $resolver->setAllowedValues('path_mode', array(null, 'override', 'intersection'));
+        $resolver->setAllowedValues('path_mode', [null, 'override', 'intersection']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/PhpLint.php
+++ b/src/GrumPHP/Task/PhpLint.php
@@ -27,13 +27,13 @@ class PhpLint extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'jobs' => null,
-            'exclude' => array(),
-            'triggered_by' => array('php', 'phtml', 'php3', 'php4', 'php5'),
-        ));
+            'exclude' => [],
+            'triggered_by' => ['php', 'phtml', 'php3', 'php4', 'php5'],
+        ]);
 
-        $resolver->setAllowedTypes('jobs', array('int', 'null'));
+        $resolver->setAllowedTypes('jobs', ['int', 'null']);
         $resolver->setAllowedTypes('exclude', 'array');
         $resolver->setAllowedTypes('triggered_by', 'array');
 

--- a/src/GrumPHP/Task/PhpMd.php
+++ b/src/GrumPHP/Task/PhpMd.php
@@ -28,15 +28,15 @@ class PhpMd extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
-            'exclude' => array(),
-            'ruleset' => array('cleancode', 'codesize', 'naming'),
-            'triggered_by' => array('php')
-        ));
+        $resolver->setDefaults([
+            'exclude' => [],
+            'ruleset' => ['cleancode', 'codesize', 'naming'],
+            'triggered_by' => ['php']
+        ]);
 
-        $resolver->addAllowedTypes('exclude', array('array'));
-        $resolver->addAllowedTypes('ruleset', array('array'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
+        $resolver->addAllowedTypes('exclude', ['array']);
+        $resolver->addAllowedTypes('ruleset', ['array']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Phpcs.php
+++ b/src/GrumPHP/Task/Phpcs.php
@@ -34,23 +34,23 @@ class Phpcs extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'standard' => null,
             'show_warnings' => true,
             'tab_width' => null,
             'encoding' => null,
-            'ignore_patterns' => array(),
-            'sniffs' => array(),
-            'triggered_by' => array('php')
-        ));
+            'ignore_patterns' => [],
+            'sniffs' => [],
+            'triggered_by' => ['php']
+        ]);
 
-        $resolver->addAllowedTypes('standard', array('null', 'string'));
-        $resolver->addAllowedTypes('show_warnings', array('bool'));
-        $resolver->addAllowedTypes('tab_width', array('null', 'int'));
-        $resolver->addAllowedTypes('encoding', array('null', 'string'));
-        $resolver->addAllowedTypes('ignore_patterns', array('array'));
-        $resolver->addAllowedTypes('sniffs', array('array'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
+        $resolver->addAllowedTypes('standard', ['null', 'string']);
+        $resolver->addAllowedTypes('show_warnings', ['bool']);
+        $resolver->addAllowedTypes('tab_width', ['null', 'int']);
+        $resolver->addAllowedTypes('encoding', ['null', 'string']);
+        $resolver->addAllowedTypes('ignore_patterns', ['array']);
+        $resolver->addAllowedTypes('sniffs', ['array']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Phpspec.php
+++ b/src/GrumPHP/Task/Phpspec.php
@@ -27,13 +27,13 @@ class Phpspec extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'config_file' => null,
             'stop_on_failure' => false,
-        ));
+        ]);
 
-        $resolver->addAllowedTypes('config_file', array('null', 'string'));
-        $resolver->addAllowedTypes('stop_on_failure', array('bool'));
+        $resolver->addAllowedTypes('config_file', ['null', 'string']);
+        $resolver->addAllowedTypes('stop_on_failure', ['bool']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Phpunit.php
+++ b/src/GrumPHP/Task/Phpunit.php
@@ -27,15 +27,15 @@ class Phpunit extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'config_file' => null,
-            'group' => array(),
+            'group' => [],
             'always_execute' => false,
-        ));
+        ]);
 
-        $resolver->addAllowedTypes('config_file', array('null', 'string'));
-        $resolver->addAllowedTypes('group', array('array'));
-        $resolver->addAllowedTypes('always_execute', array('bool'));
+        $resolver->addAllowedTypes('config_file', ['null', 'string']);
+        $resolver->addAllowedTypes('group', ['array']);
+        $resolver->addAllowedTypes('always_execute', ['bool']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Robo.php
+++ b/src/GrumPHP/Task/Robo.php
@@ -27,15 +27,15 @@ class Robo extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'load_from' => null,
             'task' => null,
-            'triggered_by' => array('php')
-        ));
+            'triggered_by' => ['php']
+        ]);
 
-        $resolver->addAllowedTypes('load_from', array('null', 'string'));
-        $resolver->addAllowedTypes('task', array('null', 'string'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
+        $resolver->addAllowedTypes('load_from', ['null', 'string']);
+        $resolver->addAllowedTypes('task', ['null', 'string']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/SecurityChecker.php
+++ b/src/GrumPHP/Task/SecurityChecker.php
@@ -27,19 +27,19 @@ class SecurityChecker extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'lockfile' => './composer.lock',
             'format' => null,
             'end_point' => null,
             'timeout' => null,
             'run_always' => false,
-        ));
+        ]);
 
-        $resolver->addAllowedTypes('lockfile', array('string'));
-        $resolver->addAllowedTypes('format', array('null', 'string'));
-        $resolver->addAllowedTypes('end_point', array('null', 'string'));
-        $resolver->addAllowedTypes('timeout', array('null', 'int'));
-        $resolver->addAllowedTypes('run_always', array('bool'));
+        $resolver->addAllowedTypes('lockfile', ['string']);
+        $resolver->addAllowedTypes('format', ['null', 'string']);
+        $resolver->addAllowedTypes('end_point', ['null', 'string']);
+        $resolver->addAllowedTypes('timeout', ['null', 'int']);
+        $resolver->addAllowedTypes('run_always', ['bool']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/Shell.php
+++ b/src/GrumPHP/Task/Shell.php
@@ -28,13 +28,13 @@ class Shell extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
-            'scripts' => array(),
-            'triggered_by' => array('php')
-        ));
+        $resolver->setDefaults([
+            'scripts' => [],
+            'triggered_by' => ['php']
+        ]);
 
-        $resolver->addAllowedTypes('scripts', array('array'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
+        $resolver->addAllowedTypes('scripts', ['array']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }
@@ -58,7 +58,7 @@ class Shell extends AbstractExternalTask
             return TaskResult::createSkipped($this, $context);
         }
 
-        $exceptions = array();
+        $exceptions = [];
         foreach ($config['scripts'] as $script) {
             try {
                 $this->runShell($script);

--- a/src/GrumPHP/Task/XmlLint.php
+++ b/src/GrumPHP/Task/XmlLint.php
@@ -36,19 +36,19 @@ class XmlLint extends AbstractLinterTask
     public function getConfigurableOptions()
     {
         $resolver = parent::getConfigurableOptions();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'load_from_net' => false,
             'x_include' => false,
             'dtd_validation' => false,
             'scheme_validation' => false,
-            'triggered_by' => array('xml'),
-        ));
+            'triggered_by' => ['xml'],
+        ]);
 
-        $resolver->addAllowedTypes('load_from_net', array('bool'));
-        $resolver->addAllowedTypes('x_include', array('bool'));
-        $resolver->addAllowedTypes('dtd_validation', array('bool'));
-        $resolver->addAllowedTypes('scheme_validation', array('bool'));
-        $resolver->addAllowedTypes('triggered_by', array('array'));
+        $resolver->addAllowedTypes('load_from_net', ['bool']);
+        $resolver->addAllowedTypes('x_include', ['bool']);
+        $resolver->addAllowedTypes('dtd_validation', ['bool']);
+        $resolver->addAllowedTypes('scheme_validation', ['bool']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Task/YamlLint.php
+++ b/src/GrumPHP/Task/YamlLint.php
@@ -36,13 +36,13 @@ class YamlLint extends AbstractLinterTask
     public function getConfigurableOptions()
     {
         $resolver = parent::getConfigurableOptions();
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'object_support' => false,
             'exception_on_invalid_type' => false,
-        ));
+        ]);
 
-        $resolver->addAllowedTypes('object_support', array('bool'));
-        $resolver->addAllowedTypes('exception_on_invalid_type', array('bool'));
+        $resolver->addAllowedTypes('object_support', ['bool']);
+        $resolver->addAllowedTypes('exception_on_invalid_type', ['bool']);
 
         return $resolver;
     }

--- a/src/GrumPHP/Util/Regex.php
+++ b/src/GrumPHP/Util/Regex.php
@@ -50,7 +50,7 @@ class Regex
                 return !preg_match('/[*?[:alnum:] \\\\]/', $start);
             }
 
-            foreach (array(array('{', '}'), array('(', ')'), array('[', ']'), array('<', '>')) as $delimiters) {
+            foreach ([['{', '}'], ['(', ')'], ['[', ']'], ['<', '>']] as $delimiters) {
                 if ($start === $delimiters[0] && $end === $delimiters[1]) {
                     return true;
                 }

--- a/test/src/GrumPHPTest/Linter/Json/JsonLinterTest.php
+++ b/test/src/GrumPHPTest/Linter/Json/JsonLinterTest.php
@@ -72,10 +72,10 @@ class JsonLinterTest extends \PHPUnit_Framework_TestCase
      */
     function provideJsonValidation()
     {
-        return array(
-            array('fixture' => 'valid.json', 'errors' => 0),
-            array('fixture' => 'duplicate-keys.json', 'errors' => 0),
-            array('fixture' => 'invalid.json', 'errors' => 1),
-        );
+        return [
+            ['fixture' => 'valid.json', 'errors' => 0],
+            ['fixture' => 'duplicate-keys.json', 'errors' => 0],
+            ['fixture' => 'invalid.json', 'errors' => 1],
+        ];
     }
 }

--- a/test/src/GrumPHPTest/Linter/Xml/XmlLinterTest.php
+++ b/test/src/GrumPHPTest/Linter/Xml/XmlLinterTest.php
@@ -112,10 +112,10 @@ class XmlLinterTest extends \PHPUnit_Framework_TestCase
      */
     function provideXmlValidation()
     {
-        return array(
-            array('fixture' => 'xml-valid.xml', 'errors' => 0),
-            array('fixture' => 'xml-invalid.xml', 'errors' => 1),
-        );
+        return [
+            ['fixture' => 'xml-valid.xml', 'errors' => 0],
+            ['fixture' => 'xml-invalid.xml', 'errors' => 1],
+        ];
     }
 
     /**
@@ -123,16 +123,16 @@ class XmlLinterTest extends \PHPUnit_Framework_TestCase
      */
     function provideDtdValidation()
     {
-        return array(
-            array('fixture' => 'xml-valid.xml', 'errors' => 0, 'loadFromNet' => false),
-            array('fixture' => 'dtd-internal-valid.xml', 'errors' => 0, 'loadFromNet' => false),
-            array('fixture' => 'dtd-internal-invalid.xml', 'errors' => 1, 'loadFromNet' => false),
-            array('fixture' => 'dtd-external-valid.xml', 'errors' => 0, 'loadFromNet' => false),
-            array('fixture' => 'dtd-external-invalid.xml', 'errors' => 1, 'loadFromNet' => false),
-            array('fixture' => 'dtd-url-valid.xml', 'errors' => 0, 'loadFromNet' => true),
-            array('fixture' => 'dtd-url-invalid.xml', 'errors' => 1, 'loadFromNet' => true),
-            array('fixture' => 'dtd-url-invalid.xml', 'errors' => 0, 'loadFromNet' => false),
-        );
+        return [
+            ['fixture' => 'xml-valid.xml', 'errors' => 0, 'loadFromNet' => false],
+            ['fixture' => 'dtd-internal-valid.xml', 'errors' => 0, 'loadFromNet' => false],
+            ['fixture' => 'dtd-internal-invalid.xml', 'errors' => 1, 'loadFromNet' => false],
+            ['fixture' => 'dtd-external-valid.xml', 'errors' => 0, 'loadFromNet' => false],
+            ['fixture' => 'dtd-external-invalid.xml', 'errors' => 1, 'loadFromNet' => false],
+            ['fixture' => 'dtd-url-valid.xml', 'errors' => 0, 'loadFromNet' => true],
+            ['fixture' => 'dtd-url-invalid.xml', 'errors' => 1, 'loadFromNet' => true],
+            ['fixture' => 'dtd-url-invalid.xml', 'errors' => 0, 'loadFromNet' => false],
+        ];
     }
 
     /**
@@ -140,16 +140,16 @@ class XmlLinterTest extends \PHPUnit_Framework_TestCase
      */
     function provideSchemeValidation()
     {
-        return array(
-            array('fixture' => 'xml-valid.xml', 'errors' => 0, 'loadFromNet' => false),
-            array('fixture' => 'xsd-namespace-valid.xml', 'errors' => 0, 'loadFromNet' => false),
-            array('fixture' => 'xsd-namespace-invalid.xml', 'errors' => 1, 'loadFromNet' => false),
-            array('fixture' => 'xsd-nonamespace-valid.xml', 'errors' => 0, 'loadFromNet' => false),
-            array('fixture' => 'xsd-nonamespace-invalid.xml', 'errors' => 1, 'loadFromNet' => false),
-            array('fixture' => 'xsd-url-valid.xml', 'errors' => 0, 'loadFromNet' => true),
-            array('fixture' => 'xsd-url-invalid.xml', 'errors' => 1, 'loadFromNet' => true),
-            array('fixture' => 'xsd-url-invalid.xml', 'errors' => 0, 'loadFromNet' => false),
-        );
+        return [
+            ['fixture' => 'xml-valid.xml', 'errors' => 0, 'loadFromNet' => false],
+            ['fixture' => 'xsd-namespace-valid.xml', 'errors' => 0, 'loadFromNet' => false],
+            ['fixture' => 'xsd-namespace-invalid.xml', 'errors' => 1, 'loadFromNet' => false],
+            ['fixture' => 'xsd-nonamespace-valid.xml', 'errors' => 0, 'loadFromNet' => false],
+            ['fixture' => 'xsd-nonamespace-invalid.xml', 'errors' => 1, 'loadFromNet' => false],
+            ['fixture' => 'xsd-url-valid.xml', 'errors' => 0, 'loadFromNet' => true],
+            ['fixture' => 'xsd-url-invalid.xml', 'errors' => 1, 'loadFromNet' => true],
+            ['fixture' => 'xsd-url-invalid.xml', 'errors' => 0, 'loadFromNet' => false],
+        ];
     }
 
     /**
@@ -157,10 +157,10 @@ class XmlLinterTest extends \PHPUnit_Framework_TestCase
      */
     function provideDtdAndSchemeValidation()
     {
-        return array(
-            array('fixture' => 'dtd-xsd-valid.xml', 'errors' => 0),
-            array('fixture' => 'dtd-xsd-invalid.xml', 'errors' => 2),
-        );
+        return [
+            ['fixture' => 'dtd-xsd-valid.xml', 'errors' => 0],
+            ['fixture' => 'dtd-xsd-invalid.xml', 'errors' => 2],
+        ];
     }
 
     /**
@@ -168,10 +168,10 @@ class XmlLinterTest extends \PHPUnit_Framework_TestCase
      */
     function provideXincludeValidation()
     {
-        return array(
-            array('fixture' => 'xml-valid.xml', 'errors' => 0),
-            array('fixture' => 'xinclude-valid.xml', 'errors' => 0),
-            array('fixture' => 'xinclude-invalid.xml', 'errors' => 2),
-        );
+        return [
+            ['fixture' => 'xml-valid.xml', 'errors' => 0],
+            ['fixture' => 'xinclude-valid.xml', 'errors' => 0],
+            ['fixture' => 'xinclude-invalid.xml', 'errors' => 2],
+        ];
     }
 }

--- a/test/src/GrumPHPTest/Linter/Yaml/YamlLinterTest.php
+++ b/test/src/GrumPHPTest/Linter/Yaml/YamlLinterTest.php
@@ -85,9 +85,9 @@ class YamlLinterTest extends \PHPUnit_Framework_TestCase
      */
     function provideYamlValidation()
     {
-        return array(
-            array('fixture' => 'valid.yml', 'errors' => 0),
-            array('fixture' => 'invalid.yml', 'errors' => 1),
-        );
+        return [
+            ['fixture' => 'valid.yml', 'errors' => 0],
+            ['fixture' => 'invalid.yml', 'errors' => 1],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes "php 5.3 is unsupported"
| Tests pass?   | yes "./bin/grumphp run" returned all green!
| Documented?   | yes
| Fixed tickets | N/A

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
Removed support for php 5.3 aka Traditional syntax array literal detected inspections are fixed and modified the travis.yml to not check for PHP5.3 and set PHP 5.4 as the new low dependencies. Updated the readme file.