### PR TITLE
Added hide_circumvention_tip parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ parameters:
     hooks_preset: local
     stop_on_failure: false
     ignore_unstaged_changes: false
+    hide_circumvention_tip: false
     process_async_limit: 10
     process_async_wait: 1000
     process_timeout: 60
@@ -128,13 +129,13 @@ parameters:
     extensions: []
 ```
 
-You can find a detailed overview of the configurable options in these sections:
+Details of the configuration are broken down into the following sections.
 
-- [Parameters](doc/parameters.md)
-- [Tasks](doc/tasks.md)
-- [Events](doc/events.md)
+- [Parameters](doc/parameters.md) &ndash; Configuration settings for GrumPHP itself.
+- [Tasks](doc/tasks.md) &ndash; External tasks performing code validation and their respective configurations.
 - [TestSuites](doc/testsuites.md)
 - [Extensions](doc/extensions.md)
+- [Events](doc/events.md)
 
 ## Commands
 
@@ -163,7 +164,7 @@ This package has been tested with following git clients:
 ## Roadmap
 
 Lots of tasks are already available to make sure your team writes great code.
-There are still 1 major parts that are missing before we can release a v1.0.0:
+There is one major part missing before we can release v1.0.0:
 
 - [A PHAR executable](https://github.com/phpro//grumphp/issues/61)
 
@@ -192,4 +193,4 @@ Please take a look at our rules before [contributing your code](CONTRIBUTING.md)
 
 ### License
 
-GrumPHP is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+GrumPHP is licensed under the [MIT License](LICENSE).

--- a/doc/events.md
+++ b/doc/events.md
@@ -3,7 +3,7 @@
 It is possible to hook in to GrumPHP with events.
 Internally the Symfony event dispatcher is being used. 
 
-Following events are triggered during execution:
+The following events are triggered during execution:
 
 | Event name              | Event class           | Triggered
 | ----------------------- | --------------------- | ----------
@@ -17,7 +17,7 @@ Following events are triggered during execution:
 | console.terminate       | ConsoleTerminateEvent | before a CLI command terminates
 | console.exception       | ConsoleExceptionEvent | when a CLI command throws an unhandled exception.
 
-Configured events just like you would in Symfony: 
+Configure events just like you would in Symfony:
 
 ```yml
 # grumphp.yml

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -9,6 +9,7 @@ parameters:
     hooks_preset: local
     stop_on_failure: false
     ignore_unstaged_changes: false
+    hide_circumvention_tip: false
     process_async_limit: 10
     process_async_wait: 1000
     process_timeout: 60
@@ -77,6 +78,12 @@ By enabling this option, GrumPHP will stash your unstaged changes in git before 
 This way the tasks will run with the code that is actually committed without the unstaged changes.
 Note that during the commit, the unstaged changes will be stored in git stash.
 This may mess with your working copy and result in unexpected merge conflicts.
+
+**hide_circumvention_tip**
+
+*Default: false*
+
+Hides the tip describing how to circumvent the Git commit hook and bypass GrumPHP when a task fails.
 
 **process_async_limit**
 

--- a/resources/config/parameters.yml
+++ b/resources/config/parameters.yml
@@ -7,6 +7,7 @@ parameters:
   testsuites: []
   stop_on_failure: false
   ignore_unstaged_changes: false
+  hide_circumvention_tip: false
   process_async_limit: 10
   process_async_wait: 1000
   process_timeout: 60

--- a/spec/Console/Helper/TaskRunnerHelperSpec.php
+++ b/spec/Console/Helper/TaskRunnerHelperSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\GrumPHP\Console\Helper;
 
+use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Console\Helper\PathsHelper;
 use GrumPHP\Console\Helper\TaskRunnerHelper;
 use GrumPHP\Event\Subscriber\ProgressSubscriber;
