### PR TITLE
Added JSON rules support for PHP-CS-Fixer v2.1.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "composer/composer": "^1.0",
         "doctrine/collections": "~1.2",
         "gitonomy/gitlib": "~1.0",
+        "phptype/array": "^1",
         "monolog/monolog": "~1.17",
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
         "seld/jsonlint": "~1.1",
@@ -24,7 +25,7 @@
         "symfony/yaml": "~2.7|~3.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~1|~2",
+        "friendsofphp/php-cs-fixer": "^1|^2.1",
         "jakub-onderka/php-parallel-lint": "^0.9.2",
         "nikic/php-parser": "~2.1",
         "phpspec/phpspec": "^3.2.2",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "composer/composer": "^1.0",
         "doctrine/collections": "~1.2",
         "gitonomy/gitlib": "~1.0",
-        "phptype/array": "^1",
         "monolog/monolog": "~1.17",
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
         "seld/jsonlint": "~1.1",
@@ -25,7 +24,7 @@
         "symfony/yaml": "~2.7|~3.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^1|^2.1",
+        "friendsofphp/php-cs-fixer": "~1|~2",
         "jakub-onderka/php-parallel-lint": "^0.9.2",
         "nikic/php-parser": "~2.1",
         "phpspec/phpspec": "^3.2.2",

--- a/doc/tasks/php_cs_fixer2.md
+++ b/doc/tasks/php_cs_fixer2.md
@@ -49,13 +49,34 @@ You can specify an alternate location for this file by changing this option.
 
 *Default: []*
 
-You can limit the amount of rules that are being checked.
-The rules option lets you choose the exact fixers to apply.
-Using the newly introduced rules (@PSR2 or @Symfony etc) you will have to escape those with another @ character, e.g.
+Rules may be specified as either a list or map. A list of rules may only turn certain rules on or off whereas
+a map may also configure rules where applicable.
 
-```yml
-rules: ['@@PSR2', '@@Symfony']
+In the following list-style example, PSR-2 rules are enabled but the `line_ending` rule is removed from the
+set, while the `array_syntax` rule is added.
+
+```yaml
+rules:
+  - '@@PSR2'
+  - -line_ending
+  - array_syntax
 ```
+
+The following map-style example is the same as the previous, except we take advantage of rule configuration
+to change the `array_syntax` validation mode to short array syntax (`[]`) instead of the default long syntax
+(`array()`).
+
+```yaml
+rules:
+  '@PSR2': true
+  line_ending: false
+  array_syntax:
+    syntax: short
+```
+
+Note that rule sets, beginning with the *at* symbol (`@`), must be escaped by being quoted and doubled due to
+limitations of the parser. However, when appearing in the *key* position as in the previous example, doubling
+is incorrect.
 
 **using_cache**
 

--- a/src/Task/PhpCsFixerV2.php
+++ b/src/Task/PhpCsFixerV2.php
@@ -73,12 +73,12 @@ class PhpCsFixerV2 extends AbstractPhpCsFixerTask
         $arguments->addOptionalArgument('--cache-file=%s', $config['cache_file']);
         $arguments->addOptionalArgument('--config=%s', $config['config']);
 
-        $rules = $config['rules'];
-        // JSON-encode rules if specified as a map.
-        if (array_values($rules) !== $rules) {
-            $arguments->addOptionalArgument('--rules=%s', json_encode($rules));
-        } else {
-            $arguments->addOptionalCommaSeparatedArgument('--rules=%s', $rules);
+        if ($rules = $config['rules']) {
+            $arguments->add(sprintf(
+                '--rules=%s',
+                // Comma-delimit rules if specified as a list; otherwise JSON-encode.
+                array_values($rules) === $rules ? implode(',', $rules) : json_encode($rules)
+            ));
         }
 
         $arguments->addOptionalArgument('--using-cache=%s', $config['using_cache'] ? 'yes' : 'no');

--- a/src/Task/PhpCsFixerV2.php
+++ b/src/Task/PhpCsFixerV2.php
@@ -75,7 +75,7 @@ class PhpCsFixerV2 extends AbstractPhpCsFixerTask
         $arguments->addOptionalArgument('--config=%s', $config['config']);
 
         if (is_array($rules = $config['rules']) && ArrayType::isMap($rules)) {
-            $arguments->addOptionalArgument('--rules=\'%s\'', json_encode($rules));
+            $arguments->addOptionalArgument('--rules=\'%s\'', str_replace('\'', '\'\\\'\'', json_encode($rules)));
         } else {
             $arguments->addOptionalCommaSeparatedArgument('--rules=%s', $rules);
         }

--- a/src/Task/PhpCsFixerV2.php
+++ b/src/Task/PhpCsFixerV2.php
@@ -5,7 +5,6 @@ namespace GrumPHP\Task;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\RunContext;
-use ScriptFUSION\Type\ArrayType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -74,8 +73,10 @@ class PhpCsFixerV2 extends AbstractPhpCsFixerTask
         $arguments->addOptionalArgument('--cache-file=%s', $config['cache_file']);
         $arguments->addOptionalArgument('--config=%s', $config['config']);
 
-        if (is_array($rules = $config['rules']) && ArrayType::isMap($rules)) {
-            $arguments->addOptionalArgument('--rules=\'%s\'', str_replace('\'', '\'\\\'\'', json_encode($rules)));
+        $rules = $config['rules'];
+        // JSON-encode rules if specified as a map.
+        if (array_values($rules) !== $rules) {
+            $arguments->addOptionalArgument('--rules=%s', json_encode($rules));
         } else {
             $arguments->addOptionalCommaSeparatedArgument('--rules=%s', $rules);
         }

--- a/src/Task/PhpCsFixerV2.php
+++ b/src/Task/PhpCsFixerV2.php
@@ -5,6 +5,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\RunContext;
+use ScriptFUSION\Type\ArrayType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -72,7 +73,13 @@ class PhpCsFixerV2 extends AbstractPhpCsFixerTask
         $arguments->addOptionalArgument('--allow-risky=%s', $config['allow_risky'] ? 'yes' : 'no');
         $arguments->addOptionalArgument('--cache-file=%s', $config['cache_file']);
         $arguments->addOptionalArgument('--config=%s', $config['config']);
-        $arguments->addOptionalCommaSeparatedArgument('--rules=%s', $config['rules']);
+
+        if (is_array($rules = $config['rules']) && ArrayType::isMap($rules)) {
+            $arguments->addOptionalArgument('--rules=\'%s\'', json_encode($rules));
+        } else {
+            $arguments->addOptionalCommaSeparatedArgument('--rules=%s', $rules);
+        }
+
         $arguments->addOptionalArgument('--using-cache=%s', $config['using_cache'] ? 'yes' : 'no');
         $arguments->addOptionalArgument('--path-mode=%s', $config['path_mode']);
         $arguments->addOptionalArgument('--verbose', $config['verbose']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #288

Adds JSON rule support for PHP-CS-Fixer v2.1. To take advantage of this, the rules should be specified as a map instead of a list in the YAML configuration. However, to maintain backwards compatibility, list style is still supported, in which case rules will be comma-delimited as before.

## Issues
- [x] ~~Since I do not understand phpspec there are no tests. Please help by adding some! Feel free to commit directly to my branch.~~ Tests is dunned.
- [x] ~~There may be an issue where rules are specified as a map and any of the keys or values contains the single quote character (`'`) because it may escape the shell argument quoting. Single quotes may need to be escaped.~~ ~~I added a commit to address this issue by escaping single quotes. However, all that code may be unnecessary if the Symfony console layer handles escaping for us. Investigation needed.~~ Custom escaping is not needed.