### PR TITLE
Removed GrumPHP config parameter from git hooks

### DIFF
--- a/src/Console/Command/Git/InitCommand.php
+++ b/src/Console/Command/Git/InitCommand.php
@@ -4,7 +4,6 @@ namespace GrumPHP\Console\Command\Git;
 
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Console\Helper\PathsHelper;
-use GrumPHP\Exception\FileNotFoundException;
 use GrumPHP\Util\Filesystem;
 use RuntimeException;
 use SplFileInfo;
@@ -145,30 +144,7 @@ class InitCommand extends Command
             $command
         ]);
 
-        if ($configFile = $this->useExoticConfigFile()) {
-            $this->processBuilder->add(sprintf('--config=%s', $configFile));
-        }
-
         return $this->processBuilder->getProcess()->getCommandLine();
-    }
-
-    /**
-     * This method will tell you which exotic configuration file should be used.
-     *
-     * @return null|string
-     */
-    protected function useExoticConfigFile()
-    {
-        try {
-            $configPath = $this->paths()->getAbsolutePath($this->input->getOption('config'));
-            if ($configPath != $this->paths()->getDefaultConfigPath()) {
-                return $this->paths()->getRelativeProjectPath($configPath);
-            }
-        } catch (FileNotFoundException $e) {
-            // no config file should be set.
-        }
-
-        return null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #294

There is no need to pre-bake the config path into the Git hook because GrumPHP reads the config path out of `composer.json` at runtime. Furthermore, baking the relative path actually causes GrumPHP to fail to find the config.