### PR TITLE
Removed redundant hook exit code

### DIFF
--- a/resources/hooks/local/commit-msg
+++ b/resources/hooks/local/commit-msg
@@ -14,12 +14,3 @@ DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
 
 # Run GrumPHP
 (cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | exec $(HOOK_COMMAND) "--git-user=$GIT_USER" "--git-email=$GIT_EMAIL" "$COMMIT_MSG_FILE")
-
-# Validate exit code of above command
-RC=$?
-if [ "$RC" != 0 ]; then
-  exit $RC;
-fi
-
-# Clean exit:
-exit 0;

--- a/resources/hooks/local/pre-commit
+++ b/resources/hooks/local/pre-commit
@@ -10,12 +10,3 @@ DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
 
 # Run GrumPHP
 (cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | exec $(HOOK_COMMAND) '--skip-success-output')
-
-# Validate exit code of above command
-RC=$?
-if [ "$RC" != 0 ]; then
-  exit $RC;
-fi
-
-# Clean exit:
-exit 0;

--- a/resources/hooks/vagrant/commit-msg
+++ b/resources/hooks/vagrant/commit-msg
@@ -37,12 +37,3 @@ vagrant ssh --command '$(which sh)' << COMMANDS
   rm \$VAGRANT_COMMIT_MSG_FILE
   exit \$RC
 COMMANDS
-
-# Validate exit code of above command
-RC=$?
-if [ "$RC" != 0 ]; then
-  exit $RC;
-fi
-
-# Clean exit:
-exit 0;

--- a/resources/hooks/vagrant/pre-commit
+++ b/resources/hooks/vagrant/pre-commit
@@ -19,12 +19,3 @@ vagrant ssh --command '$(which sh)' << COMMANDS
 
   printf "%s\n" "\${DIFF}" | exec $(HOOK_COMMAND) '--ansi' '--skip-success-output'
 COMMANDS
-
-# Validate exit code of above command
-RC=$?
-if [ "$RC" != 0 ]; then
-  exit $RC;
-fi
-
-# Clean exit:
-exit 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | Check Travis
| Documented?   | n/a
| Fixed tickets | n/a

The removed code is the functionally equivalent to `exit $?`. However, this construct is *also* redundant because, according to the documentation, the exit status automatically inherits the status of the last command. Ergo, the entire code is useless.

```
exit: exit [n]
    Exit the shell.

    Exits the shell with a status of N.  If N is omitted, the exit status
    is that of the last command executed.
```