### PR TITLE
Removed blank lines immediately inside compound statements.

### DIFF
--- a/spec/GrumPHP/Console/Helper/ComposerHelperSpec.php
+++ b/spec/GrumPHP/Console/Helper/ComposerHelperSpec.php
@@ -13,7 +13,6 @@ use Symfony\Component\Console\Helper\Helper;
  */
 class ComposerHelperSpec extends ObjectBehavior
 {
-
     function let(Config $config, RootPackage $rootPackage)
     {
         $this->beConstructedWith($config, $rootPackage);
@@ -48,5 +47,4 @@ class ComposerHelperSpec extends ObjectBehavior
     {
         $this->getRootPackage()->shouldBe($rootPackage);
     }
-
 }

--- a/spec/GrumPHP/Console/Helper/PathsHelperSpec.php
+++ b/spec/GrumPHP/Console/Helper/PathsHelperSpec.php
@@ -49,7 +49,6 @@ class PathsHelperSpec extends ObjectBehavior
         $filesystem->exists($fileName)->willReturn(true);
         $filesystem->readFromFileInfo(Argument::that(function (SplFileInfo $file) use ($fileName) {
             return $file->getPathname() === $fileName;
-
         }))->willReturn($content = 'ascii');
 
         $this->getAsciiContent('resource')->shouldBe($content);

--- a/spec/GrumPHP/Event/TaskEventSpec.php
+++ b/spec/GrumPHP/Event/TaskEventSpec.php
@@ -13,7 +13,6 @@ use Symfony\Component\EventDispatcher\Event;
  */
 class TaskEventSpec extends ObjectBehavior
 {
-
     function let(TaskInterface $task, ContextInterface $context)
     {
         $this->beConstructedWith($task, $context);

--- a/spec/GrumPHP/Event/TaskFailedEventSpec.php
+++ b/spec/GrumPHP/Event/TaskFailedEventSpec.php
@@ -14,8 +14,6 @@ use PhpSpec\ObjectBehavior;
  */
 class TaskFailedEventSpec extends ObjectBehavior
 {
-
-
     function let(TaskInterface $task, ContextInterface $context, Exception $exception)
     {
         $this->beConstructedWith($task, $context, $exception);

--- a/spec/GrumPHP/Parser/Php/Factory/ParserFactorySpec.php
+++ b/spec/GrumPHP/Parser/Php/Factory/ParserFactorySpec.php
@@ -19,7 +19,6 @@ class ParserFactorySpec extends ObjectBehavior
 
     function it_can_create_a_parser_from_task_options()
     {
-
         $options = ['kind' => PhpParser::KIND_PHP7];
         $this->createFromOptions($options)->shouldBeAnInstanceOf(Parser::class);
     }

--- a/spec/GrumPHP/Parser/Php/Factory/TraverserFactorySpec.php
+++ b/spec/GrumPHP/Parser/Php/Factory/TraverserFactorySpec.php
@@ -26,7 +26,6 @@ class TraverserFactorySpec extends ObjectBehavior
 
     function it_can_create_a_task_and_context_specific_traverser(TraverserConfigurator $configurator, ParserContext $context)
     {
-
         $taskOptions = ['visitors' => []];
 
         $configurator->registerOptions($taskOptions)->shouldBeCalled();

--- a/spec/GrumPHP/Process/ProcessBuilderSpec.php
+++ b/spec/GrumPHP/Process/ProcessBuilderSpec.php
@@ -71,7 +71,6 @@ class ProcessBuilderSpec extends ObjectBehavior
 
         $arguments = new ProcessArgumentsCollection([$command]);
         $process = $this->buildProcess($arguments);
-
     }
 
     function getMatchers()

--- a/spec/GrumPHP/Runner/TaskRunnerSpec.php
+++ b/spec/GrumPHP/Runner/TaskRunnerSpec.php
@@ -26,7 +26,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class TaskRunnerSpec extends ObjectBehavior
 {
-
     public function let(
         GrumPHP $grumPHP,
         EventDispatcherInterface $eventDispatcher,

--- a/spec/GrumPHP/Task/AbstractLinterTaskSpec.php
+++ b/spec/GrumPHP/Task/AbstractLinterTaskSpec.php
@@ -10,7 +10,6 @@ use PhpSpec\ObjectBehavior;
  */
 abstract class AbstractLinterTaskSpec extends ObjectBehavior
 {
-
     function it_is_a_task()
     {
         $this->shouldImplement(TaskInterface::class);

--- a/spec/GrumPHP/Task/AbstractParserTaskSpec.php
+++ b/spec/GrumPHP/Task/AbstractParserTaskSpec.php
@@ -10,7 +10,6 @@ use PhpSpec\ObjectBehavior;
  */
 abstract class AbstractParserTaskSpec extends ObjectBehavior
 {
-
     function it_is_a_task()
     {
         $this->shouldImplement(TaskInterface::class);

--- a/spec/GrumPHP/Task/DoctrineOrmSpec.php
+++ b/spec/GrumPHP/Task/DoctrineOrmSpec.php
@@ -23,7 +23,6 @@ use Symfony\Component\Process\Process;
  */
 class DoctrineOrmSpec extends ObjectBehavior
 {
-
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('doctrine_orm')->willReturn([]);

--- a/spec/GrumPHP/Task/Git/BlacklistSpec.php
+++ b/spec/GrumPHP/Task/Git/BlacklistSpec.php
@@ -23,7 +23,6 @@ use Symfony\Component\Process\Process;
  */
 class BlacklistSpec extends ObjectBehavior
 {
-
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter, ConsoleIO $consoleIO)
     {
         $grumPHP->getTaskConfiguration('git_blacklist')->willReturn([]);

--- a/spec/GrumPHP/Task/Git/ConflictSpec.php
+++ b/spec/GrumPHP/Task/Git/ConflictSpec.php
@@ -22,7 +22,6 @@ use Symfony\Component\Process\Process;
  */
 class ConflictSpec extends ObjectBehavior
 {
-
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('git_conflict')->willReturn([]);

--- a/spec/GrumPHP/Task/KahlanSpec.php
+++ b/spec/GrumPHP/Task/KahlanSpec.php
@@ -23,7 +23,6 @@ use Symfony\Component\Process\Process;
  */
 class KahlanSpec extends ObjectBehavior
 {
-
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('kahlan')->willReturn([]);

--- a/spec/GrumPHP/Task/Php7ccSpec.php
+++ b/spec/GrumPHP/Task/Php7ccSpec.php
@@ -23,7 +23,6 @@ use Symfony\Component\Process\Process;
  */
 class Php7ccSpec extends ObjectBehavior
 {
-
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('php7cc')->willReturn([]);

--- a/spec/GrumPHP/Task/PhpCpdSpec.php
+++ b/spec/GrumPHP/Task/PhpCpdSpec.php
@@ -23,7 +23,6 @@ use Symfony\Component\Process\Process;
  */
 class PhpCpdSpec extends ObjectBehavior
 {
-
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('phpcpd')->willReturn([]);

--- a/spec/GrumPHP/Task/PhpCsFixerSpec.php
+++ b/spec/GrumPHP/Task/PhpCsFixerSpec.php
@@ -25,7 +25,6 @@ use Symfony\Component\Process\Process;
  */
 class PhpCsFixerSpec extends ObjectBehavior
 {
-
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, AsyncProcessRunner $processRunner, PhpCsFixerFormatter $formatter)
     {
         $grumPHP->getTaskConfiguration('phpcsfixer')->willReturn([]);

--- a/spec/GrumPHP/Task/PhpCsFixerV2Spec.php
+++ b/spec/GrumPHP/Task/PhpCsFixerV2Spec.php
@@ -25,7 +25,6 @@ use Symfony\Component\Process\Process;
  */
 class PhpCsFixerV2Spec extends ObjectBehavior
 {
-
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, AsyncProcessRunner $processRunner, PhpCsFixerFormatter $formatter)
     {
         $grumPHP->getTaskConfiguration('phpcsfixer2')->willReturn([]);

--- a/spec/GrumPHP/Task/PhpLintSpec.php
+++ b/spec/GrumPHP/Task/PhpLintSpec.php
@@ -22,7 +22,6 @@ use Symfony\Component\Process\Process;
  */
 class PhpLintSpec extends ObjectBehavior
 {
-
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('phplint')->willReturn([]);

--- a/spec/GrumPHP/Task/PhpMdSpec.php
+++ b/spec/GrumPHP/Task/PhpMdSpec.php
@@ -23,7 +23,6 @@ use Symfony\Component\Process\Process;
  */
 class PhpMdSpec extends ObjectBehavior
 {
-
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('phpmd')->willReturn([]);

--- a/spec/GrumPHP/Task/PhpParserSpec.php
+++ b/spec/GrumPHP/Task/PhpParserSpec.php
@@ -14,7 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class PhpParserSpec extends AbstractParserTaskSpec
 {
-
     function let(GrumPHP $grumPHP, ParserInterface $parser)
     {
         $parser->isInstalled()->willReturn(true);

--- a/spec/GrumPHP/Task/PhpcsSpec.php
+++ b/spec/GrumPHP/Task/PhpcsSpec.php
@@ -23,7 +23,6 @@ use Symfony\Component\Process\Process;
  */
 class PhpcsSpec extends ObjectBehavior
 {
-
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, PhpcsFormatter $formatter)
     {
         $grumPHP->getTaskConfiguration('phpcs')->willReturn([]);

--- a/spec/GrumPHP/Task/PhpspecSpec.php
+++ b/spec/GrumPHP/Task/PhpspecSpec.php
@@ -23,7 +23,6 @@ use Symfony\Component\Process\Process;
  */
 class PhpspecSpec extends ObjectBehavior
 {
-
     function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
     {
         $grumPHP->getTaskConfiguration('phpspec')->willReturn([]);

--- a/spec/GrumPHP/Util/RegexSpec.php
+++ b/spec/GrumPHP/Util/RegexSpec.php
@@ -9,7 +9,6 @@ use PhpSpec\ObjectBehavior;
  */
 class RegexSpec extends ObjectBehavior
 {
-
     function it_will_handle_regex_input()
     {
         $this->beConstructedWith('#test#');

--- a/src/GrumPHP/Collection/TasksCollection.php
+++ b/src/GrumPHP/Collection/TasksCollection.php
@@ -16,7 +16,6 @@ use SplPriorityQueue;
  */
 class TasksCollection extends ArrayCollection
 {
-
     /**
      * @param ContextInterface $context
      *

--- a/src/GrumPHP/Collection/TestSuiteCollection.php
+++ b/src/GrumPHP/Collection/TestSuiteCollection.php
@@ -13,7 +13,6 @@ use GrumPHP\TestSuite\TestSuiteInterface;
  */
 class TestSuiteCollection extends ArrayCollection
 {
-
     /**
      * @param string $name
      *

--- a/src/GrumPHP/Configuration/Compiler/TaskCompilerPass.php
+++ b/src/GrumPHP/Configuration/Compiler/TaskCompilerPass.php
@@ -15,7 +15,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class TaskCompilerPass implements CompilerPassInterface
 {
-
     const TAG_GRUMPHP_TASK = 'grumphp.task';
 
     /**

--- a/src/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriber.php
+++ b/src/GrumPHP/Event/Subscriber/StashUnstagedChangesSubscriber.php
@@ -22,7 +22,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class StashUnstagedChangesSubscriber implements EventSubscriberInterface
 {
-
     /**
      * @var GrumPHP
      */

--- a/src/GrumPHP/Exception/RuntimeException.php
+++ b/src/GrumPHP/Exception/RuntimeException.php
@@ -13,7 +13,6 @@ use RuntimeException as BaseRuntimeException;
  */
 class RuntimeException extends BaseRuntimeException implements ExceptionInterface
 {
-
     /**
      * @param Exception $e
      *

--- a/src/GrumPHP/Linter/Json/JsonLintError.php
+++ b/src/GrumPHP/Linter/Json/JsonLintError.php
@@ -13,7 +13,6 @@ use SplFileInfo;
  */
 class JsonLintError extends LintError
 {
-
     /**
      * @param SplFileInfo      $file
      * @param ParsingException $exception

--- a/src/GrumPHP/Linter/Xml/XmlLinter.php
+++ b/src/GrumPHP/Linter/Xml/XmlLinter.php
@@ -14,7 +14,6 @@ use SplFileInfo;
  */
 class XmlLinter implements LinterInterface
 {
-
     const XSI_NAMESPACE = 'http://www.w3.org/2001/XMLSchema-instance';
 
     /**

--- a/src/GrumPHP/Linter/Yaml/YamlLintError.php
+++ b/src/GrumPHP/Linter/Yaml/YamlLintError.php
@@ -12,7 +12,6 @@ use Symfony\Component\Yaml\Exception\ParseException;
  */
 class YamlLintError extends LintError
 {
-
     /**
      * @var string
      */

--- a/src/GrumPHP/Linter/Yaml/YamlLinter.php
+++ b/src/GrumPHP/Linter/Yaml/YamlLinter.php
@@ -17,7 +17,6 @@ use Symfony\Component\Yaml\Yaml;
  */
 class YamlLinter implements LinterInterface
 {
-
     /**
      * True if object support is enabled, false otherwise
      *

--- a/src/GrumPHP/Process/ProcessBuilder.php
+++ b/src/GrumPHP/Process/ProcessBuilder.php
@@ -18,7 +18,6 @@ use \Symfony\Component\Process\ProcessBuilder as SymfonyProcessBuilder;
  */
 class ProcessBuilder
 {
-
     /**
      * @var ExternalCommand
      */

--- a/src/GrumPHP/Runner/TaskRunnerContext.php
+++ b/src/GrumPHP/Runner/TaskRunnerContext.php
@@ -12,7 +12,6 @@ use GrumPHP\TestSuite\TestSuiteInterface;
  */
 class TaskRunnerContext
 {
-
     /**
      * @var ContextInterface
      */

--- a/src/GrumPHP/Task/Composer.php
+++ b/src/GrumPHP/Task/Composer.php
@@ -20,7 +20,6 @@ use SplFileInfo;
  */
 class Composer extends AbstractExternalTask
 {
-
     /**
      * @var Filesystem
      */

--- a/src/GrumPHP/Task/Context/ContextInterface.php
+++ b/src/GrumPHP/Task/Context/ContextInterface.php
@@ -11,7 +11,6 @@ use GrumPHP\Collection\FilesCollection;
  */
 interface ContextInterface
 {
-
     /**
      * @return FilesCollection
      */

--- a/src/GrumPHP/Task/Context/GitCommitMsgContext.php
+++ b/src/GrumPHP/Task/Context/GitCommitMsgContext.php
@@ -11,7 +11,6 @@ use GrumPHP\Collection\FilesCollection;
  */
 class GitCommitMsgContext implements ContextInterface
 {
-
     /**
      * @var FilesCollection
      */

--- a/src/GrumPHP/Task/Context/GitPreCommitContext.php
+++ b/src/GrumPHP/Task/Context/GitPreCommitContext.php
@@ -11,7 +11,6 @@ use GrumPHP\Collection\FilesCollection;
  */
 class GitPreCommitContext implements ContextInterface
 {
-
     /**
      * @var FilesCollection
      */

--- a/src/GrumPHP/Task/DoctrineOrm.php
+++ b/src/GrumPHP/Task/DoctrineOrm.php
@@ -13,7 +13,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class DoctrineOrm extends AbstractExternalTask
 {
-
     /**
      * @return string
      */

--- a/src/GrumPHP/Task/PhpCpd.php
+++ b/src/GrumPHP/Task/PhpCpd.php
@@ -13,7 +13,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class PhpCpd extends AbstractExternalTask
 {
-
     /**
      * @return string
      */

--- a/src/GrumPHP/Task/PhpMd.php
+++ b/src/GrumPHP/Task/PhpMd.php
@@ -13,7 +13,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class PhpMd extends AbstractExternalTask
 {
-
     /**
      * @return string
      */

--- a/src/GrumPHP/Task/TaskInterface.php
+++ b/src/GrumPHP/Task/TaskInterface.php
@@ -13,7 +13,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 interface TaskInterface
 {
-
     /**
      * @return string
      */

--- a/src/GrumPHP/Util/Composer.php
+++ b/src/GrumPHP/Util/Composer.php
@@ -19,7 +19,6 @@ use GrumPHP\Exception\RuntimeException;
  */
 class Composer
 {
-
     /**
      * @param string|JsonFile $json
      * @param Config $config

--- a/src/GrumPHP/Util/PhpVersion.php
+++ b/src/GrumPHP/Util/PhpVersion.php
@@ -10,7 +10,6 @@ use DateTime;
  */
 class PhpVersion
 {
-
     /**
      * @var array
      */

--- a/src/GrumPHP/Util/Regex.php
+++ b/src/GrumPHP/Util/Regex.php
@@ -12,7 +12,6 @@ use RuntimeException;
  */
 class Regex
 {
-
     /**
      * A list of all allowed regex modifiers in PHP.
      */

--- a/test/src/GrumPHPTest/Linter/Yaml/YamlLinterTest.php
+++ b/test/src/GrumPHPTest/Linter/Yaml/YamlLinterTest.php
@@ -85,7 +85,6 @@ class YamlLinterTest extends PHPUnit_Framework_TestCase
         $this->linter->setExceptionOnInvalidType(true);
         $fixture = YamlLinter::supportsFlags() ? 'object-support.yml' : 'object-support-old.yml';
         $this->validateFixture($fixture, 1);
-
     }
 
     /**

--- a/test/src/GrumPHPTest/Parser/Php/Visitor/AbstractVisitorTest.php
+++ b/test/src/GrumPHPTest/Parser/Php/Visitor/AbstractVisitorTest.php
@@ -19,7 +19,6 @@ use SplFileInfo;
  */
 abstract class AbstractVisitorTest extends PHPUnit_Framework_TestCase
 {
-
     /**
      * @test
      */

--- a/test/src/GrumPHPTest/Parser/Php/Visitor/ForbiddenStaticMethodCallsVisitorTest.php
+++ b/test/src/GrumPHPTest/Parser/Php/Visitor/ForbiddenStaticMethodCallsVisitorTest.php
@@ -41,7 +41,7 @@ class ForbiddenStaticMethodCallsVisitorTest extends AbstractVisitorTest
     {
         $code = <<<EOC
 <?php
-use Dumper\StaticDumper As StaticDumper;
+use Dumper\StaticDumper;
 use Dumper\Alias As StaticDumperAlias;
 
 StaticDumper::dump('something');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | n/a

* Removed blank lines immediately inside compound statements (`{}`).
* Bonus: removed redundant import alias aliased to itself.