### PR TITLE
Remove task field shadowing

### DIFF
--- a/src/Task/JsonLint.php
+++ b/src/Task/JsonLint.php
@@ -10,13 +10,11 @@ use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @property JsonLinter $linter
+ */
 class JsonLint extends AbstractLinterTask
 {
-    /**
-     * @var JsonLinter
-     */
-    protected $linter;
-
     /**
      * @return string
      */

--- a/src/Task/PhpParser.php
+++ b/src/Task/PhpParser.php
@@ -8,16 +8,13 @@ use GrumPHP\Runner\TaskResult;
 
 /**
  * Php Parser task
+ *
+ * @property \GrumPHP\Parser\Php\PhpParser $parser
  */
 class PhpParser extends AbstractParserTask
 {
     const KIND_PHP5 = 'php5';
     const KIND_PHP7 = 'php7';
-
-    /**
-     * @var \GrumPHP\Parser\Php\PhpParser
-     */
-    protected $parser;
 
     /**
      * @return string

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -13,14 +13,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Phpcs task
+ *
+ * @property PhpcsFormatter $formatter
  */
 class Phpcs extends AbstractExternalTask
 {
-    /**
-     * @var PhpcsFormatter
-     */
-    protected $formatter;
-
     /**
      * @return string
      */

--- a/src/Task/XmlLint.php
+++ b/src/Task/XmlLint.php
@@ -10,13 +10,11 @@ use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @property XmlLinter $linter
+ */
 class XmlLint extends AbstractLinterTask
 {
-    /**
-     * @var XmlLinter
-     */
-    protected $linter;
-
     /**
      * @return string
      */

--- a/src/Task/YamlLint.php
+++ b/src/Task/YamlLint.php
@@ -10,13 +10,11 @@ use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @property YamlLinter $linter
+ */
 class YamlLint extends AbstractLinterTask
 {
-    /**
-     * @var YamlLinter
-     */
-    protected $linter;
-
     /**
      * @return string
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | n/a

Removes field shadowing from tasks and replaces them with `@property` annotations to facilitate code completion for the derived type of the inherited field.