### PR TITLE
Add phpcpd names-exclude option

### DIFF
--- a/doc/tasks/phpcpd.md
+++ b/doc/tasks/phpcpd.md
@@ -10,6 +10,7 @@ parameters:
         phpcpd:
             directory: '.'
             exclude: ['vendor']
+            names_exclude: []
             fuzzy: false
             min_lines: 5
             min_tokens: 70
@@ -27,6 +28,12 @@ With this parameter you can define which directory you want to run `phpcpd` in (
 *Default: [vendor]*
 
 With this parameter you will be able to exclude one or multiple directories from code analysis (must be relative to `directory`).
+
+**names_exclude**
+
+*Default: []*
+
+With this parameter you will be able to exclude one or multiple files from code analysis (must be relative to `directory`).
 
 **fuzzy**
 

--- a/spec/GrumPHP/Task/PhpCpdSpec.php
+++ b/spec/GrumPHP/Task/PhpCpdSpec.php
@@ -42,6 +42,7 @@ class PhpCpdSpec extends ObjectBehavior
         $options->shouldBeAnInstanceOf(OptionsResolver::class);
         $options->getDefinedOptions()->shouldContain('directory');
         $options->getDefinedOptions()->shouldContain('exclude');
+        $options->getDefinedOptions()->shouldContain('names_exclude');
         $options->getDefinedOptions()->shouldContain('fuzzy');
         $options->getDefinedOptions()->shouldContain('min_lines');
         $options->getDefinedOptions()->shouldContain('min_tokens');

--- a/src/GrumPHP/Task/PhpCpd.php
+++ b/src/GrumPHP/Task/PhpCpd.php
@@ -30,6 +30,7 @@ class PhpCpd extends AbstractExternalTask
         $resolver->setDefaults([
             'directory' => '.',
             'exclude' => ['vendor'],
+            'names_exclude' => [],
             'fuzzy' => false,
             'min_lines' => 5,
             'min_tokens' => 70,
@@ -38,6 +39,7 @@ class PhpCpd extends AbstractExternalTask
 
         $resolver->addAllowedTypes('directory', ['string']);
         $resolver->addAllowedTypes('exclude', ['array']);
+        $resolver->addAllowedTypes('names_exclude', ['array']);
         $resolver->addAllowedTypes('fuzzy', ['bool']);
         $resolver->addAllowedTypes('min_lines', ['int']);
         $resolver->addAllowedTypes('min_tokens', ['int']);
@@ -72,6 +74,7 @@ class PhpCpd extends AbstractExternalTask
         }, $config['triggered_by']);
 
         $arguments->addArgumentArray('--exclude=%s', $config['exclude']);
+        $arguments->addArgumentArray('--names-exclude=%s', $config['names_exclude']);
         $arguments->addRequiredArgument('--min-lines=%u', $config['min_lines']);
         $arguments->addRequiredArgument('--min-tokens=%u', $config['min_tokens']);
         $arguments->addOptionalCommaSeparatedArgument('--names=%s', $extensions);


### PR DESCRIPTION
Adds the phpcpd --names-exclude option, this allows a comma-separated list of file names to exclude.

Example:

```
  phpcpd:
        names_exclude: ['_ide_helper.php']
```