### PR TITLE
Added original commit message to CommitMessage task

### DIFF
--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -96,7 +96,18 @@ class CommitMessage implements TaskInterface
         }
 
         if (count($exceptions)) {
-            return TaskResult::createFailed($this, $context, implode(PHP_EOL, $exceptions));
+            return TaskResult::createFailed(
+                $this,
+                $context,
+                implode(PHP_EOL, $exceptions) . <<<KAWAii
+</>
+
+Original commit message follows
+_______________________________
+
+$commitMessage
+KAWAii
+            );
         }
 
         return TaskResult::createPassed($this, $context);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | n/a

GrumPHP is quite rude when he swallows your commit message. It's still available, if you know where to look, but it would be much more polite to echo it back to the user when this happens so they can just copy/paste it back into their editor for amending.

![](https://cloud.githubusercontent.com/assets/470626/23573073/62299aee-006b-11e7-93fd-d5677580780c.png)