### PR TITLE
Removed file scanning code from GitCommitMsgContext

### DIFF
--- a/spec/Task/Context/GitCommitMsgContextSpec.php
+++ b/spec/Task/Context/GitCommitMsgContextSpec.php
@@ -2,21 +2,15 @@
 
 namespace spec\GrumPHP\Task\Context;
 
-use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitCommitMsgContext;
 use PhpSpec\ObjectBehavior;
 
 class GitCommitMsgContextSpec extends ObjectBehavior
 {
-    /**
-     * @var string
-     */
-    protected $tempFile;
-
-    function let(FilesCollection $files)
+    function let()
     {
-        $this->beConstructedWith($files, 'message', 'user', 'user@email.com');
+        $this->beConstructedWith('message', 'user', 'user@email.com');
     }
 
     function it_is_initializable()
@@ -29,9 +23,9 @@ class GitCommitMsgContextSpec extends ObjectBehavior
         $this->shouldImplement(ContextInterface::class);
     }
 
-    function it_should_have_files(FilesCollection $files)
+    function it_should_have_files()
     {
-        $this->getFiles()->shouldBe($files);
+        $this->getFiles()->shouldHaveCount(0);
     }
 
     function it_should_know_the_git_user()

--- a/src/Console/Command/Git/CommitMsgCommand.php
+++ b/src/Console/Command/Git/CommitMsgCommand.php
@@ -69,12 +69,10 @@ class CommitMsgCommand extends Command
      * @param InputInterface  $input
      * @param OutputInterface $output
      *
-     * @return int|void
+     * @return int
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $io = new ConsoleIO($input, $output);
-        $files = $this->getCommittedFiles($io);
         $gitUser = $input->getOption('git-user');
         $gitEmail = $input->getOption('git-email');
         $commitMsgPath = $input->getArgument('commit-msg-file');
@@ -84,7 +82,7 @@ class CommitMsgCommand extends Command
         $output->writeln('<fg=yellow>GrumPHP detected a commit-msg command.</fg=yellow>');
 
         $context = new TaskRunnerContext(
-            new GitCommitMsgContext($files, $commitMsg, $gitUser, $gitEmail),
+            new GitCommitMsgContext($commitMsg, $gitUser, $gitEmail),
             $this->grumPHP->getTestSuites()->getOptional('git_commit_msg')
         );
 

--- a/src/Task/Context/GitCommitMsgContext.php
+++ b/src/Task/Context/GitCommitMsgContext.php
@@ -7,11 +7,6 @@ use GrumPHP\Collection\FilesCollection;
 class GitCommitMsgContext implements ContextInterface
 {
     /**
-     * @var FilesCollection
-     */
-    private $files;
-
-    /**
      * @var string
      */
     private $commitMessage = null;
@@ -27,14 +22,12 @@ class GitCommitMsgContext implements ContextInterface
     private $userEmail;
 
     /**
-     * @param FilesCollection $files
      * @param string          $commitMessage
      * @param string          $userName
      * @param string          $userEmail
      */
-    public function __construct(FilesCollection $files, $commitMessage, $userName, $userEmail)
+    public function __construct($commitMessage, $userName, $userEmail)
     {
-        $this->files = $files;
         $this->commitMessage = $commitMessage;
         $this->userName = $userName;
         $this->userEmail = $userEmail;
@@ -64,11 +57,8 @@ class GitCommitMsgContext implements ContextInterface
         return $this->userEmail;
     }
 
-    /**
-     * @return FilesCollection
-     */
     public function getFiles()
     {
-        return $this->files;
+        return new FilesCollection;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no?
| Deprecations? | no
| Documented?   | no
| Fixed tickets | n/a

The commit msg hook does not need a list of files for any purpose. Why is it there? Seemingly because `ContextInterface` requires it. That is a very unfortunate interface. Perhaps we should also remove the method from the interface?

I had to remove this because it was impossible to run `git:commit-msg` from the command line because it was hanging [here](https://github.com/phpro/grumphp/blob/db227510aa702105f47a9b8ac5e7dfd9947b0306/src/Console/Command/Git/CommitMsgCommand.php#L77) whilst trying to scan for files or some such nonsense. Imagine my reaction when I find the reason the application is hung is because it's doing something it doesn't even need to do that doesn't serve any purpose. This is it. My reaction is to remove that useless code.