### PR TITLE
Removed duplicate 'exec' in local githooks

### DIFF
--- a/resources/hooks/local/commit-msg
+++ b/resources/hooks/local/commit-msg
@@ -13,4 +13,4 @@ COMMIT_MSG_FILE=$1
 DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
 
 # Run GrumPHP
-(cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | exec $(HOOK_COMMAND) "--git-user=$GIT_USER" "--git-email=$GIT_EMAIL" "$COMMIT_MSG_FILE")
+(cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | $(HOOK_COMMAND) "--git-user=$GIT_USER" "--git-email=$GIT_EMAIL" "$COMMIT_MSG_FILE")

--- a/resources/hooks/local/pre-commit
+++ b/resources/hooks/local/pre-commit
@@ -9,4 +9,4 @@
 DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
 
 # Run GrumPHP
-(cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | exec $(HOOK_COMMAND) '--skip-success-output')
+(cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | $(HOOK_COMMAND) '--skip-success-output')

--- a/resources/hooks/vagrant/commit-msg
+++ b/resources/hooks/vagrant/commit-msg
@@ -32,7 +32,7 @@ vagrant ssh --command '$(which sh)' << COMMANDS
 
   VAGRANT_COMMIT_MSG_FILE=\$(mktemp -t "grumphp-commitmsg.XXXXXXXXXX")
   echo "\${COMMIT_MSG}" > \$VAGRANT_COMMIT_MSG_FILE
-  printf "%s\n" "\${DIFF}" | exec $(HOOK_COMMAND) '--ansi' --git-user='$GIT_USER' --git-email='$GIT_EMAIL' \$VAGRANT_COMMIT_MSG_FILE
+  printf "%s\n" "\${DIFF}" | $(HOOK_COMMAND) '--ansi' --git-user='$GIT_USER' --git-email='$GIT_EMAIL' \$VAGRANT_COMMIT_MSG_FILE
   RC=\$?
   rm \$VAGRANT_COMMIT_MSG_FILE
   exit \$RC

--- a/resources/hooks/vagrant/pre-commit
+++ b/resources/hooks/vagrant/pre-commit
@@ -17,5 +17,5 @@ vagrant ssh --command '$(which sh)' << COMMANDS
 	__GRUMPHP_DIFF_HEREDOC__
   )
 
-  printf "%s\n" "\${DIFF}" | exec $(HOOK_COMMAND) '--ansi' '--skip-success-output'
+  printf "%s\n" "\${DIFF}" | $(HOOK_COMMAND) '--ansi' '--skip-success-output'
 COMMANDS


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 0.11.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #339

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
The hook templates contain a duplicated `exec` because there is already `exec` defined in the `HOOK_COMMAND`.