### PR TITLE
Add various commit message tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,19 @@ parameters:
         gherkin: ~
         git_blacklist: ~
         git_branch_name: ~
+        git_capitalized_subject: ~
         git_commit_message: ~
+        git_conflict: ~
+        git_empty_message: ~
+        git_single_line_subject: ~
+        git_text_width: ~
+        git_trailing_period: ~
         grunt: ~
         gulp: ~
         jsonlint: ~
         kahlan: ~
         npm_script: ~
-        phan: ~        
+        phan: ~
         phing: ~
         php7cc: ~
         phpcpd: ~

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -71,10 +71,7 @@ Every task has it's own default configuration. It is possible to overwrite the p
 - [Deptrac](tasks/deptrac.md)
 - [Gherkin](tasks/gherkin.md)
 - [Git blacklist](tasks/git_blacklist.md)
-<<<<<<< HEAD
 - [Git branch name](tasks/git_branch_name.md)
-- [Git commit message](tasks/git_commit_message.md)
-=======
 - [Git capitalized subject](tasks/git_capitalized_subject.md)
 - [Git commit message](tasks/git_commit_message.md)
 - [Git conflict](tasks/git_conflict.md)
@@ -82,7 +79,6 @@ Every task has it's own default configuration. It is possible to overwrite the p
 - [Git single line subject](tasks/git_single_line_subject.md)
 - [Git text width](tasks/git_text_width.md)
 - [Git trailing_period](tasks/git_trailing_period.md)
->>>>>>> 3c705e7... Add various commit message tasks
 - [Grunt](tasks/grunt.md)
 - [Gulp](tasks/gulp.md)
 - [JsonLint](tasks/jsonlint.md)

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -20,7 +20,13 @@ parameters:
         gherkin: ~
         git_blacklist: ~
         git_branch_name: ~
+        git_capitalized_subject: ~
         git_commit_message: ~
+        git_conflict: ~
+        git_empty_message: ~
+        git_single_line_subject: ~
+        git_text_width: ~
+        git_trailing_period: ~
         grunt: ~
         gulp: ~
         jsonlint: ~
@@ -65,8 +71,18 @@ Every task has it's own default configuration. It is possible to overwrite the p
 - [Deptrac](tasks/deptrac.md)
 - [Gherkin](tasks/gherkin.md)
 - [Git blacklist](tasks/git_blacklist.md)
+<<<<<<< HEAD
 - [Git branch name](tasks/git_branch_name.md)
 - [Git commit message](tasks/git_commit_message.md)
+=======
+- [Git capitalized subject](tasks/git_capitalized_subject.md)
+- [Git commit message](tasks/git_commit_message.md)
+- [Git conflict](tasks/git_conflict.md)
+- [Git empty message](tasks/git_empty_message.md)
+- [Git single line subject](tasks/git_single_line_subject.md)
+- [Git text width](tasks/git_text_width.md)
+- [Git trailing_period](tasks/git_trailing_period.md)
+>>>>>>> 3c705e7... Add various commit message tasks
 - [Grunt](tasks/grunt.md)
 - [Gulp](tasks/gulp.md)
 - [JsonLint](tasks/jsonlint.md)

--- a/doc/tasks/git_capitalized_subject.md
+++ b/doc/tasks/git_capitalized_subject.md
@@ -1,0 +1,11 @@
+# Git Capitalized Subject
+
+The Git Capitalized Subject task ensures commit message subject lines start with a capital letter.
+It lives under the `git_capitalized_subject` namespace and has following configurable parameters:
+
+```yaml
+# grumphp.yml
+parameters:
+    tasks:
+        git_capitalized_subject: ~
+```

--- a/doc/tasks/git_empty_message.md
+++ b/doc/tasks/git_empty_message.md
@@ -1,0 +1,11 @@
+# Git Empty Message
+
+The Git Empty Message task checks that the commit message is not empty.
+It lives under the `git_empty_message` namespace and has following configurable parameters:
+
+```yaml
+# grumphp.yml
+parameters:
+    tasks:
+        git_empty_message: ~
+```

