### PR TITLE
Validate Git branch naming convention #328

### DIFF
--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -19,6 +19,7 @@ parameters:
         gherkin: ~
         git_blacklist: ~
         git_commit_message: ~
+        git_branch_name: ~
         git_conflict: ~
         grunt: ~
         gulp: ~
@@ -61,6 +62,7 @@ Every task has it's own default configuration. It is possible to overwrite the p
 - [Gherkin](tasks/gherkin.md)
 - [Git blacklist](tasks/git_blacklist.md)
 - [Git commit message](tasks/git_commit_message.md)
+- [Git branch name](tasks/git_branch_name.md)
 - [Git conflict](tasks/git_conflict.md)
 - [Grunt](tasks/grunt.md)
 - [Gulp](tasks/gulp.md)

--- a/doc/tasks/git_branch_name.md
+++ b/doc/tasks/git_branch_name.md
@@ -1,0 +1,47 @@
+# Git commit message
+
+The Git branch name task ensures that the current branch name matches the specified patterns.  
+For example: if you are working with JIRA, it is possible to add a pattern for the JIRA issue number.
+
+```yaml
+# grumphp.yml
+parameters:
+    tasks:
+        git_branch_name:
+            matchers:
+                Must contain JIRA issue number: /JIRA-\d+/
+            case_insensitive: true
+            additional_modifiers: ''
+```
+
+**matchers**
+
+*Default: []*
+
+Use this parameter to specify one or multiple patterns. The value can be in regex or glob style.
+Here are some example matchers:
+
+- /JIRA-([0-9]*)/
+- pre-fix*
+- *suffix
+- ...
+
+**case_insensitive**
+
+*Default: true*
+
+Mark the matchers as case sensitive.
+
+**additional_modifiers**
+
+*Default: ''*
+
+Add one or multiple additional modifiers like:
+
+```yaml
+additional_modifiers: 'u'
+
+# or
+
+additional_modifiers: 'xu'
+```

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -106,6 +106,13 @@ services:
         tags:
             - {name: grumphp.task, config: git_commit_message}
 
+    task.git.branchname:
+        class: GrumPHP\Task\Git\BranchName
+        arguments:
+            - '@config'
+        tags:
+            - {name: grumphp.task, config: git_branch_name}
+
     task.git.conflict:
         class: GrumPHP\Task\Git\Conflict
         arguments:

--- a/src/Configuration/GrumPHP.php
+++ b/src/Configuration/GrumPHP.php
@@ -41,6 +41,14 @@ class GrumPHP
     }
 
     /**
+     * @return \Gitonomy\Git\Repository
+     */
+    public function getGitRepository()
+    {
+        return $this->container->get('git.repository');
+    }
+
+    /**
      * @return string
      */
     public function getHooksDir()

--- a/src/Task/Git/AbstractRegex.php
+++ b/src/Task/Git/AbstractRegex.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace GrumPHP\Task\Git;
+
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Task\TaskInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+abstract class AbstractRegex implements TaskInterface {
+
+    /**
+     * @var GrumPHP
+     */
+    protected $grumPHP;
+
+    /**
+     * @param GrumPHP $grumPHP
+     */
+    public function __construct(GrumPHP $grumPHP)
+    {
+        $this->grumPHP = $grumPHP;
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfiguration()
+    {
+        $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+
+        return $this->getConfigurableOptions()->resolve($configured);
+    }
+
+    /**
+     * @return OptionsResolver
+     */
+    public function getConfigurableOptions()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+          'case_insensitive' => true,
+          'matchers' => [],
+          'additional_modifiers' => ''
+        ]);
+
+        $resolver->addAllowedTypes('case_insensitive', ['bool']);
+        $resolver->addAllowedTypes('matchers', ['array']);
+        $resolver->addAllowedTypes('additional_modifiers', ['string']);
+
+        return $resolver;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | 

This PR adds branch name checking as per #328 allowing to define branch names as follows:

```yaml
parameters:
  tasks:
      git_branch_name:
        matchers:
          - '/^issue-\d+-[a-z-]+/'
        case_insensitive: false
```

# New Task Checklist:

- [ ] Is the README.md file updated?
- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [ ] Does the task contains phpspec tests?
- [ ] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [ ] Is the `run()` method readable?
- [ ] Is the `run()` method using the configuration correctly?
- [ ] Are all CI services returning green?