@@ -21,6 +22,7 @@ use Prophecy\Argument;
 class TaskRunnerHelperSpec extends ObjectBehavior
 {
     function let(
+        GrumPHP $config,
         TaskRunner $taskRunner,
         EventDispatcherInterface $eventDispatcher,
         HelperSet $helperSet,
@@ -28,15 +30,16 @@ class TaskRunnerHelperSpec extends ObjectBehavior
         TaskRunnerContext $runnerContext,
         ContextInterface $taskContext
     ) {
-        $this->beConstructedWith($taskRunner, $eventDispatcher);
+        $this->beConstructedWith($config, $taskRunner, $eventDispatcher);
 
         $helperSet->get(PathsHelper::HELPER_NAME)->willreturn($pathsHelper);
         $this->setHelperSet($helperSet);
 
         $runnerContext->getTaskContext()->willReturn($taskContext);
         $runnerContext->hasTestSuite()->willReturn(false);
-        $runnerContext->shouldSkipSuccessOutput()->willReturn(false);
-        $runnerContext->shouldHideCircumventionTip()->willReturn(false);
+        $runnerContext->skipSuccessOutput()->willReturn(false);
+
+        $config->hideCircumventionTip()->willReturn(false);
     }
 
     function it_is_a_console_helper()

--- a/spec/Console/Helper/TaskRunnerHelperSpec.php
+++ b/spec/Console/Helper/TaskRunnerHelperSpec.php
@@ -35,7 +35,8 @@ class TaskRunnerHelperSpec extends ObjectBehavior
 
         $runnerContext->getTaskContext()->willReturn($taskContext);
         $runnerContext->hasTestSuite()->willReturn(false);
-        $runnerContext->isSkipSuccessOutput()->willReturn(false);
+        $runnerContext->shouldSkipSuccessOutput()->willReturn(false);
+        $runnerContext->shouldHideCircumventionTip()->willReturn(false);
     }
 
     function it_is_a_console_helper()

--- a/spec/Runner/TaskRunnerContextSpec.php
+++ b/spec/Runner/TaskRunnerContextSpec.php
@@ -39,8 +39,8 @@ class TaskRunnerContextSpec extends ObjectBehavior
 
     function it_knows_to_skip_the_success_message()
     {
-        $this->isSkipSuccessOutput()->shouldBe(false);
+        $this->shouldSkipSuccessOutput()->shouldBe(false);
         $this->setSkipSuccessOutput(true);
-        $this->isSkipSuccessOutput()->shouldBe(true);
+        $this->shouldSkipSuccessOutput()->shouldBe(true);
     }
 }

--- a/spec/Runner/TaskRunnerContextSpec.php
+++ b/spec/Runner/TaskRunnerContextSpec.php
@@ -39,8 +39,8 @@ class TaskRunnerContextSpec extends ObjectBehavior
 
     function it_knows_to_skip_the_success_message()
     {
-        $this->shouldSkipSuccessOutput()->shouldBe(false);
+        $this->skipSuccessOutput()->shouldBe(false);
         $this->setSkipSuccessOutput(true);
-        $this->shouldSkipSuccessOutput()->shouldBe(true);
+        $this->skipSuccessOutput()->shouldBe(true);
     }
 }

--- a/src/Configuration/GrumPHP.php
+++ b/src/Configuration/GrumPHP.php
@@ -114,7 +114,7 @@ class GrumPHP
      *
      * @return bool True to hide the tip, otherwise false.
      */
-    public function shouldHideCircumventionTip()
+    public function hideCircumventionTip()
     {
         return (bool)$this->container->getParameter('hide_circumvention_tip');
     }

