### PR TITLE
Changed issue template "branch" to "version"

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,6 +1,6 @@
 | Q               | A
 | --------------- | ---
-| Branch          | master for features and deprecations
+| Version         | `grumphp -V`
 | Bug?            | yes/no
 | New feature?    | yes/no
 | Question?       | yes/no


### PR DESCRIPTION
*Branch* doesn't make sense for issues. I have replaced it with the version because we might want to know which version of the program the user is using instead.