### PR TITLE
Removed class name duplicated into comments and package annotations.

### DIFF
--- a/.phpspec/specification.tpl
+++ b/.phpspec/specification.tpl
@@ -6,9 +6,6 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use %subject%;
 
-/**
- * Class %name%
- */
 class %name% extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Collection/FilesCollectionSpec.php
+++ b/spec/GrumPHP/Collection/FilesCollectionSpec.php
@@ -8,9 +8,6 @@ use GrumPHP\Collection\FilesCollection;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Finder\SplFileInfo;
 
-/**
- * Class FilesCollectionSpec
- */
 class FilesCollectionSpec extends ObjectBehavior
 {
     /**

--- a/spec/GrumPHP/Collection/LintErrorsCollectionSpec.php
+++ b/spec/GrumPHP/Collection/LintErrorsCollectionSpec.php
@@ -7,9 +7,6 @@ use GrumPHP\Collection\LintErrorsCollection;
 use GrumPHP\Linter\LintError;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class LintErrorsCollectionSpec
- */
 class LintErrorsCollectionSpec extends ObjectBehavior
 {
     function let()

--- a/spec/GrumPHP/Collection/ParseErrorsCollectionSpec.php
+++ b/spec/GrumPHP/Collection/ParseErrorsCollectionSpec.php
@@ -7,9 +7,6 @@ use GrumPHP\Collection\ParseErrorsCollection;
 use GrumPHP\Parser\ParseError;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class ParseErrorsCollectionSpec
- */
 class ParseErrorsCollectionSpec extends ObjectBehavior
 {
     function let()

--- a/spec/GrumPHP/Collection/ProcessArgumentsCollectionSpec.php
+++ b/spec/GrumPHP/Collection/ProcessArgumentsCollectionSpec.php
@@ -8,9 +8,6 @@ use GrumPHP\Exception\InvalidArgumentException;
 use PhpSpec\ObjectBehavior;
 use SplFileInfo;
 
-/**
- * Class ProcessArgumentsCollectionSpec
- */
 class ProcessArgumentsCollectionSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Collection/TaskResultCollectionSpec.php
+++ b/spec/GrumPHP/Collection/TaskResultCollectionSpec.php
@@ -8,9 +8,6 @@ use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class TaskResultCollectionSpec
- */
 class TaskResultCollectionSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Collection/TasksCollectionSpec.php
+++ b/spec/GrumPHP/Collection/TasksCollectionSpec.php
@@ -10,9 +10,6 @@ use GrumPHP\Task\TaskInterface;
 use GrumPHP\TestSuite\TestSuiteInterface;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class TasksCollectionSpec
- */
 class TasksCollectionSpec extends ObjectBehavior
 {
     public function let(TaskInterface $task1, TaskInterface $task2)

--- a/spec/GrumPHP/Collection/TestSuiteCollectionSpec.php
+++ b/spec/GrumPHP/Collection/TestSuiteCollectionSpec.php
@@ -8,9 +8,6 @@ use GrumPHP\Task\TaskInterface;
 use GrumPHP\TestSuite\TestSuiteInterface;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class TestSuiteCollectionSpec
- */
 class TestSuiteCollectionSpec extends ObjectBehavior
 {
     public function let(TestSuiteInterface $testSuite1, TaskInterface $testSuite2)

--- a/spec/GrumPHP/Composer/GrumPHPPluginSpec.php
+++ b/spec/GrumPHP/Composer/GrumPHPPluginSpec.php
@@ -7,9 +7,6 @@ use Composer\Plugin\PluginInterface;
 use GrumPHP\Composer\GrumPHPPlugin;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class GrumPHPPluginSpec
- */
 class GrumPHPPluginSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Configuration/GrumPHPSpec.php
+++ b/spec/GrumPHP/Configuration/GrumPHPSpec.php
@@ -8,9 +8,6 @@ use GrumPHP\Exception\RuntimeException;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-/**
- * Class GrumPHPSpec
- */
 class GrumPHPSpec extends ObjectBehavior
 {
     function let(ContainerInterface $container)

--- a/spec/GrumPHP/Console/Helper/ComposerHelperSpec.php
+++ b/spec/GrumPHP/Console/Helper/ComposerHelperSpec.php
@@ -8,9 +8,6 @@ use GrumPHP\Console\Helper\ComposerHelper;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Console\Helper\Helper;
 
-/**
- * Class ComposerHelperSpec
- */
 class ComposerHelperSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Console/Helper/PathsHelperSpec.php
+++ b/spec/GrumPHP/Console/Helper/PathsHelperSpec.php
@@ -11,16 +11,13 @@ use Symfony\Component\Console\Helper\Helper;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
-/**
- * Class PathsHelperSpec
- */
 class PathsHelperSpec extends ObjectBehavior
 {
     function let(GrumPHP $config, Filesystem $filesystem, ExternalCommand $externalCommandLocator)
     {
         $this->beConstructedWith($config, $filesystem, $externalCommandLocator, '/grumphp.yml');
     }
-    
+
     function it_is_a_console_helper()
     {
         $this->shouldHaveType(Helper::class);

--- a/spec/GrumPHP/Console/Helper/TaskRunnerHelperSpec.php
+++ b/spec/GrumPHP/Console/Helper/TaskRunnerHelperSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
-/**
- * Class TaskRunnerHelperSpec
- */
 class TaskRunnerHelperSpec extends ObjectBehavior
 {
     function let(

--- a/spec/GrumPHP/Event/RunnerEventSpec.php
+++ b/spec/GrumPHP/Event/RunnerEventSpec.php
@@ -9,9 +9,6 @@ use GrumPHP\Task\Context\ContextInterface;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\EventDispatcher\Event;
 
-/**
- * Class RunnerEventSpec
- */
 class RunnerEventSpec extends ObjectBehavior
 {
     function let(TasksCollection $tasks, ContextInterface $context, TaskResultCollection $taskResults)

--- a/spec/GrumPHP/Event/RunnerFailedEventSpec.php
+++ b/spec/GrumPHP/Event/RunnerFailedEventSpec.php
@@ -10,9 +10,6 @@ use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class RunnerFailedEventSpec
- */
 class RunnerFailedEventSpec extends ObjectBehavior
 {
     function let(TasksCollection $tasks, ContextInterface $context, TaskResultCollection $taskResults)

--- a/spec/GrumPHP/Event/Subscriber/ProgressSubscriberSpec.php
+++ b/spec/GrumPHP/Event/Subscriber/ProgressSubscriberSpec.php
@@ -13,9 +13,6 @@ use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-/**
- * Class ProgressSubscriberSpec
- */
 class ProgressSubscriberSpec extends ObjectBehavior
 {
     function let(OutputInterface $output, ProgressBar $progressBar)

--- a/spec/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriberSpec.php
+++ b/spec/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriberSpec.php
@@ -19,9 +19,6 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-/**
- * Class StashUnstagedChangesSubscriberSpec
- */
 class StashUnstagedChangesSubscriberSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, Repository $repository, IOInterface $io, WorkingCopy $workingCopy, Diff $unstaged)

--- a/spec/GrumPHP/Event/TaskEventSpec.php
+++ b/spec/GrumPHP/Event/TaskEventSpec.php
@@ -8,9 +8,6 @@ use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\EventDispatcher\Event;
 
-/**
- * Class TaskEventSpec
- */
 class TaskEventSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Event/TaskFailedEventSpec.php
+++ b/spec/GrumPHP/Event/TaskFailedEventSpec.php
@@ -9,9 +9,6 @@ use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class TaskFailedEventSpec
- */
 class TaskFailedEventSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Exception/InvalidArgumentExceptionSpec.php
+++ b/spec/GrumPHP/Exception/InvalidArgumentExceptionSpec.php
@@ -6,9 +6,6 @@ use GrumPHP\Exception\RuntimeException;
 use PhpSpec\ObjectBehavior;
 use GrumPHP\Exception\InvalidArgumentException;
 
-/**
- * Class InvalidArgumentExceptionSpec
- */
 class InvalidArgumentExceptionSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Formatter/GitBlacklistFormatterSpec.php
+++ b/spec/GrumPHP/Formatter/GitBlacklistFormatterSpec.php
@@ -8,9 +8,6 @@ use GrumPHP\IO\ConsoleIO;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Process\Process;
 
-/**
- * Class GitBlacklistFormatterSpec
- */
 class GitBlacklistFormatterSpec extends ObjectBehavior
 {
     function let(ConsoleIO $consoleIO)

--- a/spec/GrumPHP/Formatter/PhpCsFixerFormatterSpec.php
+++ b/spec/GrumPHP/Formatter/PhpCsFixerFormatterSpec.php
@@ -8,9 +8,6 @@ use PhpSpec\ObjectBehavior;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessUtils;
 
-/**
- * Class PhpCsFixerFormatterSpec
- */
 class PhpCsFixerFormatterSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Formatter/PhpcsFormatterSpec.php
+++ b/spec/GrumPHP/Formatter/PhpcsFormatterSpec.php
@@ -9,9 +9,6 @@ use GrumPHP\Process\ProcessBuilder;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Process\Process;
 
-/**
- * Class PhpcsFormatterSpec
- */
 class PhpcsFormatterSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Formatter/RawProcessFormatterSpec.php
+++ b/spec/GrumPHP/Formatter/RawProcessFormatterSpec.php
@@ -7,9 +7,6 @@ use GrumPHP\Formatter\RawProcessFormatter;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Process\Process;
 
-/**
- * Class RawProcessFormatterSpec
- */
 class RawProcessFormatterSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/IO/ConsoleIOSpec.php
+++ b/spec/GrumPHP/IO/ConsoleIOSpec.php
@@ -10,9 +10,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * Class ConsoleIOSpec
- */
 class ConsoleIOSpec extends ObjectBehavior
 {
     function let(InputInterface $input, OutputInterface $output)

--- a/spec/GrumPHP/IO/NullIOSpec.php
+++ b/spec/GrumPHP/IO/NullIOSpec.php
@@ -6,9 +6,6 @@ use GrumPHP\IO\IOInterface;
 use GrumPHP\IO\NullIO;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class NullIOSpec
- */
 class NullIOSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Linter/Json/JsonLintErrorSpec.php
+++ b/spec/GrumPHP/Linter/Json/JsonLintErrorSpec.php
@@ -6,9 +6,6 @@ use GrumPHP\Linter\Json\JsonLintError;
 use GrumPHP\Linter\LintError;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class JsonLintErrorSpec
- */
 class JsonLintErrorSpec extends ObjectBehavior
 {
     function let()

--- a/spec/GrumPHP/Linter/Json/JsonLinterSpec.php
+++ b/spec/GrumPHP/Linter/Json/JsonLinterSpec.php
@@ -8,9 +8,6 @@ use GrumPHP\Util\Filesystem;
 use PhpSpec\ObjectBehavior;
 use Seld\JsonLint\JsonParser;
 
-/**
- * Class JsonLinterSpec
- */
 class JsonLinterSpec extends ObjectBehavior
 {
     function let(Filesystem $filesystem, JsonParser $jsonParser)

--- a/spec/GrumPHP/Linter/LintErrorSpec.php
+++ b/spec/GrumPHP/Linter/LintErrorSpec.php
@@ -5,9 +5,6 @@ namespace spec\GrumPHP\Linter;
 use GrumPHP\Linter\LintError;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class LintErrorSpec
- */
 class LintErrorSpec extends ObjectBehavior
 {
     function let()

--- a/spec/GrumPHP/Linter/Xml/XmlLintErrorSpec.php
+++ b/spec/GrumPHP/Linter/Xml/XmlLintErrorSpec.php
@@ -6,9 +6,6 @@ use GrumPHP\Linter\LintError;
 use GrumPHP\Linter\Xml\XmlLintError;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class XmlLintErrorSpec
- */
 class XmlLintErrorSpec extends ObjectBehavior
 {
     function let()

--- a/spec/GrumPHP/Linter/Xml/XmlLinterSpec.php
+++ b/spec/GrumPHP/Linter/Xml/XmlLinterSpec.php
@@ -6,9 +6,6 @@ use GrumPHP\Linter\LinterInterface;
 use GrumPHP\Linter\Xml\XmlLinter;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class XmlLinterSpec
- */
 class XmlLinterSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Linter/Yaml/YamlLintErrorSpec.php
+++ b/spec/GrumPHP/Linter/Yaml/YamlLintErrorSpec.php
@@ -6,9 +6,6 @@ use GrumPHP\Linter\LintError;
 use GrumPHP\Linter\Yaml\YamlLintError;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class YamlLintErrorSpec
- */
 class YamlLintErrorSpec extends ObjectBehavior
 {
     function let()

--- a/spec/GrumPHP/Linter/Yaml/YamlLinterSpec.php
+++ b/spec/GrumPHP/Linter/Yaml/YamlLinterSpec.php
@@ -7,9 +7,6 @@ use GrumPHP\Linter\Yaml\YamlLinter;
 use GrumPHP\Util\Filesystem;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class YamlLinterSpec
- */
 class YamlLinterSpec extends ObjectBehavior
 {
     function let(Filesystem $filesystem)

--- a/spec/GrumPHP/Locator/ChangedFilesSpec.php
+++ b/spec/GrumPHP/Locator/ChangedFilesSpec.php
@@ -12,9 +12,6 @@ use GrumPHP\Util\Filesystem;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Prophet;
 
-/**
- * Class ChangedFilesSpec
- */
 class ChangedFilesSpec extends ObjectBehavior
 {
     function let(Repository $repository, Filesystem $filesystem)

--- a/spec/GrumPHP/Locator/ConfigurationFileSpec.php
+++ b/spec/GrumPHP/Locator/ConfigurationFileSpec.php
@@ -8,9 +8,6 @@ use GrumPHP\Util\Filesystem;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
-/**
- * Class ConfigurationFileSpec
- */
 class ConfigurationFileSpec extends ObjectBehavior
 {
     function let(Filesystem $filesystem)

--- a/spec/GrumPHP/Locator/ExternalCommandSpec.php
+++ b/spec/GrumPHP/Locator/ExternalCommandSpec.php
@@ -7,9 +7,6 @@ use GrumPHP\Locator\ExternalCommand;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Process\ExecutableFinder;
 
-/**
- * Class ExternalCommandSpec
- */
 class ExternalCommandSpec extends ObjectBehavior
 {
     function let(ExecutableFinder $executableFinder)

--- a/spec/GrumPHP/Locator/RegisteredFilesSpec.php
+++ b/spec/GrumPHP/Locator/RegisteredFilesSpec.php
@@ -7,9 +7,6 @@ use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Locator\RegisteredFiles;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class RegisteredFilesSpec
- */
 class RegisteredFilesSpec extends ObjectBehavior
 {
     function let(Repository $repository)

--- a/spec/GrumPHP/Parser/ParseErrorSpec.php
+++ b/spec/GrumPHP/Parser/ParseErrorSpec.php
@@ -5,9 +5,6 @@ namespace spec\GrumPHP\Parser;
 use GrumPHP\Parser\ParseError;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class ParseErrorSpec
- */
 class ParseErrorSpec extends ObjectBehavior
 {
     function let()

--- a/spec/GrumPHP/Parser/Php/Configurator/TraverserConfiguratorSpec.php
+++ b/spec/GrumPHP/Parser/Php/Configurator/TraverserConfiguratorSpec.php
@@ -12,9 +12,6 @@ use PhpParser\NodeVisitor;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-/**
- * Class TraverserConfiguratorSpec
- */
 class TraverserConfiguratorSpec extends ObjectBehavior
 {
     function let(ContainerInterface $container)

--- a/spec/GrumPHP/Parser/Php/Context/ParserContextSpec.php
+++ b/spec/GrumPHP/Parser/Php/Context/ParserContextSpec.php
@@ -7,9 +7,6 @@ use GrumPHP\Parser\Php\Context\ParserContext;
 use PhpSpec\ObjectBehavior;
 use SplFileInfo;
 
-/**
- * Class ParserContextSpec
- */
 class ParserContextSpec extends ObjectBehavior
 {
     function let(SplFileInfo $file, ParseErrorsCollection $errors)

--- a/spec/GrumPHP/Parser/Php/Factory/ParserFactorySpec.php
+++ b/spec/GrumPHP/Parser/Php/Factory/ParserFactorySpec.php
@@ -7,9 +7,6 @@ use GrumPHP\Task\PhpParser;
 use PhpParser\Parser;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class ParserFactorySpec
- */
 class ParserFactorySpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Parser/Php/Factory/TraverserFactorySpec.php
+++ b/spec/GrumPHP/Parser/Php/Factory/TraverserFactorySpec.php
@@ -9,9 +9,6 @@ use PhpParser\NodeTraverser;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
-/**
- * Class TraverserFactorySpec
- */
 class TraverserFactorySpec extends ObjectBehavior
 {
     function let(TraverserConfigurator $configurator)

--- a/spec/GrumPHP/Parser/Php/PhpParserErrorSpec.php
+++ b/spec/GrumPHP/Parser/Php/PhpParserErrorSpec.php
@@ -7,9 +7,6 @@ use GrumPHP\Parser\Php\PhpParserError;
 use PhpParser\Error;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class PhpParserErrorSpec
- */
 class PhpParserErrorSpec extends ObjectBehavior
 {
     function let()

--- a/spec/GrumPHP/Parser/Php/PhpParserSpec.php
+++ b/spec/GrumPHP/Parser/Php/PhpParserSpec.php
@@ -15,9 +15,6 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use SplFileInfo;
 
-/**
- * Class PhpParserSpec
- */
 class PhpParserSpec extends ObjectBehavior
 {
     function let(

--- a/spec/GrumPHP/Process/AsyncProcessRunnerSpec.php
+++ b/spec/GrumPHP/Process/AsyncProcessRunnerSpec.php
@@ -8,9 +8,6 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Prophet;
 use Symfony\Component\Process\Process;
 
-/**
- * Class AsyncProcessRunnerSpec
- */
 class AsyncProcessRunnerSpec extends ObjectBehavior
 {
     public function let(GrumPHP $grumPHP) {

--- a/spec/GrumPHP/Process/ProcessBuilderSpec.php
+++ b/spec/GrumPHP/Process/ProcessBuilderSpec.php
@@ -12,9 +12,6 @@ use PhpSpec\ObjectBehavior;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessUtils;
 
-/**
- * Class ProcessBuilderSpec
- */
 class ProcessBuilderSpec extends ObjectBehavior
 {
     function let(GrumPHP $config, ExternalCommand $externalCommandLocator, IOInterface $io)

--- a/spec/GrumPHP/Runner/TaskResultSpec.php
+++ b/spec/GrumPHP/Runner/TaskResultSpec.php
@@ -7,9 +7,6 @@ use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class TaskResultSpec
- */
 class TaskResultSpec extends ObjectBehavior
 {
     const FAILED_TASK_MESSAGE = 'failed task message';

--- a/spec/GrumPHP/Runner/TaskRunnerContextSpec.php
+++ b/spec/GrumPHP/Runner/TaskRunnerContextSpec.php
@@ -7,9 +7,6 @@ use GrumPHP\TestSuite\TestSuiteInterface;
 use PhpSpec\ObjectBehavior;
 use GrumPHP\Runner\TaskRunnerContext;
 
-/**
- * Class TaskRunnerContextSpec
- */
 class TaskRunnerContextSpec extends ObjectBehavior
 {
     function let(ContextInterface $context, TestSuiteInterface $testSuite)

--- a/spec/GrumPHP/Runner/TaskRunnerSpec.php
+++ b/spec/GrumPHP/Runner/TaskRunnerSpec.php
@@ -21,9 +21,6 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-/**
- * Class TaskRunnerSpec
- */
 class TaskRunnerSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/AbstractLinterTaskSpec.php
+++ b/spec/GrumPHP/Task/AbstractLinterTaskSpec.php
@@ -5,9 +5,6 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class AbstractLinterTaskSpec
- */
 abstract class AbstractLinterTaskSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/AbstractParserTaskSpec.php
+++ b/spec/GrumPHP/Task/AbstractParserTaskSpec.php
@@ -5,9 +5,6 @@ namespace spec\GrumPHP\Task;
 use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class AbstractParserTaskSpec
- */
 abstract class AbstractParserTaskSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/AntSpec.php
+++ b/spec/GrumPHP/Task/AntSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class AntSpec
- */
 class AntSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/AtoumSpec.php
+++ b/spec/GrumPHP/Task/AtoumSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class AtoumSpec
- */
 class AtoumSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/BehatSpec.php
+++ b/spec/GrumPHP/Task/BehatSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class BehatSpec
- */
 class BehatSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/BrunchSpec.php
+++ b/spec/GrumPHP/Task/BrunchSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class BrunchSpec
- */
 class BrunchSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/CloverCoverageSpec.php
+++ b/spec/GrumPHP/Task/CloverCoverageSpec.php
@@ -13,9 +13,6 @@ use GrumPHP\Util\Filesystem;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class CloverCoverageSpec
- */
 class CloverCoverageSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP)

--- a/spec/GrumPHP/Task/CodeceptionSpec.php
+++ b/spec/GrumPHP/Task/CodeceptionSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class CodeceptionSpec
- */
 class CodeceptionSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/ComposerScriptSpec.php
+++ b/spec/GrumPHP/Task/ComposerScriptSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class ComposerScriptSpec
- */
 class ComposerScriptSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/ComposerSpec.php
+++ b/spec/GrumPHP/Task/ComposerSpec.php
@@ -19,9 +19,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class ComposerSpec
- */
 class ComposerSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter, Filesystem $filesystem)

--- a/spec/GrumPHP/Task/Context/GitCommitMsgContextSpec.php
+++ b/spec/GrumPHP/Task/Context/GitCommitMsgContextSpec.php
@@ -7,9 +7,6 @@ use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitCommitMsgContext;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class GitCommitMsgContextSpec
- */
 class GitCommitMsgContextSpec extends ObjectBehavior
 {
     /**

--- a/spec/GrumPHP/Task/Context/GitPreCommitContextSpec.php
+++ b/spec/GrumPHP/Task/Context/GitPreCommitContextSpec.php
@@ -7,9 +7,6 @@ use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class GitPreCommitContextSpec
- */
 class GitPreCommitContextSpec extends ObjectBehavior
 {
     function let(FilesCollection $files)

--- a/spec/GrumPHP/Task/Context/RunContextSpec.php
+++ b/spec/GrumPHP/Task/Context/RunContextSpec.php
@@ -7,9 +7,6 @@ use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\RunContext;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class RunContextSpec
- */
 class RunContextSpec extends ObjectBehavior
 {
     function let(FilesCollection $files)

--- a/spec/GrumPHP/Task/DoctrineOrmSpec.php
+++ b/spec/GrumPHP/Task/DoctrineOrmSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class DoctrineOrmSpec
- */
 class DoctrineOrmSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/GherkinSpec.php
+++ b/spec/GrumPHP/Task/GherkinSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class GherkinSpec
- */
 class GherkinSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/Git/BlacklistSpec.php
+++ b/spec/GrumPHP/Task/Git/BlacklistSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class BlacklistSpec
- */
 class BlacklistSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/Git/CommitMessageSpec.php
+++ b/spec/GrumPHP/Task/Git/CommitMessageSpec.php
@@ -10,9 +10,6 @@ use GrumPHP\Task\TaskInterface;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class CommitMessageSpec
- */
 class CommitMessageSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP)

--- a/spec/GrumPHP/Task/Git/ConflictSpec.php
+++ b/spec/GrumPHP/Task/Git/ConflictSpec.php
@@ -17,9 +17,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class ConflictSpec
- */
 class ConflictSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/GruntSpec.php
+++ b/spec/GrumPHP/Task/GruntSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class GruntSpec
- */
 class GruntSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/GulpSpec.php
+++ b/spec/GrumPHP/Task/GulpSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class GulpSpec
- */
 class GulpSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/JsonLintSpec.php
+++ b/spec/GrumPHP/Task/JsonLintSpec.php
@@ -18,9 +18,6 @@ use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class JsonLintSpec
- */
 class JsonLintSpec extends AbstractLinterTaskSpec
 {
     function let(GrumPHP $grumPHP, JsonLinter $linter)

--- a/spec/GrumPHP/Task/MakeSpec.php
+++ b/spec/GrumPHP/Task/MakeSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class MakeSpec
- */
 class MakeSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/NpmScriptSpec.php
+++ b/spec/GrumPHP/Task/NpmScriptSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class NpmScriptSpec
- */
 class NpmScriptSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/PhingSpec.php
+++ b/spec/GrumPHP/Task/PhingSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class PhingSpec
- */
 class PhingSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/Php7ccSpec.php
+++ b/spec/GrumPHP/Task/Php7ccSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class Php7ccSpec
- */
 class Php7ccSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/PhpCpdSpec.php
+++ b/spec/GrumPHP/Task/PhpCpdSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class PhpCpdSpec
- */
 class PhpCpdSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/PhpCsFixerSpec.php
+++ b/spec/GrumPHP/Task/PhpCsFixerSpec.php
@@ -20,9 +20,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class PhpCsFixerSpec
- */
 class PhpCsFixerSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/PhpCsFixerV2Spec.php
+++ b/spec/GrumPHP/Task/PhpCsFixerV2Spec.php
@@ -20,9 +20,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class PhpCsFixerV2Spec
- */
 class PhpCsFixerV2Spec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/PhpLintSpec.php
+++ b/spec/GrumPHP/Task/PhpLintSpec.php
@@ -17,9 +17,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class PhpLintSpec
- */
 class PhpLintSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/PhpMdSpec.php
+++ b/spec/GrumPHP/Task/PhpMdSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class PhpMdSpec
- */
 class PhpMdSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/PhpParserSpec.php
+++ b/spec/GrumPHP/Task/PhpParserSpec.php
@@ -9,9 +9,6 @@ use GrumPHP\Task\Context\RunContext;
 use GrumPHP\Task\PhpParser;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class PhpParserSpec
- */
 class PhpParserSpec extends AbstractParserTaskSpec
 {
 

--- a/spec/GrumPHP/Task/PhpcsSpec.php
+++ b/spec/GrumPHP/Task/PhpcsSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class PhpcsSpec
- */
 class PhpcsSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/PhpspecSpec.php
+++ b/spec/GrumPHP/Task/PhpspecSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class PhpspecSpec
- */
 class PhpspecSpec extends ObjectBehavior
 {
 

--- a/spec/GrumPHP/Task/PhpunitSpec.php
+++ b/spec/GrumPHP/Task/PhpunitSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class PhpunitSpec
- */
 class PhpunitSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/RoboSpec.php
+++ b/spec/GrumPHP/Task/RoboSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class RoboSpec
- */
 class RoboSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/SecurityCheckerSpec.php
+++ b/spec/GrumPHP/Task/SecurityCheckerSpec.php
@@ -19,9 +19,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class SecurityCheckerSpec
- */
 class SecurityCheckerSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/ShellSpec.php
+++ b/spec/GrumPHP/Task/ShellSpec.php
@@ -18,9 +18,6 @@ use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
-/**
- * Class ShellSpec
- */
 class ShellSpec extends ObjectBehavior
 {
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)

--- a/spec/GrumPHP/Task/XmlLintSpec.php
+++ b/spec/GrumPHP/Task/XmlLintSpec.php
@@ -18,9 +18,6 @@ use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class XmlLintSpec
- */
 class XmlLintSpec extends AbstractLinterTaskSpec
 {
     function let(GrumPHP $grumPHP, XmlLinter $linter)
@@ -69,7 +66,7 @@ class XmlLintSpec extends AbstractLinterTaskSpec
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf(TaskResultInterface::class);
-        $result->getResultCode()->shouldBe(TaskResult::SKIPPED);        
+        $result->getResultCode()->shouldBe(TaskResult::SKIPPED);
     }
 
     function it_runs_the_suite(XmlLinter $linter, ContextInterface $context)

--- a/spec/GrumPHP/Task/YamlLintSpec.php
+++ b/spec/GrumPHP/Task/YamlLintSpec.php
@@ -18,9 +18,6 @@ use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class YamlLintSpec
- */
 class YamlLintSpec extends AbstractLinterTaskSpec
 {
     function let(GrumPHP $grumPHP, YamlLinter $linter)

--- a/spec/GrumPHP/TestSuite/TestSuiteSpec.php
+++ b/spec/GrumPHP/TestSuite/TestSuiteSpec.php
@@ -6,9 +6,6 @@ use GrumPHP\TestSuite\TestSuiteInterface;
 use PhpSpec\ObjectBehavior;
 use GrumPHP\TestSuite\TestSuite;
 
-/**
- * Class TestSuiteSpec
- */
 class TestSuiteSpec extends ObjectBehavior
 {
     function let()

--- a/spec/GrumPHP/Util/FilesystemSpec.php
+++ b/spec/GrumPHP/Util/FilesystemSpec.php
@@ -8,9 +8,6 @@ use SplFileInfo;
 use SplFileObject;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 
-/**
- * Class FilesystemSpec
- */
 class FilesystemSpec extends ObjectBehavior
 {
     function it_is_initializable()

--- a/spec/GrumPHP/Util/PhpVersionSpec.php
+++ b/spec/GrumPHP/Util/PhpVersionSpec.php
@@ -7,10 +7,6 @@ use DateTime;
 use GrumPHP\Util\PhpVersion;
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class PhpVersionSpec
- * @package spec\GrumPHP\Util
- */
 class PhpVersionSpec extends ObjectBehavior
 {
     function let(PhpVersion $phpVersion)

--- a/spec/GrumPHP/Util/RegexSpec.php
+++ b/spec/GrumPHP/Util/RegexSpec.php
@@ -4,9 +4,6 @@ namespace spec\GrumPHP\Util;
 
 use PhpSpec\ObjectBehavior;
 
-/**
- * Class RegexSpec
- */
 class RegexSpec extends ObjectBehavior
 {
 

--- a/src/GrumPHP/Collection/FilesCollection.php
+++ b/src/GrumPHP/Collection/FilesCollection.php
@@ -12,8 +12,6 @@ use Traversable;
 
 /**
  * Class FileSequence
- *
- * @package GrumPHP\Collection
  */
 class FilesCollection extends ArrayCollection
 {

--- a/src/GrumPHP/Collection/LintErrorsCollection.php
+++ b/src/GrumPHP/Collection/LintErrorsCollection.php
@@ -4,11 +4,6 @@ namespace GrumPHP\Collection;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
-/**
- * Class LintErrorsCollection
- *
- * @package GrumPHP\Collection
- */
 class LintErrorsCollection extends ArrayCollection
 {
     /**

--- a/src/GrumPHP/Collection/ParseErrorsCollection.php
+++ b/src/GrumPHP/Collection/ParseErrorsCollection.php
@@ -4,11 +4,6 @@ namespace GrumPHP\Collection;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
-/**
- * Class ParseErrorsCollection
- *
- * @package GrumPHP\Collection
- */
 class ParseErrorsCollection extends ArrayCollection
 {
     /**

--- a/src/GrumPHP/Collection/ProcessArgumentsCollection.php
+++ b/src/GrumPHP/Collection/ProcessArgumentsCollection.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 use GrumPHP\Exception\InvalidArgumentException;
 
-/**
- * Class ProcessArgumentsCollection
- *
- * @package GrumPHP\Collection
- */
 class ProcessArgumentsCollection extends ArrayCollection
 {
     /**

--- a/src/GrumPHP/Collection/TasksCollection.php
+++ b/src/GrumPHP/Collection/TasksCollection.php
@@ -9,11 +9,6 @@ use GrumPHP\Task\TaskInterface;
 use GrumPHP\TestSuite\TestSuiteInterface;
 use SplPriorityQueue;
 
-/**
- * Class TasksCollection
- *
- * @package GrumPHP\Collection
- */
 class TasksCollection extends ArrayCollection
 {
 

--- a/src/GrumPHP/Collection/TestSuiteCollection.php
+++ b/src/GrumPHP/Collection/TestSuiteCollection.php
@@ -6,11 +6,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use GrumPHP\Exception\InvalidArgumentException;
 use GrumPHP\TestSuite\TestSuiteInterface;
 
-/**
- * Class TestSuiteCollection
- *
- * @package GrumPHP\Collection
- */
 class TestSuiteCollection extends ArrayCollection
 {
 

--- a/src/GrumPHP/Composer/GrumPHPPlugin.php
+++ b/src/GrumPHP/Composer/GrumPHPPlugin.php
@@ -21,11 +21,6 @@ use GrumPHP\Locator\ExternalCommand;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\ProcessBuilder;
 
-/**
- * Class GrumPHPPlugin
- *
- * @package GrumPHP\Composer
- */
 class GrumPHPPlugin implements PluginInterface, EventSubscriberInterface
 {
     const PACKAGE_NAME = 'phpro/grumphp';

--- a/src/GrumPHP/Configuration/Compiler/ExtensionCompilerPass.php
+++ b/src/GrumPHP/Configuration/Compiler/ExtensionCompilerPass.php
@@ -7,11 +7,6 @@ use GrumPHP\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * Class ExtensionCompilerPass
- *
- * @package GrumPHP\Configuration\Compiler
- */
 class ExtensionCompilerPass implements CompilerPassInterface
 {
     /**

--- a/src/GrumPHP/Configuration/Compiler/PhpParserCompilerPass.php
+++ b/src/GrumPHP/Configuration/Compiler/PhpParserCompilerPass.php
@@ -7,11 +7,6 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-/**
- * Class PhpParserCompilerPass
- *
- * @package GrumPHP\Configuration\Compiler
- */
 class PhpParserCompilerPass implements CompilerPassInterface
 {
     const TAG = 'php_parser.visitor';

--- a/src/GrumPHP/Configuration/Compiler/TaskCompilerPass.php
+++ b/src/GrumPHP/Configuration/Compiler/TaskCompilerPass.php
@@ -8,11 +8,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class TaskCompilerPass
- *
- * @package GrumPHP\Configuration\Compiler
- */
 class TaskCompilerPass implements CompilerPassInterface
 {
 

--- a/src/GrumPHP/Configuration/Compiler/TestSuiteCompilerPass.php
+++ b/src/GrumPHP/Configuration/Compiler/TestSuiteCompilerPass.php
@@ -9,11 +9,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class TestSuiteCompilerPass
- *
- * @package GrumPHP\Configuration\Compiler
- */
 class TestSuiteCompilerPass implements CompilerPassInterface
 {
     /**

--- a/src/GrumPHP/Configuration/ContainerFactory.php
+++ b/src/GrumPHP/Configuration/ContainerFactory.php
@@ -10,11 +10,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 
-/**
- * Class ContainerFactory
- *
- * @package GrumPHP\Configuration
- */
 final class ContainerFactory
 {
     /**

--- a/src/GrumPHP/Console/Application.php
+++ b/src/GrumPHP/Console/Application.php
@@ -18,11 +18,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Process\ProcessBuilder;
 
-/**
- * Class Application
- *
- * @package GrumPHP\Console
- */
 class Application extends SymfonyConsole
 {
     const APP_NAME = 'GrumPHP';

--- a/src/GrumPHP/Console/Command/ConfigureCommand.php
+++ b/src/GrumPHP/Console/Command/ConfigureCommand.php
@@ -20,11 +20,6 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Yaml\Yaml;
 
-/**
- * Class ConfigureCommand
- *
- * @package GrumPHP\Console\Command
- */
 class ConfigureCommand extends Command
 {
     const COMMAND_NAME = 'configure';

--- a/src/GrumPHP/Console/Command/RunCommand.php
+++ b/src/GrumPHP/Console/Command/RunCommand.php
@@ -14,11 +14,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * Class RunCommand
- *
- * @package GrumPHP\Console\Command
- */
 class RunCommand extends Command
 {
     const COMMAND_NAME = 'run';

--- a/src/GrumPHP/Console/Helper/TaskRunnerHelper.php
+++ b/src/GrumPHP/Console/Helper/TaskRunnerHelper.php
@@ -11,11 +11,6 @@ use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-/**
- * Class TaskRunnerHelper
- *
- * @package GrumPHP\Console\Helper
- */
 class TaskRunnerHelper extends Helper
 {
     const HELPER_NAME = 'taskrunner';

--- a/src/GrumPHP/Event/RunnerEvent.php
+++ b/src/GrumPHP/Event/RunnerEvent.php
@@ -7,11 +7,6 @@ use GrumPHP\Collection\TasksCollection;
 use GrumPHP\Task\Context\ContextInterface;
 use Symfony\Component\EventDispatcher\Event;
 
-/**
- * Class RunnerEvent
- *
- * @package GrumPHP\Event
- */
 class RunnerEvent extends Event
 {
     /**

--- a/src/GrumPHP/Event/RunnerEvents.php
+++ b/src/GrumPHP/Event/RunnerEvents.php
@@ -2,11 +2,6 @@
 
 namespace GrumPHP\Event;
 
-/**
- * Class RunnerEvents
- *
- * @package GrumPHP\Events
- */
 final class RunnerEvents
 {
     const RUNNER_RUN = 'grumphp.runner.run';

--- a/src/GrumPHP/Event/RunnerFailedEvent.php
+++ b/src/GrumPHP/Event/RunnerFailedEvent.php
@@ -2,11 +2,6 @@
 
 namespace GrumPHP\Event;
 
-/**
- * Class RunnerFailedEvent
- *
- * @package GrumPHP\Event
- */
 class RunnerFailedEvent extends RunnerEvent
 {
     /**

--- a/src/GrumPHP/Event/Subscriber/ProgressSubscriber.php
+++ b/src/GrumPHP/Event/Subscriber/ProgressSubscriber.php
@@ -11,11 +11,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use ReflectionClass;
 
-/**
- * Class ProgressSubscriber
- *
- * @package GrumPHP\Event\Subscriber
- */
 class ProgressSubscriber implements EventSubscriberInterface
 {
     /**

--- a/src/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriber.php
+++ b/src/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriber.php
@@ -15,11 +15,6 @@ use GrumPHP\Task\Context\GitPreCommitContext;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-/**
- * Class StashUnstagedChangesSubscriber
- *
- * @package GrumPHP\Event\Subscriber
- */
 class StashUnstagedChangesSubscriber implements EventSubscriberInterface
 {
 

--- a/src/GrumPHP/Event/TaskEvent.php
+++ b/src/GrumPHP/Event/TaskEvent.php
@@ -6,11 +6,6 @@ use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 use Symfony\Component\EventDispatcher\Event;
 
-/**
- * Class TaskEvent
- *
- * @package GrumPHP\Event
- */
 class TaskEvent extends Event
 {
     /**

--- a/src/GrumPHP/Event/TaskEvents.php
+++ b/src/GrumPHP/Event/TaskEvents.php
@@ -2,11 +2,6 @@
 
 namespace GrumPHP\Event;
 
-/**
- * Class TaskEvents
- *
- * @package GrumPHP\Event
- */
 final class TaskEvents
 {
     const TASK_RUN = 'grumphp.task.run';

--- a/src/GrumPHP/Event/TaskFailedEvent.php
+++ b/src/GrumPHP/Event/TaskFailedEvent.php
@@ -6,11 +6,6 @@ use Exception;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 
-/**
- * Class TaskFailedEvent
- *
- * @package GrumPHP\Event
- */
 class TaskFailedEvent extends TaskEvent
 {
     /**

--- a/src/GrumPHP/Exception/ExceptionInterface.php
+++ b/src/GrumPHP/Exception/ExceptionInterface.php
@@ -2,11 +2,6 @@
 
 namespace GrumPHP\Exception;
 
-/**
- * Interface ExceptionInterface
- *
- * @package GrumPHP\Exception
- */
 interface ExceptionInterface
 {
 }

--- a/src/GrumPHP/Exception/FileNotFoundException.php
+++ b/src/GrumPHP/Exception/FileNotFoundException.php
@@ -2,11 +2,6 @@
 
 namespace GrumPHP\Exception;
 
-/**
- * Class FileNotFoundException
- *
- * @package GrumPHP\Exception
- */
 class FileNotFoundException extends RuntimeException
 {
     /**

--- a/src/GrumPHP/Exception/InvalidArgumentException.php
+++ b/src/GrumPHP/Exception/InvalidArgumentException.php
@@ -2,11 +2,6 @@
 
 namespace GrumPHP\Exception;
 
-/**
- * Class InvalidArgumentException
- *
- * @package GrumPHP\Exception
- */
 class InvalidArgumentException extends RuntimeException
 {
     /**

--- a/src/GrumPHP/Exception/PlatformException.php
+++ b/src/GrumPHP/Exception/PlatformException.php
@@ -6,11 +6,6 @@ namespace GrumPHP\Exception;
 use GrumPHP\Util\Platform;
 use Symfony\Component\Process\Process;
 
-/**
- * Class PlatformException
- *
- * @package GrumPHP\Exception
- */
 class PlatformException extends RuntimeException
 {
     /**

--- a/src/GrumPHP/Exception/RuntimeException.php
+++ b/src/GrumPHP/Exception/RuntimeException.php
@@ -6,11 +6,6 @@ use Exception;
 use GrumPHP\Task\TaskInterface;
 use RuntimeException as BaseRuntimeException;
 
-/**
- * Class RuntimeException
- *
- * @package GrumPHP\Exception
- */
 class RuntimeException extends BaseRuntimeException implements ExceptionInterface
 {
 

--- a/src/GrumPHP/Formatter/GitBlacklistFormatter.php
+++ b/src/GrumPHP/Formatter/GitBlacklistFormatter.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Formatter;
 use GrumPHP\IO\IOInterface;
 use Symfony\Component\Process\Process;
 
-/**
- * Class GitBlacklistFormatter
- *
- * @package GrumPHP\Formatter
- */
 class GitBlacklistFormatter implements ProcessFormatterInterface
 {
     const WORD_COLOR = "\033[1;31";

--- a/src/GrumPHP/Formatter/PhpCsFixerFormatter.php
+++ b/src/GrumPHP/Formatter/PhpCsFixerFormatter.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Formatter;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessUtils;
 
-/**
- * Class PhpCsFixerFormatter
- *
- * @package GrumPHP\Formatter
- */
 class PhpCsFixerFormatter implements ProcessFormatterInterface
 {
     /**

--- a/src/GrumPHP/Formatter/PhpcsFormatter.php
+++ b/src/GrumPHP/Formatter/PhpcsFormatter.php
@@ -6,11 +6,6 @@ use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Process\ProcessBuilder;
 use Symfony\Component\Process\Process;
 
-/**
- * Class PhpcsFormatter
- *
- * @package GrumPHP\Formatter
- */
 class PhpcsFormatter implements ProcessFormatterInterface
 {
     /**

--- a/src/GrumPHP/Formatter/ProcessFormatterInterface.php
+++ b/src/GrumPHP/Formatter/ProcessFormatterInterface.php
@@ -5,8 +5,6 @@ use Symfony\Component\Process\Process;
 
 /**
  * Class RawProcessFormatter
- *
- * @package GrumPHP\Formatter
  */
 interface ProcessFormatterInterface
 {

--- a/src/GrumPHP/Formatter/RawProcessFormatter.php
+++ b/src/GrumPHP/Formatter/RawProcessFormatter.php
@@ -4,11 +4,6 @@ namespace GrumPHP\Formatter;
 
 use Symfony\Component\Process\Process;
 
-/**
- * Class RawProcessFormatter
- *
- * @package GrumPHP\Formatter
- */
 class RawProcessFormatter implements ProcessFormatterInterface
 {
     /**

--- a/src/GrumPHP/IO/ConsoleIO.php
+++ b/src/GrumPHP/IO/ConsoleIO.php
@@ -7,11 +7,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * Class ConsoleIO
- *
- * @package GrumPHP\IO
- */
 class ConsoleIO implements IOInterface
 {
     /**
@@ -114,7 +109,7 @@ class ConsoleIO implements IOInterface
         if ($this->stdin !== null || ftell($handle) !== 0) {
             return $this->stdin;
         }
-        
+
         $input = '';
         while (!feof($handle)) {
             $input .= fread($handle, 1024);

--- a/src/GrumPHP/IO/IOInterface.php
+++ b/src/GrumPHP/IO/IOInterface.php
@@ -2,11 +2,6 @@
 
 namespace GrumPHP\IO;
 
-/**
- * Interface IOInterface
- *
- * @package GrumPHP\IO
- */
 interface IOInterface
 {
     /**

--- a/src/GrumPHP/IO/NullIO.php
+++ b/src/GrumPHP/IO/NullIO.php
@@ -2,11 +2,6 @@
 
 namespace GrumPHP\IO;
 
-/**
- * Class NullIO
- *
- * @package GrumPHP\IO
- */
 class NullIO implements IOInterface
 {
     /**

--- a/src/GrumPHP/Linter/Json/JsonLintError.php
+++ b/src/GrumPHP/Linter/Json/JsonLintError.php
@@ -6,11 +6,6 @@ use GrumPHP\Linter\LintError;
 use Seld\JsonLint\ParsingException;
 use SplFileInfo;
 
-/**
- * Class JsonLintError
- *
- * @package GrumPHP\Linter\Json
- */
 class JsonLintError extends LintError
 {
 

--- a/src/GrumPHP/Linter/Json/JsonLinter.php
+++ b/src/GrumPHP/Linter/Json/JsonLinter.php
@@ -9,11 +9,6 @@ use Seld\JsonLint\JsonParser;
 use Seld\JsonLint\ParsingException;
 use SplFileInfo;
 
-/**
- * Class JsonLinter
- *
- * @package GrumPHP\Linter\Json
- */
 class JsonLinter implements LinterInterface
 {
     /**

--- a/src/GrumPHP/Linter/LintError.php
+++ b/src/GrumPHP/Linter/LintError.php
@@ -2,11 +2,6 @@
 
 namespace GrumPHP\Linter;
 
-/**
- * Class LintError
- *
- * @package GrumPHP\Linter
- */
 class LintError
 {
     const TYPE_NONE = 'none';

--- a/src/GrumPHP/Linter/LinterInterface.php
+++ b/src/GrumPHP/Linter/LinterInterface.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Linter;
 use GrumPHP\Collection\LintErrorsCollection;
 use SplFileInfo;
 
-/**
- * Interface LinterInterface
- *
- * @package GrumPHP\Linter
- */
 interface LinterInterface
 {
     /**

--- a/src/GrumPHP/Linter/Xml/XmlLintError.php
+++ b/src/GrumPHP/Linter/Xml/XmlLintError.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Linter\Xml;
 use GrumPHP\Linter\LintError;
 use LibXMLError;
 
-/**
- * Class XmlLintError
- *
- * @package GrumPHP\Linter\Xml
- */
 class XmlLintError extends LintError
 {
     /**

--- a/src/GrumPHP/Linter/Xml/XmlLinter.php
+++ b/src/GrumPHP/Linter/Xml/XmlLinter.php
@@ -7,11 +7,6 @@ use GrumPHP\Collection\LintErrorsCollection;
 use GrumPHP\Linter\LinterInterface;
 use SplFileInfo;
 
-/**
- * Class XmlLinter
- *
- * @package GrumPHP\Linter\Xml
- */
 class XmlLinter implements LinterInterface
 {
 

--- a/src/GrumPHP/Linter/Yaml/YamlLintError.php
+++ b/src/GrumPHP/Linter/Yaml/YamlLintError.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Linter\Yaml;
 use GrumPHP\Linter\LintError;
 use Symfony\Component\Yaml\Exception\ParseException;
 
-/**
- * Class YamlLintError
- *
- * @package GrumPHP\Linter\Yaml
- */
 class YamlLintError extends LintError
 {
 

--- a/src/GrumPHP/Linter/Yaml/YamlLinter.php
+++ b/src/GrumPHP/Linter/Yaml/YamlLinter.php
@@ -10,11 +10,6 @@ use SplFileInfo;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
-/**
- * Class YamlLinter
- *
- * @package GrumPHP\Linter\Yaml
- */
 class YamlLinter implements LinterInterface
 {
 

--- a/src/GrumPHP/Locator/ChangedFiles.php
+++ b/src/GrumPHP/Locator/ChangedFiles.php
@@ -11,8 +11,6 @@ use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * Class Git
- *
- * @package GrumPHP\Locator
  */
 class ChangedFiles
 {

--- a/src/GrumPHP/Locator/ConfigurationFile.php
+++ b/src/GrumPHP/Locator/ConfigurationFile.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Locator;
 use Composer\Package\PackageInterface;
 use GrumPHP\Util\Filesystem;
 
-/**
- * Class ConfigurationFile
- *
- * @package GrumPHP\Locator
- */
 class ConfigurationFile
 {
     const APP_CONFIG_FILE = 'grumphp.yml';

--- a/src/GrumPHP/Locator/ExternalCommand.php
+++ b/src/GrumPHP/Locator/ExternalCommand.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Locator;
 use GrumPHP\Exception\RuntimeException;
 use Symfony\Component\Process\ExecutableFinder;
 
-/**
- * Class ExternalCommand
- *
- * @package GrumPHP\Locator
- */
 class ExternalCommand
 {
     /**

--- a/src/GrumPHP/Locator/RegisteredFiles.php
+++ b/src/GrumPHP/Locator/RegisteredFiles.php
@@ -6,11 +6,6 @@ use Gitonomy\Git\Repository;
 use GrumPHP\Collection\FilesCollection;
 use Symfony\Component\Finder\SplFileInfo;
 
-/**
- * Class RegisteredFiles
- *
- * @package GrumPHP\Locator
- */
 class RegisteredFiles
 {
     /**

--- a/src/GrumPHP/Parser/ParseError.php
+++ b/src/GrumPHP/Parser/ParseError.php
@@ -2,11 +2,6 @@
 
 namespace GrumPHP\Parser;
 
-/**
- * Class ParseError
- *
- * @package GrumPHP\Parser
- */
 class ParseError
 {
     const TYPE_NOTICE = 'notice';

--- a/src/GrumPHP/Parser/ParserInterface.php
+++ b/src/GrumPHP/Parser/ParserInterface.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Parser;
 use GrumPHP\Collection\ParseErrorsCollection;
 use SplFileInfo;
 
-/**
- * Interface ParserInterface
- *
- * @package GrumPHP\Parser
- */
 interface ParserInterface
 {
     /**

--- a/src/GrumPHP/Parser/Php/Configurator/TraverserConfigurator.php
+++ b/src/GrumPHP/Parser/Php/Configurator/TraverserConfigurator.php
@@ -9,11 +9,6 @@ use GrumPHP\Parser\Php\Visitor\ContextAwareVisitorInterface;
 use PhpParser\NodeTraverserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-/**
- * Class TraverserConfigurator
- *
- * @package GrumPHP\Parser\Php\Configurator
- */
 class TraverserConfigurator
 {
     /**
@@ -114,7 +109,7 @@ class TraverserConfigurator
 
         $visitorIds = array_values(array_intersect($registeredVisitorsIds, $configuredVisitorIds));
         $unknownConfiguredVisitorIds = array_diff($configuredVisitorIds, $registeredVisitorsIds);
-        
+
         if (count($unknownConfiguredVisitorIds)) {
             throw new RuntimeException(
                 sprintf('Found unknown php_parser visitors: %s', implode(',', $unknownConfiguredVisitorIds))
@@ -155,7 +150,6 @@ class TraverserConfigurator
     }
 
     /**
-     *
      * @throws \GrumPHP\Exception\RuntimeException
      */
     private function guardTaskHasVisitors()

--- a/src/GrumPHP/Parser/Php/Context/ParserContext.php
+++ b/src/GrumPHP/Parser/Php/Context/ParserContext.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Parser\Php\Context;
 use GrumPHP\Collection\ParseErrorsCollection;
 use SplFileInfo;
 
-/**
- * Class ParserContext
- *
- * @package GrumPHP\Parser\Php\Context
- */
 class ParserContext
 {
     /**

--- a/src/GrumPHP/Parser/Php/Factory/ParserFactory.php
+++ b/src/GrumPHP/Parser/Php/Factory/ParserFactory.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Parser\Php\Factory;
 use GrumPHP\Task\PhpParser;
 use PhpParser\ParserFactory as PhpParserFactory;
 
-/**
- * Class ParserFactory
- *
- * @package GrumPHP\Parser\Php\Factory
- */
 class ParserFactory
 {
     /**

--- a/src/GrumPHP/Parser/Php/Factory/TraverserFactory.php
+++ b/src/GrumPHP/Parser/Php/Factory/TraverserFactory.php
@@ -6,11 +6,6 @@ use GrumPHP\Parser\Php\Configurator\TraverserConfigurator;
 use GrumPHP\Parser\Php\Context\ParserContext;
 use PhpParser\NodeTraverser;
 
-/**
- * Class TraverserFactory
- *
- * @package GrumPHP\Parser\Php\Factory
- */
 class TraverserFactory
 {
     /**

--- a/src/GrumPHP/Parser/Php/PhpParser.php
+++ b/src/GrumPHP/Parser/Php/PhpParser.php
@@ -12,11 +12,6 @@ use PhpParser\Error;
 use PhpParser\Parser;
 use SplFileInfo;
 
-/**
- * Class PhpParser
- *
- * @package GrumPHP\Parser\Php
- */
 class PhpParser implements ParserInterface
 {
     /**

--- a/src/GrumPHP/Parser/Php/PhpParserError.php
+++ b/src/GrumPHP/Parser/Php/PhpParserError.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Parser\Php;
 use GrumPHP\Parser\ParseError;
 use PhpParser\Error;
 
-/**
- * Class PhpParserError
- *
- * @package GrumPHP\Parser\Php
- */
 class PhpParserError extends ParseError
 {
     /**

--- a/src/GrumPHP/Parser/Php/Visitor/AbstractVisitor.php
+++ b/src/GrumPHP/Parser/Php/Visitor/AbstractVisitor.php
@@ -7,11 +7,6 @@ use GrumPHP\Parser\Php\Context\ParserContext;
 use GrumPHP\Parser\Php\PhpParserError;
 use PhpParser\NodeVisitorAbstract;
 
-/**
- * Class AbstractVisitor
- *
- * @package GrumPHP\Parser\Php\Visitor
- */
 class AbstractVisitor extends NodeVisitorAbstract implements ContextAwareVisitorInterface
 {
     /**

--- a/src/GrumPHP/Parser/Php/Visitor/ConfigurableVisitorInterface.php
+++ b/src/GrumPHP/Parser/Php/Visitor/ConfigurableVisitorInterface.php
@@ -4,11 +4,6 @@ namespace GrumPHP\Parser\Php\Visitor;
 
 use PhpParser\NodeVisitor;
 
-/**
- * Interface ConfigurableVisitorInterface
- *
- * @package GrumPHP\Parser\Php\Visitor
- */
 interface ConfigurableVisitorInterface extends NodeVisitor
 {
     /**

--- a/src/GrumPHP/Parser/Php/Visitor/ContextAwareVisitorInterface.php
+++ b/src/GrumPHP/Parser/Php/Visitor/ContextAwareVisitorInterface.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Parser\Php\Visitor;
 use GrumPHP\Parser\Php\Context\ParserContext;
 use PhpParser\NodeVisitor;
 
-/**
- * Interface ContextAwareVisitorInterface
- *
- * @package GrumPHP\Parser\Php\Visitor
- */
 interface ContextAwareVisitorInterface extends NodeVisitor
 {
     /**

--- a/src/GrumPHP/Parser/Php/Visitor/DeclareStrictTypesVisitor.php
+++ b/src/GrumPHP/Parser/Php/Visitor/DeclareStrictTypesVisitor.php
@@ -4,11 +4,6 @@ namespace GrumPHP\Parser\Php\Visitor;
 
 use PhpParser\Node;
 
-/**
- * Class DeclareStrictTypesVisitor
- *
- * @package GrumPHP\Parser\Php\Visitor
- */
 class DeclareStrictTypesVisitor extends AbstractVisitor
 {
     /**

--- a/src/GrumPHP/Parser/Php/Visitor/ForbiddenClassMethodCallsVisitor.php
+++ b/src/GrumPHP/Parser/Php/Visitor/ForbiddenClassMethodCallsVisitor.php
@@ -6,11 +6,6 @@ use GrumPHP\Parser\ParseError;
 use PhpParser\Node;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class ForbiddenClassMethodCallsVisitor
- *
- * @package GrumPHP\Parser\Php\Visitor
- */
 class ForbiddenClassMethodCallsVisitor extends AbstractVisitor implements ConfigurableVisitorInterface
 {
     /**

--- a/src/GrumPHP/Parser/Php/Visitor/ForbiddenFunctionCallsVisitor.php
+++ b/src/GrumPHP/Parser/Php/Visitor/ForbiddenFunctionCallsVisitor.php
@@ -6,11 +6,6 @@ use GrumPHP\Parser\ParseError;
 use PhpParser\Node;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class ForbiddenFunctionCallsVisitor
- *
- * @package GrumPHP\Parser\Php\Visitor
- */
 class ForbiddenFunctionCallsVisitor extends AbstractVisitor implements ConfigurableVisitorInterface
 {
     /**

--- a/src/GrumPHP/Parser/Php/Visitor/ForbiddenStaticMethodCallsVisitor.php
+++ b/src/GrumPHP/Parser/Php/Visitor/ForbiddenStaticMethodCallsVisitor.php
@@ -6,11 +6,6 @@ use GrumPHP\Parser\ParseError;
 use PhpParser\Node;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class ForbiddenStaticMethodCallsVisitor
- *
- * @package GrumPHP\Parser\Php\Visitor
- */
 class ForbiddenStaticMethodCallsVisitor extends AbstractVisitor implements ConfigurableVisitorInterface
 {
     /**

--- a/src/GrumPHP/Parser/Php/Visitor/NeverUseElseVisitor.php
+++ b/src/GrumPHP/Parser/Php/Visitor/NeverUseElseVisitor.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Parser\Php\Visitor;
 use GrumPHP\Parser\ParseError;
 use PhpParser\Node;
 
-/**
- * Class NeverUseElseVisitor
- *
- * @package GrumPHP\Parser\Php\Visitor
- */
 class NeverUseElseVisitor extends AbstractVisitor
 {
     /**

--- a/src/GrumPHP/Parser/Php/Visitor/NoExitStatementsVisitor.php
+++ b/src/GrumPHP/Parser/Php/Visitor/NoExitStatementsVisitor.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Parser\Php\Visitor;
 use GrumPHP\Parser\ParseError;
 use PhpParser\Node;
 
-/**
- * Class NoExitStatementsVisitor
- *
- * @package GrumPHP\Parser\Php\Visitor
- */
 class NoExitStatementsVisitor extends AbstractVisitor
 {
     /**

--- a/src/GrumPHP/Process/AsyncProcessRunner.php
+++ b/src/GrumPHP/Process/AsyncProcessRunner.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Process;
 use GrumPHP\Configuration\GrumPHP;
 use Symfony\Component\Process\Process;
 
-/**
- * Class AsyncProcessRunner
- *
- * @package GrumPHP\Process
- */
 class AsyncProcessRunner
 {
     /**

--- a/src/GrumPHP/Process/ProcessBuilder.php
+++ b/src/GrumPHP/Process/ProcessBuilder.php
@@ -11,11 +11,6 @@ use GrumPHP\Util\Platform;
 use Symfony\Component\Process\Process;
 use \Symfony\Component\Process\ProcessBuilder as SymfonyProcessBuilder;
 
-/**
- * Class ProcessBuilder
- *
- * @package GrumPHP\Process
- */
 class ProcessBuilder
 {
 

--- a/src/GrumPHP/Runner/TaskResult.php
+++ b/src/GrumPHP/Runner/TaskResult.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Runner;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 
-/**
- * Class TaskResult
- *
- * @package GrumPHP\Runner
- */
 class TaskResult implements TaskResultInterface
 {
     const SKIPPED = -100;

--- a/src/GrumPHP/Runner/TaskResultInterface.php
+++ b/src/GrumPHP/Runner/TaskResultInterface.php
@@ -4,11 +4,6 @@ namespace GrumPHP\Runner;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 
-/**
- * Class TaskResult
- *
- * @package GrumPHP\Runner
- */
 interface TaskResultInterface
 {
     /**

--- a/src/GrumPHP/Runner/TaskRunner.php
+++ b/src/GrumPHP/Runner/TaskRunner.php
@@ -17,11 +17,6 @@ use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\TaskInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-/**
- * Class TaskRunner
- *
- * @package GrumPHP\Runner
- */
 class TaskRunner
 {
     /**
@@ -134,7 +129,7 @@ class TaskRunner
         } catch (RuntimeException $e) {
             $result = TaskResult::createFailed($task, $context, $e->getMessage());
         }
-        
+
         if (!$result instanceof TaskResultInterface) {
             throw RuntimeException::invalidTaskReturnType($task);
         }
@@ -146,7 +141,7 @@ class TaskRunner
                 $result->getMessage()
             );
         }
-        
+
         if (!$result->isPassed()) {
             $e = new RuntimeException($result->getMessage());
             $this->eventDispatcher->dispatch(TaskEvents::TASK_FAILED, new TaskFailedEvent($task, $context, $e));

--- a/src/GrumPHP/Runner/TaskRunnerContext.php
+++ b/src/GrumPHP/Runner/TaskRunnerContext.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Runner;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\TestSuite\TestSuiteInterface;
 
-/**
- * Class TaskRunnerContext
- *
- * @package GrumPHP\Runner
- */
 class TaskRunnerContext
 {
 

--- a/src/GrumPHP/Task/AbstractExternalTask.php
+++ b/src/GrumPHP/Task/AbstractExternalTask.php
@@ -6,11 +6,6 @@ use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 
-/**
- * Class AbstractExternalTask
- *
- * @package GrumPHP\Task
- */
 abstract class AbstractExternalTask implements TaskInterface
 {
     /**

--- a/src/GrumPHP/Task/AbstractLinterTask.php
+++ b/src/GrumPHP/Task/AbstractLinterTask.php
@@ -9,11 +9,6 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Linter\LinterInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class AbstractLinter
- *
- * @package GrumPHP\Task
- */
 abstract class AbstractLinterTask implements TaskInterface
 {
     /**

--- a/src/GrumPHP/Task/AbstractParserTask.php
+++ b/src/GrumPHP/Task/AbstractParserTask.php
@@ -9,11 +9,6 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Parser\ParserInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class AbstractParser
- *
- * @package GrumPHP\Task
- */
 abstract class AbstractParserTask implements TaskInterface
 {
     /**

--- a/src/GrumPHP/Task/AbstractPhpCsFixerTask.php
+++ b/src/GrumPHP/Task/AbstractPhpCsFixerTask.php
@@ -15,8 +15,6 @@ use GrumPHP\Task\Context\RunContext;
 
 /**
  * Class PhpCsFixerRunner
- *
- * @package GrumPHP\Task
  */
 abstract class AbstractPhpCsFixerTask implements TaskInterface
 {

--- a/src/GrumPHP/Task/Codeception.php
+++ b/src/GrumPHP/Task/Codeception.php
@@ -10,8 +10,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Codeception task
- *
- * @package GrumPHP\Task
  */
 class Codeception extends AbstractExternalTask
 {

--- a/src/GrumPHP/Task/Composer.php
+++ b/src/GrumPHP/Task/Composer.php
@@ -15,8 +15,6 @@ use SplFileInfo;
 
 /**
  * Composer task
- *
- * @package GrumPHP\Task
  */
 class Composer extends AbstractExternalTask
 {

--- a/src/GrumPHP/Task/Context/ContextInterface.php
+++ b/src/GrumPHP/Task/Context/ContextInterface.php
@@ -4,11 +4,6 @@ namespace GrumPHP\Task\Context;
 
 use GrumPHP\Collection\FilesCollection;
 
-/**
- * Interface ContextInterface
- *
- * @package GrumPHP\Context
- */
 interface ContextInterface
 {
 

--- a/src/GrumPHP/Task/Context/GitCommitMsgContext.php
+++ b/src/GrumPHP/Task/Context/GitCommitMsgContext.php
@@ -4,11 +4,6 @@ namespace GrumPHP\Task\Context;
 
 use GrumPHP\Collection\FilesCollection;
 
-/**
- * Class GitCommitMsgContext
- *
- * @package GrumPHP\Task\Context
- */
 class GitCommitMsgContext implements ContextInterface
 {
 

--- a/src/GrumPHP/Task/Context/GitPreCommitContext.php
+++ b/src/GrumPHP/Task/Context/GitPreCommitContext.php
@@ -4,11 +4,6 @@ namespace GrumPHP\Task\Context;
 
 use GrumPHP\Collection\FilesCollection;
 
-/**
- * Class GitPreCommitContext
- *
- * @package GrumPHP\Task\Context
- */
 class GitPreCommitContext implements ContextInterface
 {
 

--- a/src/GrumPHP/Task/Context/RunContext.php
+++ b/src/GrumPHP/Task/Context/RunContext.php
@@ -4,11 +4,6 @@ namespace GrumPHP\Task\Context;
 
 use GrumPHP\Collection\FilesCollection;
 
-/**
- * Class RunContext
- *
- * @package GrumPHP\Task\Context
- */
 class RunContext implements ContextInterface
 {
     /**

--- a/src/GrumPHP/Task/Git/Blacklist.php
+++ b/src/GrumPHP/Task/Git/Blacklist.php
@@ -14,8 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Git Blacklist Task
- *
- * @package GrumPHP\Task\Git
  */
 class Blacklist extends AbstractExternalTask
 {

--- a/src/GrumPHP/Task/Git/CommitMessage.php
+++ b/src/GrumPHP/Task/Git/CommitMessage.php
@@ -13,8 +13,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Git CommitMessage Task
- *
- * @package GrumPHP\Task
  */
 class CommitMessage implements TaskInterface
 {

--- a/src/GrumPHP/Task/Git/Conflict.php
+++ b/src/GrumPHP/Task/Git/Conflict.php
@@ -10,8 +10,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Git Conflict Task
- *
- * @package GrumPHP\Task\Git
  */
 class Conflict extends AbstractExternalTask
 {

--- a/src/GrumPHP/Task/JsonLint.php
+++ b/src/GrumPHP/Task/JsonLint.php
@@ -10,11 +10,6 @@ use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class JsonLint
- *
- * @package GrumPHP\Task
- */
 class JsonLint extends AbstractLinterTask
 {
     /**
@@ -71,7 +66,7 @@ class JsonLint extends AbstractLinterTask
         } catch (RuntimeException $e) {
             return TaskResult::createFailed($this, $context, $e->getMessage());
         }
-        
+
         if ($lintErrors->count()) {
             return TaskResult::createFailed($this, $context, (string) $lintErrors);
         }

--- a/src/GrumPHP/Task/TaskInterface.php
+++ b/src/GrumPHP/Task/TaskInterface.php
@@ -6,11 +6,6 @@ use GrumPHP\Runner\TaskResultInterface;
 use GrumPHP\Task\Context\ContextInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Interface TaskInterface
- *
- * @package GrumPHP\Task
- */
 interface TaskInterface
 {
 

--- a/src/GrumPHP/Task/XmlLint.php
+++ b/src/GrumPHP/Task/XmlLint.php
@@ -10,11 +10,6 @@ use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class XmlLint
- *
- * @package GrumPHP\Task
- */
 class XmlLint extends AbstractLinterTask
 {
     /**

--- a/src/GrumPHP/Task/YamlLint.php
+++ b/src/GrumPHP/Task/YamlLint.php
@@ -10,11 +10,6 @@ use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * Class YamlLint
- *
- * @package GrumPHP\Task
- */
 class YamlLint extends AbstractLinterTask
 {
     /**

--- a/src/GrumPHP/TestSuite/TestSuite.php
+++ b/src/GrumPHP/TestSuite/TestSuite.php
@@ -2,11 +2,6 @@
 
 namespace GrumPHP\TestSuite;
 
-/**
- * Class TestSuite
- *
- * @package GrumPHP\TestSuite
- */
 class TestSuite implements TestSuiteInterface
 {
     /**

--- a/src/GrumPHP/TestSuite/TestSuiteInterface.php
+++ b/src/GrumPHP/TestSuite/TestSuiteInterface.php
@@ -2,11 +2,6 @@
 
 namespace GrumPHP\TestSuite;
 
-/**
- * Class TestSuite
- *
- * @package GrumPHP\TestSuite
- */
 interface TestSuiteInterface
 {
     /**

--- a/src/GrumPHP/Util/Composer.php
+++ b/src/GrumPHP/Util/Composer.php
@@ -12,11 +12,6 @@ use Composer\Repository\RepositoryFactory;
 use Exception;
 use GrumPHP\Exception\RuntimeException;
 
-/**
- * Class Composer
- *
- * @package GrumPHP\Util
- */
 class Composer
 {
 

--- a/src/GrumPHP/Util/Filesystem.php
+++ b/src/GrumPHP/Util/Filesystem.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Util;
 use SplFileInfo;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 
-/**
- * Class Filesystem
- *
- * @package GrumPHP\Util
- */
 class Filesystem extends SymfonyFilesystem
 {
     /**

--- a/src/GrumPHP/Util/PhpVersion.php
+++ b/src/GrumPHP/Util/PhpVersion.php
@@ -4,10 +4,6 @@ namespace GrumPHP\Util;
 
 use DateTime;
 
-/**
- * Class PhpVersion
- * @package GrumPHP\Util
- */
 class PhpVersion
 {
 

--- a/src/GrumPHP/Util/Platform.php
+++ b/src/GrumPHP/Util/Platform.php
@@ -3,11 +3,6 @@
 
 namespace GrumPHP\Util;
 
-/**
- * Class Platform
- *
- * @package GrumPHP\Util
- */
 class Platform
 {
     /**

--- a/src/GrumPHP/Util/Regex.php
+++ b/src/GrumPHP/Util/Regex.php
@@ -5,11 +5,6 @@ namespace GrumPHP\Util;
 use Symfony\Component\Finder\Glob;
 use RuntimeException;
 
-/**
- * Class Regex
- *
- * @package GrumPHP\Util
- */
 class Regex
 {
 

--- a/test/src/GrumPHPTest/Linter/Json/JsonLinterTest.php
+++ b/test/src/GrumPHPTest/Linter/Json/JsonLinterTest.php
@@ -11,11 +11,6 @@ use RuntimeException;
 use Seld\JsonLint\JsonParser;
 use SplFileInfo;
 
-/**
- * Class JsonLinterTest
- *
- * @package GrumPHPTest\Linter\Json
- */
 class JsonLinterTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/test/src/GrumPHPTest/Linter/Xml/XmlLinterTest.php
+++ b/test/src/GrumPHPTest/Linter/Xml/XmlLinterTest.php
@@ -9,11 +9,6 @@ use PHPUnit_Framework_TestCase;
 use RuntimeException;
 use SplFileInfo;
 
-/**
- * Class XmlLinterTest
- *
- * @package GrumPHP\Linter\Xml
- */
 class XmlLinterTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/test/src/GrumPHPTest/Linter/Yaml/YamlLinterTest.php
+++ b/test/src/GrumPHPTest/Linter/Yaml/YamlLinterTest.php
@@ -10,11 +10,6 @@ use PHPUnit_Framework_TestCase;
 use RuntimeException;
 use SplFileInfo;
 
-/**
- * Class YamlLinterTest
- *
- * @package GrumPHPTest\Linter\Yaml
- */
 class YamlLinterTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/test/src/GrumPHPTest/Parser/Php/Visitor/AbstractVisitorTest.php
+++ b/test/src/GrumPHPTest/Parser/Php/Visitor/AbstractVisitorTest.php
@@ -12,11 +12,6 @@ use PhpParser\ParserFactory;
 use PHPUnit_Framework_TestCase;
 use SplFileInfo;
 
-/**
- * Class AbstractVisitorTest
- *
- * @package GrumPHPTest\Parser\Php\Visitor
- */
 abstract class AbstractVisitorTest extends PHPUnit_Framework_TestCase
 {
 

--- a/test/src/GrumPHPTest/Parser/Php/Visitor/DeclareStrictTypesVisitorTest.php
+++ b/test/src/GrumPHPTest/Parser/Php/Visitor/DeclareStrictTypesVisitorTest.php
@@ -5,11 +5,6 @@ namespace GrumPHPTest\Parser\Php\Visitor;
 use GrumPHP\Parser\ParseError;
 use GrumPHP\Parser\Php\Visitor\DeclareStrictTypesVisitor;
 
-/**
- * Class DeclareStrictTypesVisitorTest
- *
- * @package GrumPHPTest\Parser\Php\Visitor
- */
 class DeclareStrictTypesVisitorTest extends AbstractVisitorTest
 {
     /**

--- a/test/src/GrumPHPTest/Parser/Php/Visitor/ForbiddenClassMethodCallsVisitorTest.php
+++ b/test/src/GrumPHPTest/Parser/Php/Visitor/ForbiddenClassMethodCallsVisitorTest.php
@@ -6,11 +6,6 @@ use GrumPHP\Parser\ParseError;
 use GrumPHP\Parser\Php\Visitor\ConfigurableVisitorInterface;
 use GrumPHP\Parser\Php\Visitor\ForbiddenClassMethodCallsVisitor;
 
-/**
- * Class ForbiddenClassMethodCallsVisitorTest
- *
- * @package GrumPHPTest\Parser\Php\Visitor
- */
 class ForbiddenClassMethodCallsVisitorTest extends AbstractVisitorTest
 {
     /**

--- a/test/src/GrumPHPTest/Parser/Php/Visitor/ForbiddenFunctionCallsVisitorTest.php
+++ b/test/src/GrumPHPTest/Parser/Php/Visitor/ForbiddenFunctionCallsVisitorTest.php
@@ -6,11 +6,6 @@ use GrumPHP\Parser\ParseError;
 use GrumPHP\Parser\Php\Visitor\ConfigurableVisitorInterface;
 use GrumPHP\Parser\Php\Visitor\ForbiddenFunctionCallsVisitor;
 
-/**
- * Class ForbiddenFunctionCallsVisitorTest
- *
- * @package GrumPHPTest\Parser\Php\Visitor
- */
 class ForbiddenFunctionCallsVisitorTest extends AbstractVisitorTest
 {
     /**

--- a/test/src/GrumPHPTest/Parser/Php/Visitor/ForbiddenStaticMethodCallsVisitorTest.php
+++ b/test/src/GrumPHPTest/Parser/Php/Visitor/ForbiddenStaticMethodCallsVisitorTest.php
@@ -6,11 +6,6 @@ use GrumPHP\Parser\ParseError;
 use GrumPHP\Parser\Php\Visitor\ConfigurableVisitorInterface;
 use GrumPHP\Parser\Php\Visitor\ForbiddenStaticMethodCallsVisitor;
 
-/**
- * Class ForbiddenStaticMethodCallsVisitorTest
- *
- * @package GrumPHPTest\Parser\Php\Visitor
- */
 class ForbiddenStaticMethodCallsVisitorTest extends AbstractVisitorTest
 {
     /**

--- a/test/src/GrumPHPTest/Parser/Php/Visitor/NeverUseElseVisitorTest.php
+++ b/test/src/GrumPHPTest/Parser/Php/Visitor/NeverUseElseVisitorTest.php
@@ -5,11 +5,6 @@ namespace GrumPHPTest\Parser\Php\Visitor;
 use GrumPHP\Parser\ParseError;
 use GrumPHP\Parser\Php\Visitor\NeverUseElseVisitor;
 
-/**
- * Class NeverUseElseVisitorTest
- *
- * @package GrumPHPTest\Parser\Php\Visitor
- */
 class NeverUseElseVisitorTest extends AbstractVisitorTest
 {
     /**

--- a/test/src/GrumPHPTest/Parser/Php/Visitor/NoExitStatementsVisitorTest.php
+++ b/test/src/GrumPHPTest/Parser/Php/Visitor/NoExitStatementsVisitorTest.php
@@ -5,11 +5,6 @@ namespace GrumPHPTest\Parser\Php\Visitor;
 use GrumPHP\Parser\ParseError;
 use GrumPHP\Parser\Php\Visitor\NoExitStatementsVisitor;
 
-/**
- * Class NoExitStatementsVisitorTest
- *
- * @package GrumPHPTest\Parser\Php\Visitor
- */
 class NoExitStatementsVisitorTest extends AbstractVisitorTest
 {
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | n/a

Class names duplicated into class docblocks and namespaces duplicated in `@package` annotations are pure technical debt, providing no added value but producing maintenance burden to ensure they remain correct.

I presume nobody manually entered these comments so you probably want to look into reconfiguring your editor templates to prevent perpetuating this problem.