### PR TITLE
Added support for a commit message rule names displayed in failure output

### DIFF
--- a/doc/tasks/git_commit_message.md
+++ b/doc/tasks/git_commit_message.md
@@ -1,7 +1,6 @@
 # Git commit message
 
-The git comit message can be used in combination with the git hook `git:commit-msg`.
-It can be used to enforce patterns in a commit message.
+The Git commit message task ensures commit messages match the specified patterns.  
 For example: if you are working with JIRA, it is possible to add a pattern for the JIRA issue number.
 
 ```yaml
@@ -10,7 +9,7 @@ parameters:
     tasks:
         git_commit_message:
             matchers:
-                - /JIRA-([0-9]*)/
+                Must contain JIRA issue number: /JIRA-\d+/
             case_insensitive: true
             multiline: true
             additional_modifiers: ''

--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -80,6 +80,8 @@ class CommitMessage implements TaskInterface
 
     /**
      * @param ContextInterface|GitCommitMsgContext $context
+     *
+     * @return TaskResult
      */
     public function run(ContextInterface $context)
     {
@@ -87,9 +89,9 @@ class CommitMessage implements TaskInterface
         $commitMessage = $context->getCommitMessage();
         $exceptions = [];
 
-        foreach ($config['matchers'] as $rule) {
+        foreach ($config['matchers'] as $ruleName => $rule) {
             try {
-                $this->runMatcher($config, $commitMessage, $rule);
+                $this->runMatcher($config, $commitMessage, $rule, $ruleName);
             } catch (RuntimeException $e) {
                 $exceptions[] = $e->getMessage();
             }
@@ -103,13 +105,14 @@ class CommitMessage implements TaskInterface
     }
 
     /**
-     * @param array  $config
+     * @param array $config
      * @param string $commitMessage
      * @param string $rule
+     * @param string $ruleName
      *
      * @throws RuntimeException
      */
-    private function runMatcher(array $config, $commitMessage, $rule)
+    private function runMatcher(array $config, $commitMessage, $rule, $ruleName)
     {
         $regex = new Regex($rule);
 
@@ -125,9 +128,7 @@ class CommitMessage implements TaskInterface
         array_map([$regex, 'addPatternModifier'], $additionalModifiersArray);
 
         if (!preg_match((string) $regex, $commitMessage)) {
-            throw new RuntimeException(
-                sprintf('The commit message does not match the rule: %s', $rule)
-            );
+            throw new RuntimeException("Rule not matched: \"$ruleName\" $rule");
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | n/a

When a commit message failed we used to see:

>The commit message does not match the rule: /JIRA-\d+/

Now we see:

>Rule not matched: "Must contain JIRA issue number" /JIRA-\d+/

Seems good 👍 