--- a/doc/tasks/git_single_line_subject.md
+++ b/doc/tasks/git_single_line_subject.md
@@ -1,0 +1,11 @@
+# Git Single Line Subject
+
+The Git Single Line Subject task ensures commit message subject lines are followed by a blank line.
+It lives under the `git_single_line_subject` namespace and has following configurable parameters:
+
+```yaml
+# grumphp.yml
+parameters:
+    tasks:
+        git_single_line_subject: ~
+```

--- a/doc/tasks/git_text_width.md
+++ b/doc/tasks/git_text_width.md
@@ -1,0 +1,25 @@
+# Git Text Width
+
+The Git Text Width task ensures the number of columns the subject and commit message lines occupy is under the preferred limits.
+It lives under the `git_text_width` namespace and has following configurable parameters:
+
+```yaml
+# grumphp.yml
+parameters:
+    tasks:
+        git_text_width:
+            max_body_width: 72
+            max_subject_width: 60
+```
+
+**max_body_width**
+
+*Default: 72*
+
+Preferred limit on the commit message lines.
+
+**max_subject_width**
+
+*Default: 60*
+
+Preferred limit on the subject line.

--- a/doc/tasks/git_trailing_period.md
+++ b/doc/tasks/git_trailing_period.md
@@ -1,0 +1,11 @@
+# Git Trailing Period
+
+The Git Trailing Period task ensures commit message subject lines do not have a trailing period.
+It lives under the `git_trailing_period` namespace and has following configurable parameters:
+
+```yaml
+# grumphp.yml
+parameters:
+    tasks:
+        git_trailing_period: ~
+```

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -108,6 +108,21 @@ services:
         tags:
             - {name: grumphp.task, config: git_blacklist}
 
+    task.git.branchname:
+      class: GrumPHP\Task\Git\BranchName
+      arguments:
+          - '@config'
+          - '@git.repository'
+      tags:
+          - {name: grumphp.task, config: git_branch_name}
+
+    task.git.capitalizedsubject:
+        class: GrumPHP\Task\Git\CapitalizedSubject
+        arguments:
+            - '@config'
+        tags:
+            - {name: grumphp.task, config: git_capitalized_subject}
+
     task.git.commitmessage:
         class: GrumPHP\Task\Git\CommitMessage
         arguments:
@@ -115,13 +130,33 @@ services:
         tags:
             - {name: grumphp.task, config: git_commit_message}
 
-    task.git.branchname:
-        class: GrumPHP\Task\Git\BranchName
+    task.git.emptymessage:
+        class: GrumPHP\Task\Git\EmptyMessage
         arguments:
             - '@config'
-            - '@git.repository'
         tags:
-            - {name: grumphp.task, config: git_branch_name}
+            - {name: grumphp.task, config: git_empty_message}
+
+    task.git.singlelinesubject:
+        class: GrumPHP\Task\Git\SingleLineSubject
+        arguments:
+            - '@config'
+        tags:
+            - {name: grumphp.task, config: git_single_line_subject}
+
+    task.git.textwidth:
+        class: GrumPHP\Task\Git\TextWidth
+        arguments:
+            - '@config'
+        tags:
+            - {name: grumphp.task, config: git_text_width}
+
+    task.git.trailingperiod:
+        class: GrumPHP\Task\Git\TrailingPeriod
+        arguments:
+            - '@config'
+        tags:
+            - {name: grumphp.task, config: git_trailing_period}
 
     task.grunt:
         class: GrumPHP\Task\Grunt

