### PR TITLE
Add phpdoc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ parameters:
         phpcs: ~
         phpcsfixer: ~
         phpcsfixer2: ~
+        phpdoc: ~
         phplint: ~
         phpmd: ~
         phpparser: ~

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -32,6 +32,7 @@ parameters:
         phpcs: ~
         phpcsfixer: ~
         phpcsfixer2: ~
+        phpdoc: ~
         phplint: ~
         phpmd: ~
         phpparser: ~
@@ -74,6 +75,7 @@ Every task has it's own default configuration. It is possible to overwrite the p
 - [Phpcs](tasks/phpcs.md)
 - [PHP-CS-Fixer](tasks/php_cs_fixer.md)
 - [PHP-CS-Fixer 2](tasks/php_cs_fixer2.md)
+- [Phpdoc](tasks/phpdoc.md)
 - [PHPLint](tasks/phplint.md)
 - [PhpMd](tasks/phpmd.md)
 - [PhpParser](tasks/phpparser.md)

--- a/doc/tasks/phpdoc.md
+++ b/doc/tasks/phpdoc.md
@@ -1,0 +1,191 @@
+# Phpdoc
+
+Phpdoc is the world standard auto-documentation tool for PHP. Written in PHP, phpdoc can be used directly from the command-line. 
+It lives under the `phpdoc` namespace and has following configurable parameters:
+
+```yaml
+# grumphp.yml
+parameters:
+    tasks:
+        phpdoc:
+          config_file: ~
+          target_folder: ~
+          cache_folder: ~
+          filename: ~
+          directory: ~
+          encoding: ~
+          extensions: ~
+          ignore: ~
+          ignore_tags: ~
+          ignore_symlinks: ~
+          markers: ~
+          title: ~
+          force: ~
+          visibility: ~
+          default_package_name: ~
+          source_code: ~
+          progress_bar: ~
+          template: ~
+          quiet: ~
+          ansi: ~
+          no_ansi: ~
+          no_interaction: ~
+```
+
+**config_file**
+
+*Default: `null`*
+
+Without config_file parameter phpdoc will search for a phpdoc.dist.xml config file. 
+This file can be overload by phpdoc.xml.
+If no file found, no config file will be used.
+
+
+**target_folder**
+
+*Default: `null`*
+
+Without this parameter the doc will be generated in an `output/` folder.
+
+
+**cache_folder**
+
+*Default: `null`*
+
+Without this parameter, cache will be placed in the `target_folder`.
+
+
+**filename**
+
+*Default: `null`*
+
+Comma separated file list to documents.
+
+
+**directory**
+
+*Default: `null`*
+
+Comma separated directory list to documents.
+
+
+**encoding**
+
+*Default: `null`*
+
+Without this parameter, encoding will be `'UTF-8'`.
+
+
+**extensions**
+
+*Default: `null`*
+
+Comma separated file extension list. Contains extension of file to parse.
+Without this parameter, parsed file are :
+* php
+* php3
+* phtml
+
+**ignore**
+
+*Default: `null`*
+
+Comma separated list of paths to skip when parsing.
+
+**ignore_tags**
+
+*Default: `null`*
+
+Comma separated list of tags to skip when parsing.
+
+
+**ignore_symlinks**
+
+*Default: `false`*
+
+Tells the parser not to follow symlinks.
+
+
+**markers**
+
+*Default: `null`*
+
+Provide a comma-separated list of markers to parse (TODO ...).
+
+
+**title**
+
+*Default: `null`*
+
+Specify a title for the documentation.
+
+
+**force**
+
+*Default: `null`*
+
+Ignore exceptions and continue parsing.
+
+
+**visibility**
+
+*Default: `null`*
+
+Provide a comma-separated list of visibility scopes to parse.
+This parameter may be used to tell phpDocumentor to only parse public properties and methods, or public and protected.
+
+
+**default_package_name**
+
+*Default: `null`*
+
+Default package name
+
+
+**source_code**
+
+*Default: `null`*
+
+When this parameter is provided the parser will add a compressed, base64-encoded version of the parsed file’s source as child element of the <file> element. 
+This information can then be picked up by the transformer to generate a syntax highlighted view of the file’s source code and even have direct links to specific lines.
+
+
+**progress_bar**
+
+*Default: `null`*
+
+Display progress bar during the process.
+
+
+**template**
+
+*Default: `null`*
+
+Specify a template to use. Without this parameter the template named "clean" will be used.
+
+**quiet**
+
+*Default: `null`*
+
+With this option, only errors will be displayed.
+
+
+**ansi**
+
+*Default: `null`*
+
+Force ANSI output.
+
+
+**no_ansi**
+
+*Default: `null`*
+
+Disable ANSI output.
+
+
+**no_interaction**
+
+*Default: `null`*
+
+Do not ask any interactive question.

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -214,6 +214,15 @@ services:
         tags:
           - {name: grumphp.task, config: phpcsfixer2}
 
