### PR TITLE
Added spaces between PHP-CS-Fixer formatter fixers

### DIFF
--- a/spec/Formatter/PhpCsFixerFormatterSpec.php
+++ b/spec/Formatter/PhpCsFixerFormatterSpec.php
@@ -56,7 +56,7 @@ class PhpCsFixerFormatterSpec extends ObjectBehavior
             ['name' => 'name2', 'appliedFixers' => ['fixer1', 'fixer2']],
         ]);
         $process->getOutput()->willReturn($json);
-        $this->format($process)->shouldBe('1) name1' . PHP_EOL . '2) name2 (fixer1,fixer2)');
+        $this->format($process)->shouldBe('1) name1' . PHP_EOL . '2) name2 (fixer1, fixer2)');
     }
 
     function it_formats_php_cs_fixer_json_output_for_diff(Process $process)

--- a/src/Formatter/PhpCsFixerFormatter.php
+++ b/src/Formatter/PhpCsFixerFormatter.php
@@ -107,7 +107,7 @@ class PhpCsFixerFormatter implements ProcessFormatterInterface
             '%s) %s%s%s',
             ++$this->counter,
             $file['name'],
-            $hasFixers ? ' (' . implode(',', $file['appliedFixers']) . ')' : '',
+            $hasFixers ? ' (' . implode(', ', $file['appliedFixers']) . ')' : '',
             $hasDiff ? PHP_EOL . PHP_EOL . $file['diff'] : ''
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | n/a

Adds spaces between fixer names for PHP-CS-Fixer task to make list of fixers applied to a file more readable. This is consistent with the format output by the tool normally.