--- a/spec/Task/Git/CapitalizedSubjectSpec.php
+++ b/spec/Task/Git/CapitalizedSubjectSpec.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace spec\GrumPHP\Task\Git;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Context\GitCommitMsgContext;
+use GrumPHP\Task\Git\CapitalizedSubject;
+use GrumPHP\Task\TaskInterface;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CapitalizedSubjectSpec extends ObjectBehavior
+{
+    function let(GrumPHP $grumPHP)
+    {
+        $this->beConstructedWith($grumPHP);
+    }
+
+    function it_should_have_a_name()
+    {
+        $this->getName()->shouldBe('git_capitalized_subject');
+    }
+
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf(OptionsResolver::class);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CapitalizedSubject::class);
+    }
+
+    function it_is_a_grumphp_task()
+    {
+        $this->shouldImplement(TaskInterface::class);
+    }
+
+    function it_should_run_in_git_commit_msg_context(GitCommitMsgContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_pass_when_commit_message_is_empty(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn('');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_subject_starts_with_a_capital_letter(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+Initial commit
+
+Mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_subject_starts_with_a_utf8_capital_letter(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+Årsgång
+
+Mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_subject_starts_with_punctuation_and_a_capital_letter(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+"Initial" commit
+
+Mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_fail_when_subject_starts_with_a_lowercase_letter(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+initial commit
+
+I forget about commit message standards and decide to not capitalize my
+subject. Still mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+
+    function it_should_fail_when_subject_starts_with_a_utf8_lowercase_letter(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+årsgång
+
+I forget about commit message standards and decide to not capitalize my
+subject. Still mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+
+    function it_should_fail_when_subject_starts_with_punctuation_and_a_lowercase_letter(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+"initial" commit
+
+I forget about commit message standards and decide to not capitalize my
+subject. Still mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+
+    function it_should_pass_when_subject_starts_with_special_fixup_prefix(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+fixup! commit
+
+This was created by running git commit --fixup=...
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_subject_starts_with_special_squash_prefix(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+squash! commit
+
+This was created by running git commit --squash=...
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_first_line_of_commit_message_is_an_empty_line(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+
+There was no first line
+
+This is a mistake.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+}

--- a/spec/Task/Git/EmptyMessageSpec.php
+++ b/spec/Task/Git/EmptyMessageSpec.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace spec\GrumPHP\Task\Git;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Context\GitCommitMsgContext;
+use GrumPHP\Task\Git\EmptyMessage;
+use GrumPHP\Task\TaskInterface;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class EmptyMessageSpec extends ObjectBehavior
+{
+    function let(GrumPHP $grumPHP)
+    {
+        $this->beConstructedWith($grumPHP);
+    }
+
+    function it_should_have_a_name()
+    {
+        $this->getName()->shouldBe('git_empty_message');
+    }
+
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf(OptionsResolver::class);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(EmptyMessage::class);
+    }
+
+    function it_is_a_grumphp_task()
+    {
+        $this->shouldImplement(TaskInterface::class);
+    }
+
+    function it_should_run_in_git_commit_msg_context(GitCommitMsgContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_fail_when_commit_message_is_empty(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn('');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+
+    function it_should_fail_when_commit_message_contains_only_whitespace(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn(' ');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+
+    function it_should_pass_when_commit_message_is_not_empty(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn('when commit message is not empty');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+}

--- a/spec/Task/Git/SingleLineSubjectSpec.php
+++ b/spec/Task/Git/SingleLineSubjectSpec.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace spec\GrumPHP\Task\Git;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Context\GitCommitMsgContext;
+use GrumPHP\Task\Git\SingleLineSubject;
+use GrumPHP\Task\TaskInterface;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class SingleLineSubjectSpec extends ObjectBehavior
+{
+    function let(GrumPHP $grumPHP)
+    {
+        $this->beConstructedWith($grumPHP);
+    }
+
+    function it_should_have_a_name()
+    {
+        $this->getName()->shouldBe('git_single_line_subject');
+    }
+
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf(OptionsResolver::class);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(SingleLineSubject::class);
+    }
+
+    function it_is_a_grumphp_task()
+    {
+        $this->shouldImplement(TaskInterface::class);
+    }
+
+    function it_should_run_in_git_commit_msg_context(GitCommitMsgContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_pass_when_commit_message_is_empty(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn('');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_subject_is_separated_from_body_by_a_blank_line(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+Initial commit
+
+Mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_fail_when_subject_is_not_kept_to_one_line(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+Initial commit where I forget about commit message
+standards and decide to hard-wrap my subject
+
+Still mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+}

--- a/spec/Task/Git/TextWidthSpec.php
+++ b/spec/Task/Git/TextWidthSpec.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace spec\GrumPHP\Task\Git;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Context\GitCommitMsgContext;
+use GrumPHP\Task\Git\TextWidth;
+use GrumPHP\Task\TaskInterface;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TextWidthSpec extends ObjectBehavior
+{
+    function let(GrumPHP $grumPHP)
+    {
+        $this->beConstructedWith($grumPHP);
+        $grumPHP->getTaskConfiguration('git_text_width')->willReturn([
+            'max_body_width' => 72,
+            'max_subject_width' => 60,
+        ]);
+    }
+
+    function it_should_have_a_name()
+    {
+        $this->getName()->shouldBe('git_text_width');
+    }
+
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf(OptionsResolver::class);
+        $options->getDefinedOptions()->shouldContain('max_body_width');
+        $options->getDefinedOptions()->shouldContain('max_subject_width');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(TextWidth::class);
+    }
+
+    function it_is_a_grumphp_task()
+    {
+        $this->shouldImplement(TaskInterface::class);
+    }
+
+    function it_should_run_in_git_commit_msg_context(GitCommitMsgContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_pass_when_commit_message_is_empty(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn('');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_fail_when_subject_is_longer_than_60_characters(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn(str_repeat('A', 61));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+        $result->getMessage()->shouldMatch('/subject/');
+    }
+
+    function it_should_pass_when_subject_is_60_characters_or_fewer(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn(str_repeat('A', 60));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_subject_starts_with_special_fixup_and_is_longer_than_60_characters(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn('fixup! '.str_repeat('A', 60));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_subject_starts_with_special_squash_and_is_longer_than_60_characters(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn('squash! '.str_repeat('A', 60));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_the_subject_is_60_characters_followed_by_a_newline(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+This is 60 characters, or 61 if the newline is counted
+
+A reasonable line.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_a_line_in_the_message_is_72_characters_followed_by_a_newline(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+Some summary
+
+This line has 72 characters, but with newline it has 73 characters
+That shouldn't be a problem.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_fail_when_a_line_in_the_message_is_longer_than_72_characters(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+Some summary
+
+This line is longer than 72 characters which is clearly be seen by count.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+        $result->getMessage()->shouldBe('Line 3 of commit message has > 72 characters.');
+    }
+
+    function it_should_pass_when_all_lines_in_the_message_are_fewer_than_72_characters(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+Some summary
+
+A reasonable line.
+
+Another reasonable line.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_fail_when_subject_and_a_line_in_the_message_is_longer_than_the_limits(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+A subject line that is way too long. A subject line that is way too long.
+
+A message line that is way too long. A message line that is way too long.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+        $result->getMessage()->shouldMatch('/keep.*subject <= 60.*\n.*line 3.*> 72.*/im');
+    }
+}

--- a/spec/Task/Git/TrailingPeriodSpec.php
+++ b/spec/Task/Git/TrailingPeriodSpec.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace spec\GrumPHP\Task\Git;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Context\GitCommitMsgContext;
+use GrumPHP\Task\Git\TrailingPeriod;
+use GrumPHP\Task\TaskInterface;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TrailingPeriodSpec extends ObjectBehavior
+{
+    function let(GrumPHP $grumPHP)
+    {
+        $this->beConstructedWith($grumPHP);
+    }
+
+    function it_should_have_a_name()
+    {
+        $this->getName()->shouldBe('git_trailing_period');
+    }
+
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf(OptionsResolver::class);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(TrailingPeriod::class);
+    }
+
+    function it_is_a_grumphp_task()
+    {
+        $this->shouldImplement(TaskInterface::class);
+    }
+
+    function it_should_run_in_git_commit_msg_context(GitCommitMsgContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_pass_when_commit_message_is_empty(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn('');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_fail_when_subject_contains_a_trailing_period(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn('This subject has a period.');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+
+    function it_should_pass_when_subject_does_not_contain_a_trailing_period(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn('This subject has no period');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+}

--- a/src/Task/Git/CapitalizedSubject.php
+++ b/src/Task/Git/CapitalizedSubject.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace GrumPHP\Task\Git;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Exception\RuntimeException;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitCommitMsgContext;
+use GrumPHP\Task\TaskInterface;
+use GrumPHP\Util\Regex;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Git CapitalizedSubject Task
+ */
+class CapitalizedSubject implements TaskInterface
+{
+    /**
+     * @var GrumPHP
+     */
+    private $grumPHP;
+
+    /**
+     * @param GrumPHP $grumPHP
+     */
+    public function __construct(GrumPHP $grumPHP)
+    {
+        $this->grumPHP = $grumPHP;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'git_capitalized_subject';
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfiguration()
+    {
+        $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+
+        return $this->getConfigurableOptions()->resolve($configured);
+    }
+
+    /**
+     * @return OptionsResolver
+     */
+    public function getConfigurableOptions()
+    {
+        return new OptionsResolver();
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    public function canRunInContext(ContextInterface $context)
+    {
+        return $context instanceof GitCommitMsgContext;
+    }
+
+    /**
+     * @param ContextInterface|GitCommitMsgContext $context
+     */
+    public function run(ContextInterface $context)
+    {
+        $commitMessage = $context->getCommitMessage();
+
+        if (trim($commitMessage) === '') {
+            return TaskResult::createPassed($this, $context);
+        }
+
+        $commitMessage = str_replace("\r", '', $commitMessage);
+        $lines = explode("\n", $commitMessage);
+        $subject = array_reduce($lines, function ($subject, $line) {
+            if ($subject !== null) {
+                return $subject;
+            }
+
+            if (trim($line) === '') {
+                return null;
+            }
+
+            return $line;
+        }, null);
+
+
+        if ($subject === null || preg_match('/^[[:punct:]]*(.)/u', $subject, $match) !== 1) {
+            return TaskResult::createFailed(
+                $this,
+                $context,
+                'Subject should start with a capital letter.'
+            );
+        }
+
+        $firstLetter = $match[1];
+
+        if (preg_match('/^(fixup|squash)!/u', $subject) !== 1 && preg_match('/[[:upper:]]/u', $firstLetter) !== 1) {
+            return TaskResult::createFailed(
+                $this,
+                $context,
+                'Subject should start with a capital letter.'
+            );
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}

--- a/src/Task/Git/EmptyMessage.php
+++ b/src/Task/Git/EmptyMessage.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace GrumPHP\Task\Git;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Exception\RuntimeException;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitCommitMsgContext;
+use GrumPHP\Task\TaskInterface;
+use GrumPHP\Util\Regex;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Git EmptyMessage Task
+ */
+class EmptyMessage implements TaskInterface
+{
+    /**
+     * @var GrumPHP
+     */
+    private $grumPHP;
+
+    /**
+     * @param GrumPHP $grumPHP
+     */
+    public function __construct(GrumPHP $grumPHP)
+    {
+        $this->grumPHP = $grumPHP;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'git_empty_message';
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfiguration()
+    {
+        $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+
+        return $this->getConfigurableOptions()->resolve($configured);
+    }
+
+    /**
+     * @return OptionsResolver
+     */
+    public function getConfigurableOptions()
+    {
+        return new OptionsResolver();
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    public function canRunInContext(ContextInterface $context)
+    {
+        return $context instanceof GitCommitMsgContext;
+    }
+
+    /**
+     * @param ContextInterface|GitCommitMsgContext $context
+     */
+    public function run(ContextInterface $context)
+    {
+        $commitMessage = $context->getCommitMessage();
+
+        if (trim($commitMessage) === '') {
+            return TaskResult::createFailed(
+                $this,
+                $context,
+                'Commit message should not be empty.'
+            );
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}

--- a/src/Task/Git/SingleLineSubject.php
+++ b/src/Task/Git/SingleLineSubject.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace GrumPHP\Task\Git;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Exception\RuntimeException;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitCommitMsgContext;
+use GrumPHP\Task\TaskInterface;
+use GrumPHP\Util\Regex;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Git SingleLineSubject Task
+ */
+class SingleLineSubject implements TaskInterface
+{
+    /**
+     * @var GrumPHP
+     */
+    private $grumPHP;
+
+    /**
+     * @param GrumPHP $grumPHP
+     */
+    public function __construct(GrumPHP $grumPHP)
+    {
+        $this->grumPHP = $grumPHP;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'git_single_line_subject';
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfiguration()
+    {
+        $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+
+        return $this->getConfigurableOptions()->resolve($configured);
+    }
+
+    /**
+     * @return OptionsResolver
+     */
+    public function getConfigurableOptions()
+    {
+        return new OptionsResolver();
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    public function canRunInContext(ContextInterface $context)
+    {
+        return $context instanceof GitCommitMsgContext;
+    }
+
+    /**
+     * @param ContextInterface|GitCommitMsgContext $context
+     */
+    public function run(ContextInterface $context)
+    {
+        $commitMessage = $context->getCommitMessage();
+
+        if (trim($commitMessage) === '') {
+            return TaskResult::createPassed($this, $context);
+        }
+
+        $commitMessage = str_replace("\r", '', $commitMessage);
+        $lines = explode("\n", $commitMessage);
+
+        if (trim($lines[1]) !== '') {
+            return TaskResult::createFailed(
+                $this,
+                $context,
+                'Subject should be one line and followed by a blank line.'
+            );
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}

--- a/src/Task/Git/TextWidth.php
+++ b/src/Task/Git/TextWidth.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace GrumPHP\Task\Git;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Exception\RuntimeException;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitCommitMsgContext;
+use GrumPHP\Task\TaskInterface;
+use GrumPHP\Util\Regex;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Git TextWidth Task
+ */
+class TextWidth implements TaskInterface
+{
+    /**
+     * @var GrumPHP
+     */
+    private $grumPHP;
+
+    /**
+     * @param GrumPHP $grumPHP
+     */
+    public function __construct(GrumPHP $grumPHP)
+    {
+        $this->grumPHP = $grumPHP;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'git_text_width';
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfiguration()
+    {
+        $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+
+        return $this->getConfigurableOptions()->resolve($configured);
+    }
+
+    /**
+     * @return OptionsResolver
+     */
+    public function getConfigurableOptions()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'max_body_width' => 72,
+            'max_subject_width' => 60,
+        ]);
+
+        $resolver->addAllowedTypes('max_body_width', ['int']);
+        $resolver->addAllowedTypes('max_subject_width', ['int']);
+
+        return $resolver;
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    public function canRunInContext(ContextInterface $context)
+    {
+        return $context instanceof GitCommitMsgContext;
+    }
+
+    /**
+     * @param ContextInterface|GitCommitMsgContext $context
+     */
+    public function run(ContextInterface $context)
+    {
+        $commitMessage = $context->getCommitMessage();
+
+        if (trim($commitMessage) === '') {
+            return TaskResult::createPassed($this, $context);
+        }
+
+        $errors = [];
+        $commitMessage = str_replace("\r", '', $commitMessage);
+        $lines = explode("\n", $commitMessage);
+        $config = $this->getConfiguration();
+        $subject = rtrim($lines[0]);
+        $maxSubjectWidth = $config['max_subject_width'] + $this->getSpecialPrefixLength($subject);
+
+        if (mb_strlen($subject) > $maxSubjectWidth) {
+            $errors[] = sprintf('Please keep the subject <= %u characters.', $maxSubjectWidth);
+        }
+
+        foreach (array_slice($lines, 2) as $index => $line) {
+            if (mb_strlen(rtrim($line)) > $config['max_body_width']) {
+                $errors[] = sprintf(
+                    'Line %u of commit message has > %u characters.',
+                    $index + 3,
+                    $config['max_body_width']
+                );
+            }
+        }
+
+        if (count($errors) === 0) {
+            return TaskResult::createPassed($this, $context);
+        }
+
+        return TaskResult::createFailed($this, $context, implode(PHP_EOL, $errors));
+    }
+
+    private function getSpecialPrefixLength($string)
+    {
+        if (preg_match('/^(fixup|squash)! /', $string, $match) !== 1) {
+            return 0;
+        }
+
+        return mb_strlen($match[0]);
+    }
+}

--- a/src/Task/Git/TrailingPeriod.php
+++ b/src/Task/Git/TrailingPeriod.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace GrumPHP\Task\Git;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Exception\RuntimeException;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitCommitMsgContext;
+use GrumPHP\Task\TaskInterface;
+use GrumPHP\Util\Regex;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Git TrailingPeriod Task
+ */
+class TrailingPeriod implements TaskInterface
+{
+    /**
+     * @var GrumPHP
+     */
+    private $grumPHP;
+
+    /**
+     * @param GrumPHP $grumPHP
+     */
+    public function __construct(GrumPHP $grumPHP)
+    {
+        $this->grumPHP = $grumPHP;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'git_trailing_period';
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfiguration()
+    {
+        $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+
+        return $this->getConfigurableOptions()->resolve($configured);
+    }
+
+    /**
+     * @return OptionsResolver
+     */
+    public function getConfigurableOptions()
+    {
+        return new OptionsResolver();
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    public function canRunInContext(ContextInterface $context)
+    {
+        return $context instanceof GitCommitMsgContext;
+    }
+
+    /**
+     * @param ContextInterface|GitCommitMsgContext $context
+     */
+    public function run(ContextInterface $context)
+    {
+        $commitMessage = $context->getCommitMessage();
+
+        if (trim($commitMessage) === '') {
+            return TaskResult::createPassed($this, $context);
+        }
+
+        $commitMessage = str_replace("\r", '', $commitMessage);
+        $lines = explode("\n", $commitMessage);
+
+        if (mb_substr(rtrim($lines[0]), -1) === '.') {
+            return TaskResult::createFailed(
+                $this,
+                $context,
+                'Please omit trailing period from commit message subject.'
+            );
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | -

Various tasks related to commit messages I created a while back that I thought might interest others. 

- `git_capitalized_subject` ensures commit message subject lines start with a capital letter.
- `git_empty_message` checks that the commit message is not empty.
- `git_single_line_subject` ensures commit message subject lines are followed by a blank line.
- `git_text_width` ensures the number of columns the subject and commit message lines occupy is under the preferred limits.
- `git_trailing_period` ensures commit message subject lines do not have a trailing period.

Both the tasks and the specs are more or less straight PHP ports of some [Overcommit](https://github.com/brigade/overcommit) hooks, not sure what the best way to give them attribution is?

The follow code to get the commit message as an array of lines is shared between most of the tasks, might be interesting to add as a method to `GitCommitMsgContext`?

```php
$commitMessage = str_replace("\r", '', $commitMessage);
$lines = explode("\n", $commitMessage);
```

# New Task Checklist:

- [x] Is the README.md file updated?
- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpspec tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?