### PR TITLE
Add timeout configuration to shell task

### DIFF
--- a/doc/tasks/shell.md
+++ b/doc/tasks/shell.md
@@ -9,6 +9,7 @@ parameters:
     tasks:
         shell:
             scripts: []
+            timeout: 60
             triggered_by: [php]
 ```
 
@@ -32,6 +33,13 @@ parameters:
                - script.sh
                - ["./bin/command", "arg1", "arg2"]
 ```
+
+**timeout**
+
+*Default: 60*
+
+This option (in seconds) will specify the maximum time of execution of your shell scripts.
+You can overwrite this option to whatever time in seconds you want (you can use 0 for unlimited timeout)
 
 **triggered_by**
 

--- a/src/Task/Shell.php
+++ b/src/Task/Shell.php
@@ -30,11 +30,13 @@ class Shell extends AbstractExternalTask
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
             'scripts' => [],
+            'timeout' => 60,
             'triggered_by' => ['php']
         ]);
 
         $resolver->addAllowedTypes('scripts', ['array']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
+        $resolver->addAllowedTypes('timeout', ['int']);
         $resolver->setNormalizer('scripts', function ($resolver, $scripts) {
             return array_map(function ($script) {
                 return is_string($script) ? (array) $script : $script;
@@ -84,10 +86,12 @@ class Shell extends AbstractExternalTask
      */
     private function runShell(array $scriptArguments)
     {
+        $config = $this->getConfiguration();
         $arguments = $this->processBuilder->createArgumentsForCommand('sh');
         $arguments->addArgumentArray('%s', $scriptArguments);
 
         $process = $this->processBuilder->buildProcess($arguments);
+        $process->setTimeout($config['timeout']);
         $process->run();
 
         if (!$process->isSuccessful()) {


### PR DESCRIPTION
Hi,

I add this feature to your task shell today because for a custom script of code verification which exceed 60 seconds I had this error :
```
[Symfony\Component\Process\Exception\ProcessTimedOutException]                             
The process "'/bin/sh' 'your_custom_shell_script.sh'" exceeded the timeout of 60 seconds.
```

Can you accept this contribution for your next release ?

I used it as a patch today and it works very well,

Thanks by advance,

 Regards,

Thomas Giordmaina


Additional Source : http://symfony.com/doc/current/components/process.html#process-timeout