--- a/src/Configuration/GrumPHP.php
+++ b/src/Configuration/GrumPHP.php
@@ -110,6 +110,16 @@ class GrumPHP
     }
 
     /**
+     * Gets a value indicating whether the Git commit hook circumvention tip should be shown when a task fails.
+     *
+     * @return bool True to hide the tip, otherwise false.
+     */
+    public function shouldHideCircumventionTip()
+    {
+        return (bool)$this->container->getParameter('hide_circumvention_tip');
+    }
+
+    /**
      * @param string $taskName
      *
      * @return array

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -127,6 +127,7 @@ class Application extends SymfonyConsole
             $this->getDefaultConfigPath()
         ));
         $helperSet->set(new Helper\TaskRunnerHelper(
+            $container->get('config'),
             $container->get('task_runner'),
             $container->get('event_dispatcher')
         ));

--- a/src/Console/Command/Git/PreCommitCommand.php
+++ b/src/Console/Command/Git/PreCommitCommand.php
@@ -73,7 +73,6 @@ class PreCommitCommand extends Command
             new GitPreCommitContext($files),
             $this->grumPHP->getTestSuites()->getOptional('git_pre_commit')
         );
-        $context->setSkipSuccessOutput((bool) $input->getOption('skip-success-output'));
 
         $output->writeln('<fg=yellow>GrumPHP detected a pre-commit command.</fg=yellow>');
         return $this->taskRunner()->run($output, $context);

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -70,7 +70,6 @@ class RunCommand extends Command
             new RunContext($files),
             (bool) $input->getOption('testsuite') ? $testSuites->getRequired($input->getOption('testsuite')) : null
         );
-        $context->setHideCircumventionTip($this->grumPHP->shouldHideCircumventionTip());
 
         return $this->taskRunner()->run($output, $context);
     }

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -70,6 +70,7 @@ class RunCommand extends Command
             new RunContext($files),
             (bool) $input->getOption('testsuite') ? $testSuites->getRequired($input->getOption('testsuite')) : null
         );
+        $context->setHideCircumventionTip($this->grumPHP->shouldHideCircumventionTip());
 
         return $this->taskRunner()->run($output, $context);
     }

--- a/src/Console/Helper/PathsHelper.php
+++ b/src/Console/Helper/PathsHelper.php
@@ -12,8 +12,6 @@ use Symfony\Component\Console\Helper\Helper;
 
 /**
  * This class will return all configured paths relative to the working directory.
- *
- * Class PathsHelper
  */
 class PathsHelper extends Helper
 {

--- a/src/Runner/TaskRunnerContext.php
+++ b/src/Runner/TaskRunnerContext.php
@@ -18,11 +18,6 @@ class TaskRunnerContext
     private $skipSuccessOutput = false;
 
     /**
-     * @var bool
-     */
-    private $hideCircumventionTip = false;
-
-    /**
      * @var null|TestSuiteInterface
      */
     private $testSuite = null;
@@ -50,7 +45,7 @@ class TaskRunnerContext
     /**
      * @return bool
      */
-    public function shouldSkipSuccessOutput()
+    public function skipSuccessOutput()
     {
         return $this->skipSuccessOutput;
     }
@@ -69,22 +64,6 @@ class TaskRunnerContext
     public function hasTestSuite()
     {
         return $this->testSuite !== null;
-    }
-
-    /**
-     * @return bool
-     */
-    public function shouldHideCircumventionTip()
-    {
-        return $this->hideCircumventionTip;
-    }
-
-    /**
-     * @param bool $hideCircumventionTip
-     */
-    public function setHideCircumventionTip($hideCircumventionTip)
-    {
-        $this->hideCircumventionTip = (bool)$hideCircumventionTip;
     }
 
     /**

--- a/src/Runner/TaskRunnerContext.php
+++ b/src/Runner/TaskRunnerContext.php
@@ -18,6 +18,11 @@ class TaskRunnerContext
     private $skipSuccessOutput = false;
 
     /**
+     * @var bool
+     */
+    private $hideCircumventionTip = false;
+
+    /**
      * @var null|TestSuiteInterface
      */
     private $testSuite = null;
@@ -45,7 +50,7 @@ class TaskRunnerContext
     /**
      * @return bool
      */
-    public function isSkipSuccessOutput()
+    public function shouldSkipSuccessOutput()
     {
         return $this->skipSuccessOutput;
     }
@@ -55,7 +60,7 @@ class TaskRunnerContext
      */
     public function setSkipSuccessOutput($skipSuccessOutput)
     {
-        $this->skipSuccessOutput = $skipSuccessOutput;
+        $this->skipSuccessOutput = (bool)$skipSuccessOutput;
     }
 
     /**
@@ -64,6 +69,22 @@ class TaskRunnerContext
     public function hasTestSuite()
     {
         return $this->testSuite !== null;
+    }
+
+    /**
+     * @return bool
+     */
+    public function shouldHideCircumventionTip()
+    {
+        return $this->hideCircumventionTip;
+    }
+
+    /**
+     * @param bool $hideCircumventionTip
+     */
+    public function setHideCircumventionTip($hideCircumventionTip)
+    {
+        $this->hideCircumventionTip = (bool)$hideCircumventionTip;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #286

Adds a parameter to configure whether to show the Git commit hook circumvention tip when a task fails.

## Issues

One of the phpspec tests currently fails but I don't know phpspec so I don't understand why. Since I do not know phpspec I haven't written any new tests to cover this new feature; help wanted!

>----  broken examples
>
>        GrumPHP\Runner\TaskRunnerContext
>  40  ! knows to skip the success message
        no skipSuccessOutput([array:0]) matcher found for
        [obj:GrumPHP\Runner\TaskRunnerContext].

## Comments

I had difficulty even just testing this new feature manually. Although I can normally install GrumPHP, it does not work for the GrumPHP project itself for some reason.

>$ bin/grumphp git:init
>
>  [GrumPHP\Exception\RuntimeException]
  The executable for "grumphp" could not be found.

Furthermore GrumPHP does not have a feature to specify which files to check, so without being able to install the Git hook, it checks every single file which either takes a long time or fails completely due to #275. 

However, while coding I accidentally tripped a callisthenic check from the PhpParser task by writing an `else` statement, which allowed me to verify this feature does indeed seem to be working. 