+    task.phpdoc:
+            class: GrumPHP\Task\Phpdoc
+            arguments:
+                - '@config'
+                - '@process_builder'
+                - '@formatter.raw_process'
+            tags:
+                - {name: grumphp.task, config: phpdoc}
+
     task.phplint:
         class: GrumPHP\Task\PhpLint
         arguments:

--- a/spec/GrumPHP/Task/PhpdocSpec.php
+++ b/spec/GrumPHP/Task/PhpdocSpec.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace spec\GrumPHP\Task;
+
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
+use GrumPHP\Process\ProcessBuilder;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\Phpdoc;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Process\Process;
+
+/**
+ * Class PhpdocSpec
+ */
+class PhpdocSpec extends ObjectBehavior
+{
+
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
+    {
+        $grumPHP->getTaskConfiguration('phpdoc')->willReturn([]);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(Phpdoc::class);
+    }
+
+    function it_should_have_a_name()
+    {
+        $this->getName()->shouldBe('phpdoc');
+    }
+
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf(OptionsResolver::class);
+        $options->getDefinedOptions()->shouldContain('config_file');
+        $options->getDefinedOptions()->shouldContain('target_folder');
+        $options->getDefinedOptions()->shouldContain('cache_folder');
+        $options->getDefinedOptions()->shouldContain('filename');
+        $options->getDefinedOptions()->shouldContain('directory');
+        $options->getDefinedOptions()->shouldContain('encoding');
+        $options->getDefinedOptions()->shouldContain('extensions');
+        $options->getDefinedOptions()->shouldContain('ignore');
+        $options->getDefinedOptions()->shouldContain('ignore_tags');
+        $options->getDefinedOptions()->shouldContain('ignore_symlinks');
+        $options->getDefinedOptions()->shouldContain('markers');
+        $options->getDefinedOptions()->shouldContain('title');
+        $options->getDefinedOptions()->shouldContain('force');
+        $options->getDefinedOptions()->shouldContain('visibility');
+        $options->getDefinedOptions()->shouldContain('default_package_name');
+        $options->getDefinedOptions()->shouldContain('source_code');
+        $options->getDefinedOptions()->shouldContain('progress_bar');
+        $options->getDefinedOptions()->shouldContain('template');
+        $options->getDefinedOptions()->shouldContain('quiet');
+        $options->getDefinedOptions()->shouldContain('ansi');
+        $options->getDefinedOptions()->shouldContain('no_ansi');
+        $options->getDefinedOptions()->shouldContain('no_interaction');
+    }
+
+    function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_run_in_run_context(RunContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder, ContextInterface $context)
+    {
+        $processBuilder->buildProcess('phpdoc')->shouldNotBeCalled();
+        $processBuilder->buildProcess()->shouldNotBeCalled();
+        $context->getFiles()->willReturn(new FilesCollection());
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->getResultCode()->shouldBe(TaskResult::SKIPPED);
+    }
+
+    function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
+    {
+        $arguments = new ProcessArgumentsCollection();
+        $processBuilder->createArgumentsForCommand('phpdoc')->willReturn($arguments);
+        $processBuilder->buildProcess($arguments)->willReturn($process);
+
+        $process->run()->shouldBeCalled();
+        $process->isSuccessful()->willReturn(true);
+
+        $context->getFiles()->willReturn(new FilesCollection([
+            new SplFileInfo('test.php', '.', 'test.php')
+        ]));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_throws_exception_if_the_process_fails(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
+    {
+        $arguments = new ProcessArgumentsCollection();
+        $processBuilder->createArgumentsForCommand('phpdoc')->willReturn($arguments);
+        $processBuilder->buildProcess($arguments)->willReturn($process);
+
+        $process->run()->shouldBeCalled();
+        $process->isSuccessful()->willReturn(false);
+
+        $context->getFiles()->willReturn(new FilesCollection([
+            new SplFileInfo('test.php', '.', 'test.php')
+        ]));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+}

--- a/src/GrumPHP/Task/Phpdoc.php
+++ b/src/GrumPHP/Task/Phpdoc.php
@@ -126,7 +126,6 @@ class Phpdoc extends AbstractExternalTask
         $process->run();
 
         if ($process->isSuccessful() && !$process->isRunning() && $context instanceof GitPreCommitContext) {
-
             $argumentsGit = $this->processBuilder->createArgumentsForCommand('git');
             $argumentsGit->addOptionalArgumentWithSeparatedValue('add', $config['target_folder'] . '*');
 
@@ -137,4 +136,3 @@ class Phpdoc extends AbstractExternalTask
         return TaskResult::createPassed($this, $context);
     }
 }
-

--- a/src/GrumPHP/Task/Phpdoc.php
+++ b/src/GrumPHP/Task/Phpdoc.php
@@ -144,6 +144,8 @@ class Phpdoc extends AbstractExternalTask
             } elseif (file_exists('phpdoc.dist.xml')) {
                 $xmlElement = new SimpleXMLElement(file_get_contents('phpdoc.dist.xml'));
                 $trueTargetFolder = $xmlElement->transformer->target;
+            } else {
+                $trueTargetFolder = 'output';
             }
 
             $argumentsGit = $this->processBuilder->createArgumentsForCommand('git');

