### PR TITLE
Add missing configuration for git_conflict

### DIFF
--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -106,6 +106,13 @@ services:
         tags:
             - {name: grumphp.task, config: git_commit_message}
 
+    task.git.conflict:
+        class: GrumPHP\Task\Git\Conflict
+        arguments:
+            - '@config'
+        tags:
+            - {name: grumphp.task, config: git_conflict}
+
     task.grunt:
         class: GrumPHP\Task\Grunt
         arguments:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | -
| Fixed tickets | -

Seems like the `git_conflict` task isn't registered.