### PR TITLE
Prefer configured bin directoy over global installations

### DIFF
--- a/src/GrumPHP/Locator/ExternalCommand.php
+++ b/src/GrumPHP/Locator/ExternalCommand.php
@@ -44,8 +44,14 @@ class ExternalCommand
      */
     public function locate($command, $forceUnix = false)
     {
-        // Search executable:
-        $executable = $this->executableFinder->find($command, null, [$this->binDir]);
+        
+        // Search executable (prefer local installation over global):
+        if (is_executable($this->binDir . '/' . $command)) {
+            $executable = $this->binDir . '/' . $command;
+        } else {
+            $executable = $this->executableFinder->find($command, null, [$this->binDir]);
+        }
+
         if (!$executable) {
             throw new RuntimeException(
                 sprintf('The executable for "%s" could not be found.', $command)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | -
| Fixed tickets | -

To be able to work on different project with potentially different versions of external tools the configured bin dir is checked first and therefore a project installation of a tool (e.g. per composer) is used if available and the global installed one is just a fallback.
The Symfony `ExecutableFinder` checks for the $PATH first and second the configured bin directory, which causes that a global installed tool was preferred over a project specific version (see https://github.com/symfony/process/blob/master/ExecutableFinder.php#L69).

IMO this was a bug, but I'm happy to hear other arguments too.


Note: I was not sure if this is a change which requires a test as there is just a very basic one for the binary location. If so please give me a short note and I will be happy to try to provide one.