### PR TITLE
Make sure that GrumPHP can be used in a full-blown symfony application.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "doctrine/collections": "~1.2",
         "gitonomy/gitlib": "~1.0",
         "monolog/monolog": "~1.17",
+        "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
         "seld/jsonlint": "~1.1",
         "symfony/config": "~2.7|~3.0",
         "symfony/console": "~2.7|~3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #240 

This ticket adds the `ocramius/proxy-manager` dependency to the composer.json file to make sure tha GrumPHP works with t full `symfony/symfony` projects.
More information about the bug can be found in ticket #240.

