### PR TITLE
Add PHPStan task

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ To make GrumPHP even more awesome, it will suggest installing some extra package
 - phing/phing : ~2.0
 - sstalle/php7cc : ~1.1
 - phpspec/phpspec : ~2.1
+- phpstan/phpstan : ^0.6
 - phpunit/phpunit : ~4.5
 - roave/security-advisories : dev-master@dev
 - sebastian/phpcpd : ~2.0
@@ -121,8 +122,9 @@ parameters:
         phpmd: ~
         phpparser: ~
         phpspec: ~
+        phpstan: ~
         phpunit: ~
-        phpversion: ~        
+        phpversion: ~
         robo: ~
         securitychecker: ~
         shell: ~
@@ -171,7 +173,7 @@ There is one major part missing before we can release v1.0.0:
 
 - [A PHAR executable](https://github.com/phpro//grumphp/issues/61)
 
-We are always looking to support new tasks. 
+We are always looking to support new tasks.
 Feel free to log an issue or create a pull request for a task we forgot.
 
 Are you missing a feature or did you find a bug?

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpunit/phpunit": "^4.8.31",
         "sebastian/comparator": "^1.2.4",
         "sensiolabs/security-checker": "^3.0",
-        "squizlabs/php_codesniffer": "~2.3"
+        "squizlabs/php_codesniffer": "~2.4"
     },
     "suggest": {
         "atoum/atoum": "Lets GrumPHP run your unit tests.",
@@ -48,6 +48,7 @@
         "phing/phing": "Lets GrumPHP run your automated PHP tasks.",
         "phpmd/phpmd": "Lets GrumPHP sort out the mess in your code",
         "phpspec/phpspec": "Lets GrumPHP spec your code.",
+        "phpstan/phpstan": "Lets GrumPHP discover bugs in your code without running it.",
         "phpunit/phpunit": "Lets GrumPHP run your unit tests.",
         "roave/security-advisories": "Lets GrumPHP be sure that there are no known security issues.",
         "sebastian/phpcpd": "Lets GrumPHP find duplicated code.",

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -38,8 +38,9 @@ parameters:
         phpmd: ~
         phpparser: ~
         phpspec: ~
+        phpstan: ~
         phpunit: ~
-        phpversion: ~        
+        phpversion: ~
         robo: ~
         securitychecker: ~
         shell: ~
@@ -73,7 +74,7 @@ Every task has it's own default configuration. It is possible to overwrite the p
 - [NPM script](tasks/npm_script.md)
 - [Phan](tasks/phan.md)
 - [Phing](tasks/phing.md)
-- [Php7cc](tasks/php7cc.md) 
+- [Php7cc](tasks/php7cc.md)
 - [PhpCpd](tasks/phpcpd.md)
 - [Phpcs](tasks/phpcs.md)
 - [PHP-CS-Fixer](tasks/php_cs_fixer.md)
@@ -82,6 +83,7 @@ Every task has it's own default configuration. It is possible to overwrite the p
 - [PhpMd](tasks/phpmd.md)
 - [PhpParser](tasks/phpparser.md)
 - [Phpspec](tasks/phpspec.md)
+- [PHPStan](tasks/phpstan.md)
 - [Phpunit](tasks/phpunit.md)
 - [PhpVersion](tasks/phpversion.md)
 - [Robo](tasks/robo.md)

--- a/doc/tasks/phpstan.md
+++ b/doc/tasks/phpstan.md
@@ -1,0 +1,39 @@
+# PHPStan
+
+The PHPStan task focuses on finding errors in your code without actually running it. It catches whole classes of bugs even before you write tests for the code.
+It lives under the `phpstan` namespace and has following configurable parameters:
+
+```yaml
+# grumphp.yml
+parameters:
+    tasks:
+        phpstan:
+            autoload_file: ~
+            configuration: ~
+            level: 0
+            triggered_by: ['php']
+```
+
+**autoload_file**
+
+*Default: ~*
+
+With this parameter you can specify the path your project's additional autoload file path.
+
+**configuration**
+
+*Default: ~*
+
+With this parameter you can specify the path your project's configuration file.
+
+**level**
+
+*Default: 0*
+
+With this parameter you can set the level of rule options - the higher the stricter.
+
+**triggered_by**
+
+*Default: [php]*
+
+This is a list of extensions to be sniffed.

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -273,6 +273,15 @@ services:
         tags:
           - {name: grumphp.task, config: phpspec}
 
+    task.phpstan:
+        class: GrumPHP\Task\PhpStan
+        arguments:
+          - '@config'
+          - '@process_builder'
+          - '@formatter.raw_process'
+        tags:
+          - {name: grumphp.task, config: phpstan}
+
     task.phpunit:
         class: GrumPHP\Task\Phpunit
         arguments:

--- a/spec/Task/PhpStanSpec.php
+++ b/spec/Task/PhpStanSpec.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace spec\GrumPHP\Task;
+
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
+use GrumPHP\Process\ProcessBuilder;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\PhpStan;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Process\Process;
+
+class PhpStanSpec extends ObjectBehavior
+{
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
+    {
+        $grumPHP->getTaskConfiguration('phpstan')->willReturn([]);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PhpStan::class);
+    }
+
+    function it_should_have_a_name()
+    {
+        $this->getName()->shouldBe('phpstan');
+    }
+
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf(OptionsResolver::class);
+        $options->getDefinedOptions()->shouldContain('autoload_file');
+        $options->getDefinedOptions()->shouldContain('configuration');
+        $options->getDefinedOptions()->shouldContain('level');
+        $options->getDefinedOptions()->shouldContain('triggered_by');
+    }
+
+    function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_run_in_run_context(RunContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder, ContextInterface $context)
+    {
+        $processBuilder->buildProcess('phpstan')->shouldNotBeCalled();
+        $processBuilder->buildProcess()->shouldNotBeCalled();
+        $context->getFiles()->willReturn(new FilesCollection());
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->getResultCode()->shouldBe(TaskResult::SKIPPED);
+    }
+
+    function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
+    {
+        $arguments = new ProcessArgumentsCollection();
+        $processBuilder->createArgumentsForCommand('phpstan')->willReturn($arguments);
+        $processBuilder->buildProcess($arguments)->willReturn($process);
+
+        $process->run()->shouldBeCalled();
+        $process->isSuccessful()->willReturn(true);
+        $process->getErrorOutput()->willReturn('');
+        $process->getOutput()->willReturn('');
+
+        $context->getFiles()->willReturn(new FilesCollection([
+            new SplFileInfo('test.php', '.', 'test.php')
+        ]));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_throws_exception_if_the_process_fails(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
+    {
+        $arguments = new ProcessArgumentsCollection();
+        $processBuilder->createArgumentsForCommand('phpstan')->willReturn($arguments);
+        $processBuilder->buildProcess($arguments)->willReturn($process);
+
+        $process->run()->shouldBeCalled();
+        $process->isSuccessful()->willReturn(false);
+
+        $context->getFiles()->willReturn(new FilesCollection([
+            new SplFileInfo('src/Collection/TaskResultCollection.php', 'src/Collection', 'TaskResultCollection.php'),
+        ]));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+}

--- a/src/Task/PhpStan.php
+++ b/src/Task/PhpStan.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace GrumPHP\Task;
+
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Process\Process;
+
+/**
+ * PhpStan task
+ */
+class PhpStan extends AbstractExternalTask
+{
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'phpstan';
+    }
+
+    /**
+     * @return OptionsResolver
+     */
+    public function getConfigurableOptions()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'autoload_file' => null,
+            'configuration' => null,
+            'level' => 0,
+            'triggered_by' => ['php'],
+        ]);
+
+        $resolver->addAllowedTypes('autoload_file', ['null', 'string']);
+        $resolver->addAllowedTypes('configuration', ['null', 'string']);
+        $resolver->addAllowedTypes('level', ['int']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
+
+        return $resolver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canRunInContext(ContextInterface $context)
+    {
+        return ($context instanceof GitPreCommitContext || $context instanceof RunContext);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(ContextInterface $context)
+    {
+        $config = $this->getConfiguration();
+        $files = $context->getFiles()->extensions($config['triggered_by']);
+
+        if (0 === count($files)) {
+            return TaskResult::createSkipped($this, $context);
+        }
+
+        $arguments = $this->processBuilder->createArgumentsForCommand('phpstan');
+
+        $arguments->add('analyse');
+        $arguments->addOptionalArgument('--autoload-file=%s', $config['autoload_file']);
+        $arguments->addOptionalArgument('--configuration=%s', $config['configuration']);
+        $arguments->add(sprintf('--level=%u', $config['level']));
+        $arguments->add('--no-ansi');
+        $arguments->add('--no-interaction');
+        $arguments->add('--no-progress');
+        $arguments->addFiles($files);
+
+        $process = $this->processBuilder->buildProcess($arguments);
+
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #248

PHPStan task. When in `GitPreCommitContext` it'll filter the result and only report errors for files that are actually being commited. 

Currently it parses the results table with regexp (since PHPStan don't support different output formats), which have worked flawlessly for me for a while but probably is a bit too hacky to be in an "official" GrumPHP task. 

Luckily there's a PR in progress (https://github.com/phpstan/phpstan/issues/132), so either we wait for it to be merged and rewrite some code or just remove the filtering all together if we rather always report all files :)

# New Task Checklist:

- [x] Is the README.md file updated?
- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpspec tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?
