### PR TITLE
Lower monolog/monolog version constraint for Magento 2 project compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "composer/composer": "^1.0",
         "doctrine/collections": "~1.2",
         "gitonomy/gitlib": "~1.0",
-        "monolog/monolog": "~1.17",
+        "monolog/monolog": "~1.16",
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
         "seld/jsonlint": "~1.1",
         "symfony/config": "~2.7|~3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes/no

Magento 2.1 project currently requires `monolog/monolog` version `1.16.0`, whilst grumphp requires version `~1.17`. This shouldn't really break functionality it only should expand compatibility a bit more. [See release notes of `monolog/monolog` version 1.17.0](https://github.com/Seldaek/monolog/releases/tag/1.17.0).