--- a/src/GrumPHP/Task/Phpdoc.php
+++ b/src/GrumPHP/Task/Phpdoc.php
@@ -28,7 +28,8 @@ class Phpdoc extends AbstractExternalTask
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults([
+        $resolver->setDefaults(
+            [
             'config_file' => null,
             'target_folder' => null,
             'cache_folder' => null,
@@ -50,8 +51,8 @@ class Phpdoc extends AbstractExternalTask
             'quiet' => null,
             'ansi' => null,
             'no_ansi' => null,
-            'no_interaction' => null,
-        ]);
+            'no_interaction' => null]
+        );
 
         $resolver->addAllowedTypes('config_file', ['null', 'string']);
         $resolver->addAllowedTypes('target_folder', ['null', 'string']);
@@ -133,19 +134,27 @@ class Phpdoc extends AbstractExternalTask
         $trueTargetFolder = null;
 
         if ($process->isSuccessful() && $context instanceof GitPreCommitContext) {
-            if (($config['target_folder'])) {
-                $trueTargetFolder = $config['target_folder'];
-            } elseif ($config['config_file'] && file_exists($config['config_file'])) {
-                $xmlElement = new SimpleXMLElement(file_get_contents($config['config_file']));
-                $trueTargetFolder = $xmlElement->transformer->target;
-            } elseif (file_exists('phpdoc.xml')) {
-                $xmlElement = new SimpleXMLElement(file_get_contents('phpdoc.xml'));
-                $trueTargetFolder = $xmlElement->transformer->target;
-            } elseif (file_exists('phpdoc.dist.xml')) {
+            if (file_exists('phpdoc.dist.xml')) {
                 $xmlElement = new SimpleXMLElement(file_get_contents('phpdoc.dist.xml'));
                 $trueTargetFolder = $xmlElement->transformer->target;
-            } else {
-                $trueTargetFolder = 'output';
+            }
+
+            if (file_exists('phpdoc.xml')) {
+                $xmlElement = new SimpleXMLElement(file_get_contents('phpdoc.xml'));
+                $trueTargetFolder = $xmlElement->transformer->target;
+            }
+
+            if ($config['config_file'] && file_exists($config['config_file'])) {
+                $xmlElement = new SimpleXMLElement(file_get_contents($config['config_file']));
+                $trueTargetFolder = $xmlElement->transformer->target;
+            }
+
+            if (($config['target_folder'])) {
+                $trueTargetFolder = $config['target_folder'];
+            }
+
+            if (!file_exists('phpdoc.dist.xml') && !file_exists('phpdoc.xml') &&  !$config['config_file'] && !$config['target_folder']) {
+                 $trueTargetFolder = 'output';
             }
 
             $argumentsGit = $this->processBuilder->createArgumentsForCommand('git');

--- a/src/GrumPHP/Task/Phpdoc.php
+++ b/src/GrumPHP/Task/Phpdoc.php
@@ -153,9 +153,9 @@ class Phpdoc extends AbstractExternalTask
                 $trueTargetFolder = $config['target_folder'];
             }
 
-            if (!file_exists('phpdoc.dist.xml') 
-                && !file_exists('phpdoc.xml') 
-                && !$config['config_file'] 
+            if (!file_exists('phpdoc.dist.xml')
+                && !file_exists('phpdoc.xml')
+                && !$config['config_file']
                 && !$config['target_folder']
             ) {
                  $trueTargetFolder = 'output';

--- a/src/GrumPHP/Task/Phpdoc.php
+++ b/src/GrumPHP/Task/Phpdoc.php
@@ -153,7 +153,11 @@ class Phpdoc extends AbstractExternalTask
                 $trueTargetFolder = $config['target_folder'];
             }
 
-            if (!file_exists('phpdoc.dist.xml') && !file_exists('phpdoc.xml') &&  !$config['config_file'] && !$config['target_folder']) {
+            if (!file_exists('phpdoc.dist.xml') 
+                && !file_exists('phpdoc.xml') 
+                && !$config['config_file'] 
+                && !$config['target_folder']
+            ) {
                  $trueTargetFolder = 'output';
             }
 

--- a/src/GrumPHP/Task/Phpdoc.php
+++ b/src/GrumPHP/Task/Phpdoc.php
@@ -125,6 +125,10 @@ class Phpdoc extends AbstractExternalTask
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();
 
+        if (!$process->isSuccessful()) {
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
+        }
+
         if ($process->isSuccessful() && $context instanceof GitPreCommitContext) {
             $argumentsGit = $this->processBuilder->createArgumentsForCommand('git');
             $argumentsGit->addOptionalArgumentWithSeparatedValue('add', $config['target_folder'] . '*');

--- a/src/GrumPHP/Task/Phpdoc.php
+++ b/src/GrumPHP/Task/Phpdoc.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace GrumPHP\Task;
+
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Phpdoc task
+ */
+class Phpdoc extends AbstractExternalTask
+{
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'phpdoc';
+    }
+
+    /**
+     * @return OptionsResolver
+     */
+    public function getConfigurableOptions()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'config_file' => null,
+            'target_folder' => "doc/",
+            'cache_folder' => null,
+            'filename' => null,
+            'directory' => "src/",
+            'encoding' => null,
+            'extensions' => null,
+            'ignore' => null,
+            'ignore_tags' => null,
+            'ignore_symlinks' => null,
+            'markers' => null,
+            'title' => null,
+            'force' => null,
+            'visibility' => null,
+            'default_package_name' => null,
+            'source_code' => null,
+            'progress_bar' => null,
+            'template' => null,
+            'quiet' => null,
+            'ansi' => null,
+            'no_ansi' => null,
+            'no_interaction' => null,
+        ]);
+
+        $resolver->addAllowedTypes('config_file', ['null', 'string']);
+        $resolver->addAllowedTypes('target_folder', ['null', 'string']);
+        $resolver->addAllowedTypes('cache_folder', ['null', 'string']);
+        $resolver->addAllowedTypes('filename', ['null', 'string']);
+        $resolver->addAllowedTypes('directory', ['null', 'string']);
+        $resolver->addAllowedTypes('encoding', ['null', 'string']);
+        $resolver->addAllowedTypes('extensions', ['null', 'string']);
+        $resolver->addAllowedTypes('ignore', ['null', 'string']);
+        $resolver->addAllowedTypes('ignore_tags', ['null', 'string']);
+        $resolver->addAllowedTypes('ignore_symlinks', ['null', 'string']);
+        $resolver->addAllowedTypes('markers', ['null', 'string']);
+        $resolver->addAllowedTypes('title', ['null', 'string']);
+        $resolver->addAllowedTypes('force', ['null', 'bool']);
+        $resolver->addAllowedTypes('visibility', ['null', 'string']);
+        $resolver->addAllowedTypes('default_package_name', ['null', 'string']);
+        $resolver->addAllowedTypes('source_code', ['null', 'bool']);
+        $resolver->addAllowedTypes('progress_bar', ['null', 'bool']);
+        $resolver->addAllowedTypes('template', ['null', 'string']);
+        $resolver->addAllowedTypes('quiet', ['null', 'bool']);
+        $resolver->addAllowedTypes('ansi', ['null', 'bool']);
+        $resolver->addAllowedTypes('no_ansi', ['null', 'bool']);
+        $resolver->addAllowedTypes('no_interaction', ['null', 'bool']);
+
+        return $resolver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canRunInContext(ContextInterface $context)
+    {
+        return ($context instanceof GitPreCommitContext || $context instanceof RunContext);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(ContextInterface $context)
+    {
+        $files = $context->getFiles()->name('*.php');
+        if (0 === count($files)) {
+            return TaskResult::createSkipped($this, $context);
+        }
+
+        $config = $this->getConfiguration();
+
+        $arguments = $this->processBuilder->createArgumentsForCommand('phpdoc');
+        $arguments->addOptionalArgumentWithSeparatedValue('--configuration', $config['config_file']);
+        $arguments->addOptionalArgumentWithSeparatedValue('--target', $config['target_folder']);
+        $arguments->addOptionalArgumentWithSeparatedValue('--cache-folder', $config['cache_folder']);
+        $arguments->addOptionalArgumentWithSeparatedValue('--filename', $config['filename']);
+        $arguments->addOptionalArgumentWithSeparatedValue('--directory', $config['directory']);
+        $arguments->addOptionalArgumentWithSeparatedValue('--encoding', $config['encoding']);
+        $arguments->addOptionalArgumentWithSeparatedValue('--extensions', $config['extensions']);
+        $arguments->addOptionalArgumentWithSeparatedValue('--ignore', $config['ignore']);
+        $arguments->addOptionalArgumentWithSeparatedValue('--ignore-tags', $config['ignore_tags']);
+        $arguments->addOptionalArgument('--ignore-symlinks', $config['ignore_symlinks']);
+        $arguments->addOptionalArgumentWithSeparatedValue('--markers', $config['markers']);
+        $arguments->addOptionalArgumentWithSeparatedValue('--title', $config['title']);
+        $arguments->addOptionalArgument('--force', $config['force']);
+        $arguments->addOptionalArgumentWithSeparatedValue('--visibility', $config['visibility']);
+        $arguments->addOptionalArgumentWithSeparatedValue('--defaultpackagename', $config['default_package_name']);
+        $arguments->addOptionalArgument('--sourcecode', $config['source_code']);
+        $arguments->addOptionalArgument('--progressbar', $config['progress_bar']);
+        $arguments->addOptionalArgumentWithSeparatedValue('--template', $config['template']);
+        $arguments->addOptionalArgument('--quiet', $config['progress_bar']);
+        $arguments->addOptionalArgument('--ansi', $config['progress_bar']);
+        $arguments->addOptionalArgument('--no-ansi', $config['progress_bar']);
+        $arguments->addOptionalArgument('--no-interaction', $config['progress_bar']);
+
+        $process = $this->processBuilder->buildProcess($arguments);
+        $process->run();
+
+        if ($process->isSuccessful() && !$process->isRunning() && $context instanceof GitPreCommitContext) {
+
+            $argumentsGit = $this->processBuilder->createArgumentsForCommand('git');
+            $argumentsGit->addOptionalArgumentWithSeparatedValue('add', $config['target_folder'] . '*');
+
+            $processGit = $this->processBuilder->buildProcess($argumentsGit);
+            $processGit->run();
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}
+

--- a/src/GrumPHP/Task/Phpdoc.php
+++ b/src/GrumPHP/Task/Phpdoc.php
@@ -125,7 +125,7 @@ class Phpdoc extends AbstractExternalTask
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();
 
-        if ($process->isSuccessful() && !$process->isRunning() && $context instanceof GitPreCommitContext) {
+        if ($process->isSuccessful() && $context instanceof GitPreCommitContext) {
             $argumentsGit = $this->processBuilder->createArgumentsForCommand('git');
             $argumentsGit->addOptionalArgumentWithSeparatedValue('add', $config['target_folder'] . '*');
 

--- a/src/GrumPHP/Task/Phpdoc.php
+++ b/src/GrumPHP/Task/Phpdoc.php
@@ -135,6 +135,10 @@ class Phpdoc extends AbstractExternalTask
 
             $processGit = $this->processBuilder->buildProcess($argumentsGit);
             $processGit->run();
+
+            if (!$processGit->isSuccessful()) {
+                return TaskResult::createFailed($this, $context, $this->formatter->format($processGit));
+            }
         }
 
         return TaskResult::createPassed($this, $context);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | 

Added support for Phpdoc. It allowed to generate Phpdoc in pre-commit but also in run context.
When running in pre-commit context, generated doc is added to staging area right before commit.

# New Task Checklist:

- [x] Is the README.md file updated?
- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpspec tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?