### PR TITLE
Added coloured ballot marks for completed tasks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build status](https://api.travis-ci.org/phpro/grumphp.svg)](http://travis-ci.org/phpro/grumphp)
+[![Travic](https://img.shields.io/travis/phpro/grumphp/master.svg)](http://travis-ci.org/phpro/grumphp)
 [![Insight](https://img.shields.io/sensiolabs/i/9a345021-c8a1-4f48-948a-d15de51d9909.svg)](https://insight.sensiolabs.com/projects/9a345021-c8a1-4f48-948a-d15de51d9909)
-[![AppVeyor](https://img.shields.io/appveyor/ci/veewee/grumphp.svg)](https://ci.appveyor.com/project/veewee/grumphp)
+[![AppVeyor](https://ci.appveyor.com/api/projects/status/ttlbau2sjg36ep01/branch/master?svg=true)](https://ci.appveyor.com/project/veewee/grumphp/branch/master)
 [![Installs](https://img.shields.io/packagist/dt/phpro/grumphp.svg)](https://packagist.org/packages/phpro/grumphp/stats)
 [![Packagist](https://img.shields.io/packagist/v/phpro/grumphp.svg)](https://packagist.org/packages/phpro/grumphp)
 [![Twitter](https://img.shields.io/badge/Twitter-%40grumphp-blue.svg)](https://twitter.com/intent/user?screen_name=grumphp)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,22 +7,23 @@ clone_folder: c:\projects\grumphp
 
 environment:
     matrix:
-        - php_ver: 5.6.3
+        - php_ver: 7.1.2
 
 cache:
     - '%APPDATA%\Composer'
     - c:\tools\php -> appveyor.yml
 init:
-    - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
+    - SET PATH=C:\Program Files\OpenSSL;c:\tools\php71;%PATH%
     - SET COMPOSER_NO_INTERACTION=1
     - SET PHP=1
     - SET ANSICON=121x90 (121x90)
 
 install:
-    - IF EXIST c:\tools\php (SET PHP=0)
+    - ps: Set-Service wuauserv -StartupType Manual
+    - IF EXIST c:\tools\php71 (SET PHP=0)
     - IF %PHP%==1 cinst -y OpenSSL.Light
     - IF %PHP%==1 cinst -y php -version %php_ver%
-    - cd C:\tools\php
+    - cd C:\tools\php71
     - IF %PHP%==1 copy php.ini-production php.ini
     - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
     - IF %PHP%==1 echo memory_limit=1024M >> php.ini

--- a/spec/Runner/TaskRunnerSpec.php
+++ b/spec/Runner/TaskRunnerSpec.php
@@ -126,7 +126,7 @@ class TaskRunnerSpec extends ObjectBehavior
         $results->shouldContainFailedTaskResult();
     }
 
-    function it_returns_non_blocking_faled_when_tasks_throws_a_platform_exception(
+    function it_returns_skipped_when_tasks_throws_a_platform_exception(
         TaskInterface $task1,
         TaskInterface $task2,
         TaskRunnerContext $runnerContext,
@@ -137,8 +137,8 @@ class TaskRunnerSpec extends ObjectBehavior
 
         $results = $this->run($runnerContext);
         $results->shouldReturnAnInstanceOf(TaskResultCollection::class);
-        $results->shouldNotBePassed();
-        $results->shouldContainNonBlockingFailedTaskResult();
+        $results->shouldBePassed();
+        $results->shouldContainSkippedTaskResult();
     }
 
     function it_returns_a_failed_tasks_result_if_a_non_blocking_task_fails(
@@ -238,16 +238,21 @@ class TaskRunnerSpec extends ObjectBehavior
     public function getMatchers()
     {
         return [
-            'containFailedTaskResult' => function ($taskResultCollection) {
-                return $taskResultCollection->exists(function ($key, $taskResult) {
+            'containFailedTaskResult' => function (TaskResultCollection $taskResultCollection) {
+                return $taskResultCollection->exists(function ($key, TaskResult $taskResult) {
                     return TaskResult::FAILED === $taskResult->getResultCode();
                 });
             },
-            'containNonBlockingFailedTaskResult' => function ($taskResultCollection) {
-                return $taskResultCollection->exists(function ($key, $taskResult) {
+            'containNonBlockingFailedTaskResult' => function (TaskResultCollection $taskResultCollection) {
+                return $taskResultCollection->exists(function ($key, TaskResult $taskResult) {
                     return TaskResult::NONBLOCKING_FAILED === $taskResult->getResultCode();
                 });
             },
+            'containSkippedTaskResult' => function (TaskResultCollection $taskResultCollection) {
+                return $taskResultCollection->exists(function ($key, TaskResult $taskResult) {
+                    return TaskResult::SKIPPED === $taskResult->getResultCode();
+                });
+            }
         ];
     }
 }

--- a/spec/Task/Php7ccSpec.php
+++ b/spec/Task/Php7ccSpec.php
@@ -74,6 +74,7 @@ class Php7ccSpec extends ObjectBehavior
 
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
+        $process->getOutput()->willReturn('');
 
         $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')
@@ -90,8 +91,17 @@ class Php7ccSpec extends ObjectBehavior
         $processBuilder->createArgumentsForCommand('php7cc')->willReturn($arguments);
         $processBuilder->buildProcess($arguments)->willReturn($process);
 
+        $failedOutput = <<<'OUTPUT'
+File: /path/to/bad.php
+> Line 3: Removed argument $is_dst used for function "mktime"
+    mktime(5, 5, 5, 5, 5, 2000, -1);
+
+Checked 2 files in 0.040 second
+OUTPUT;
+
         $process->run()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
+        $process->getOutput()->willReturn($failedOutput);
 
         $context->getFiles()->willReturn(new FilesCollection([
             new SplFileInfo('test.php', '.', 'test.php')

--- a/src/Configuration/ContainerFactory.php
+++ b/src/Configuration/ContainerFactory.php
@@ -2,7 +2,6 @@
 
 namespace GrumPHP\Configuration;
 
-use GrumPHP\Configuration\Compiler;
 use GrumPHP\Util\Filesystem;
 use Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator;
 use Symfony\Component\Config\FileLocator;

--- a/src/Event/TaskEvents.php
+++ b/src/Event/TaskEvents.php
@@ -7,4 +7,5 @@ final class TaskEvents
     const TASK_RUN = 'grumphp.task.run';
     const TASK_COMPLETE = 'grumphp.task.complete';
     const TASK_FAILED = 'grumphp.task.failed';
+    const TASK_SKIPPED = 'grumphp.task.skipped';
 }

--- a/src/Process/ProcessBuilder.php
+++ b/src/Process/ProcessBuilder.php
@@ -86,10 +86,6 @@ class ProcessBuilder
             return;
         }
 
-        $this->io->write('', true);
-        $this->io->write('<fg=yellow>Oh no, we hit the windows cmd input limit!</fg=yellow>', true);
-        $this->io->write('<fg=yellow>Skipping task ...</fg=yellow>');
-
         throw PlatformException::commandLineStringLimit($process);
     }
 

--- a/src/Runner/TaskResult.php
+++ b/src/Runner/TaskResult.php
@@ -118,6 +118,11 @@ class TaskResult implements TaskResultInterface
         return self::PASSED === $this->getResultCode();
     }
 
+    public function hasFailed()
+    {
+        return self::FAILED === $this->getResultCode() || self::NONBLOCKING_FAILED === $this->getResultCode();
+    }
+
     /**
      * @return bool
      */

--- a/src/Task/JsonLint.php
+++ b/src/Task/JsonLint.php
@@ -4,14 +4,13 @@ namespace GrumPHP\Task;
 
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Runner\TaskResult;
-use GrumPHP\Linter\Json\JsonLinter;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * @property JsonLinter $linter
+ * @property \GrumPHP\Linter\Json\JsonLinter $linter
  */
 class JsonLint extends AbstractLinterTask
 {

--- a/src/Task/Php7cc.php
+++ b/src/Task/Php7cc.php
@@ -69,7 +69,7 @@ class Php7cc extends AbstractExternalTask
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();
 
-        if (!$process->isSuccessful()) {
+        if (preg_match('/^File: /m', $process->getOutput()) === 1) {
             return TaskResult::createFailed($this, $context, $this->formatter->format($process));
         }
 

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -3,7 +3,6 @@
 namespace GrumPHP\Task;
 
 use GrumPHP\Collection\ProcessArgumentsCollection;
-use GrumPHP\Formatter\PhpcsFormatter;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
@@ -14,7 +13,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * Phpcs task
  *
- * @property PhpcsFormatter $formatter
+ * @property \GrumPHP\Formatter\PhpcsFormatter $formatter
  */
 class Phpcs extends AbstractExternalTask
 {

--- a/src/Task/XmlLint.php
+++ b/src/Task/XmlLint.php
@@ -4,14 +4,13 @@ namespace GrumPHP\Task;
 
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Runner\TaskResult;
-use GrumPHP\Linter\Xml\XmlLinter;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * @property XmlLinter $linter
+ * @property \GrumPHP\Linter\Xml\XmlLinter $linter
  */
 class XmlLint extends AbstractLinterTask
 {

--- a/src/Task/YamlLint.php
+++ b/src/Task/YamlLint.php
@@ -4,14 +4,13 @@ namespace GrumPHP\Task;
 
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Runner\TaskResult;
-use GrumPHP\Linter\Yaml\YamlLinter;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * @property YamlLinter $linter
+ * @property \GrumPHP\Linter\Yaml\YamlLinter $linter
  */
 class YamlLint extends AbstractLinterTask
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | n/a

It would be nice to get an overview of which tasks passed and failed while GrumPHP is executing. Tasks that complete successfully tend to not output anything which isn't very helpful. Now tasks will output either a green ✔ or red ✘ in the progress summary.