### PR TITLE
Add 'diff' option to phpcsfixer2 task

### DIFF
--- a/doc/tasks/php_cs_fixer2.md
+++ b/doc/tasks/php_cs_fixer2.md
@@ -15,6 +15,7 @@ parameters:
             using_cache: true
             path_mode: ~
             verbose: true
+            diff: false
 ```
 
 
@@ -22,8 +23,8 @@ parameters:
 
 *Default: false*
 
-The allow_risky option allows you to set whether riskys fixer may run. 
-Risky fixer is a fixer, which could change code behaviour. 
+The allow_risky option allows you to set whether riskys fixer may run.
+Risky fixer is a fixer, which could change code behaviour.
 By default no risky fixers are run.
 
 
@@ -55,9 +56,9 @@ The rules option lets you choose the exact fixers to apply.
 
 *Default: true*
 
-The caching mechanism is enabled by default. 
-This will speed up further runs by fixing only files that were modified since the last run. 
-The tool will fix all files if the tool version has changed or the list of fixers has changed. 
+The caching mechanism is enabled by default.
+This will speed up further runs by fixing only files that were modified since the last run.
+The tool will fix all files if the tool version has changed or the list of fixers has changed.
 Cache is supported only for tool downloaded as phar file or installed via composer.
 
 
@@ -73,3 +74,9 @@ Specify path mode (can be override or intersection).
 *Default: true*
 
 Show applied fixers.
+
+**diff**
+
+*Default: false*
+
+Show the full diff that will be applied.

--- a/spec/Formatter/PhpCsFixerFormatterSpec.php
+++ b/spec/Formatter/PhpCsFixerFormatterSpec.php
@@ -59,6 +59,15 @@ class PhpCsFixerFormatterSpec extends ObjectBehavior
         $this->format($process)->shouldBe('1) name1' . PHP_EOL . '2) name2 (fixer1,fixer2)');
     }
 
+    function it_formats_php_cs_fixer_json_output_for_diff(Process $process)
+    {
+        $json = $this->parseJson([
+            ['name' => 'name1', 'diff' => 'diff1'],
+        ]);
+        $process->getOutput()->willReturn($json);
+        $this->format($process)->shouldBe('1) name1' . PHP_EOL . PHP_EOL . 'diff1');
+    }
+
     function it_should_be_possible_to_reset_the_counter(Process $process)
     {
         $json = $this->parseJson([['name' => 'name1']]);

--- a/spec/Task/PhpCsFixerV2Spec.php
+++ b/spec/Task/PhpCsFixerV2Spec.php
@@ -54,6 +54,7 @@ class PhpCsFixerV2Spec extends ObjectBehavior
         $options->getDefinedOptions()->shouldContain('using_cache');
         $options->getDefinedOptions()->shouldContain('path_mode');
         $options->getDefinedOptions()->shouldContain('verbose');
+        $options->getDefinedOptions()->shouldContain('diff');
     }
 
     function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder, ContextInterface $context)

--- a/src/Formatter/PhpCsFixerFormatter.php
+++ b/src/Formatter/PhpCsFixerFormatter.php
@@ -101,12 +101,14 @@ class PhpCsFixerFormatter implements ProcessFormatterInterface
         }
 
         $hasFixers = isset($file['appliedFixers']);
+        $hasDiff = isset($file['diff']);
 
         return sprintf(
-            '%s) %s%s',
+            '%s) %s%s%s',
             ++$this->counter,
             $file['name'],
-            $hasFixers ? ' (' . implode(',', $file['appliedFixers']) . ')' : ''
+            $hasFixers ? ' (' . implode(',', $file['appliedFixers']) . ')' : '',
+            $hasDiff ? PHP_EOL . PHP_EOL . $file['diff'] : ''
         );
     }
 }

--- a/src/Task/PhpCsFixerV2.php
+++ b/src/Task/PhpCsFixerV2.php
@@ -65,6 +65,7 @@ class PhpCsFixerV2 extends AbstractPhpCsFixerTask
         $this->formatter->resetCounter();
 
         $arguments = $this->processBuilder->createArgumentsForCommand('php-cs-fixer');
+        $arguments->add('--format=json');
         $arguments->add('--dry-run');
         $arguments->addOptionalArgument('--allow-risky=%s', $config['allow_risky'] ? 'yes' : 'no');
         $arguments->addOptionalArgument('--cache-file=%s', $config['cache_file']);

--- a/src/Task/PhpCsFixerV2.php
+++ b/src/Task/PhpCsFixerV2.php
@@ -34,6 +34,7 @@ class PhpCsFixerV2 extends AbstractPhpCsFixerTask
             'using_cache' => true,
             'path_mode' => null,
             'verbose' => true,
+            'diff' => false,
         ]);
 
         $resolver->addAllowedTypes('allow_risky', ['bool']);
@@ -43,6 +44,7 @@ class PhpCsFixerV2 extends AbstractPhpCsFixerTask
         $resolver->addAllowedTypes('using_cache', ['bool']);
         $resolver->addAllowedTypes('path_mode', ['null', 'string']);
         $resolver->addAllowedTypes('verbose', ['bool']);
+        $resolver->addAllowedTypes('diff', ['bool']);
 
         $resolver->setAllowedValues('path_mode', [null, 'override', 'intersection']);
 
@@ -63,7 +65,6 @@ class PhpCsFixerV2 extends AbstractPhpCsFixerTask
         $this->formatter->resetCounter();
 
         $arguments = $this->processBuilder->createArgumentsForCommand('php-cs-fixer');
-        $arguments->add('--format=json');
         $arguments->add('--dry-run');
         $arguments->addOptionalArgument('--allow-risky=%s', $config['allow_risky'] ? 'yes' : 'no');
         $arguments->addOptionalArgument('--cache-file=%s', $config['cache_file']);
@@ -72,6 +73,7 @@ class PhpCsFixerV2 extends AbstractPhpCsFixerTask
         $arguments->addOptionalArgument('--using-cache=%s', $config['using_cache'] ? 'yes' : 'no');
         $arguments->addOptionalArgument('--path-mode=%s', $config['path_mode']);
         $arguments->addOptionalArgument('--verbose', $config['verbose']);
+        $arguments->addOptionalArgument('--diff', $config['diff']);
         $arguments->add('fix');
 
         if ($context instanceof RunContext && $config['config'] !== null) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | no

PHP CS Fixer 2 has an option called `--diff` to visualize the diff of all the code violations it found. I added an option to enable the output of this diff when GrumPHP is executed. By default this option is disabled.

One note: i'm not sure why the [`--format=json`](https://github.com/phpro/grumphp/compare/master...jhuet:feature/phpcsfixer2-option-diff?expand=1#diff-5734ec63a7bc6aa3851c2701bfa89c70L66) was forced but it didn't allow the diff output to appear so i removed it.