### PR TITLE
Updated php_cs_fixer v2 doc @@ escaping

### DIFF
--- a/doc/tasks/php_cs_fixer2.md
+++ b/doc/tasks/php_cs_fixer2.md
@@ -50,6 +50,9 @@ You can specify an alternate location for this file by changing this option.
 
 You can limit the amount of rules that are being checked.
 The rules option lets you choose the exact fixers to apply.
+Using the introduced rules from php cs fixer 2 you will have to escape the rules with another @ character, e.g.
+
+rules: ['@@PSR2','@@Symfony']
 
 
 **using_cache**

--- a/doc/tasks/php_cs_fixer2.md
+++ b/doc/tasks/php_cs_fixer2.md
@@ -52,8 +52,9 @@ You can limit the amount of rules that are being checked.
 The rules option lets you choose the exact fixers to apply.
 Using the newly introduced rules (@PSR2 or @Symfony etc) you will have to escape those with another @ character, e.g.
 
-rules: ['@@PSR2','@@Symfony']
-
+```yml
+rules: ['@@PSR2', '@@Symfony']
+```
 
 **using_cache**
 

--- a/doc/tasks/php_cs_fixer2.md
+++ b/doc/tasks/php_cs_fixer2.md
@@ -50,7 +50,7 @@ You can specify an alternate location for this file by changing this option.
 
 You can limit the amount of rules that are being checked.
 The rules option lets you choose the exact fixers to apply.
-Using the introduced rules from php cs fixer 2 you will have to escape the rules with another @ character, e.g.
+Using the newly introduced rules (@PSR2 or @Symfony etc) you will have to escape those with another @ character, e.g.
 
 rules: ['@@PSR2','@@Symfony']
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #281

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

Due to a missing hint on escaping the new rules grumphp breaks the php_cs_fixer v2. 
More details on this here:
https://github.com/phpro/grumphp/issues/281

Tested and working local as well as prod for me
