### PR TITLE
Add PhpMnd task

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "nikic/php-parser": "Lets GrumPHP run static analyses through your PHP files.",
         "phing/phing": "Lets GrumPHP run your automated PHP tasks.",
         "phpmd/phpmd": "Lets GrumPHP sort out the mess in your code",
+        "phpmnd/phpmnd": "Lets GrumPHP help you detect magic numbers in PHP code.",
         "phpspec/phpspec": "Lets GrumPHP spec your code.",
         "phpstan/phpstan": "Lets GrumPHP discover bugs in your code without running it.",
         "phpunit/phpunit": "Lets GrumPHP run your unit tests.",

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -36,6 +36,7 @@ parameters:
         phpcsfixer2: ~
         phplint: ~
         phpmd: ~
+        phpmnd: ~
         phpparser: ~
         phpspec: ~
         phpstan: ~
@@ -81,6 +82,7 @@ Every task has it's own default configuration. It is possible to overwrite the p
 - [PHP-CS-Fixer 2](tasks/phpcsfixer2.md)
 - [PHPLint](tasks/phplint.md)
 - [PhpMd](tasks/phpmd.md)
+- [PhpMnd](tasks/phpmnd.md)
 - [PhpParser](tasks/phpparser.md)
 - [Phpspec](tasks/phpspec.md)
 - [PHPStan](tasks/phpstan.md)

--- a/doc/tasks/phpmnd.md
+++ b/doc/tasks/phpmnd.md
@@ -1,0 +1,129 @@
+# PhpMnd
+
+The PhpMnd task helps you detect magic numbers in PHP code.
+
+***Composer***
+
+```
+composer require --dev povils/phpmnd
+```
+
+***Config***
+
+The task lives under the `phpmnd` namespace and has following configurable parameters:
+
+```yaml
+# grumphp.yml
+parameters:
+    tasks:
+        phpmnd:
+            directory: .
+            exclude: []
+            exclude_name: []
+            exclude_path: []
+            extensions: []
+            hint: false
+            ignore_numbers: []
+            ignore_strings: []
+            strings: false
+            triggered_by: ['php']
+```
+
+**directory**
+
+*Default: .*
+
+With this parameter you can define which directory you want to run `phpmnd` in (must be relative to cwd).
+
+**exclude**
+
+*Default: []*
+
+This parameter will allow you to exclude directories from the code analysis (must be relative to source).
+
+**exclude_name**
+
+*Default: []*
+
+This parameter will allow you to exclude files from the code analysis (must be relative to source).
+
+**exclude_path**
+
+*Default: []*
+
+This parameter will allow you to exclude paths from the code analysis (must be relative to source).
+
+**extensions**
+
+*Default: []*
+
+By default PHP Magic Number Detector analyses conditions, return statements and switch cases. This parameter lets you extend the code analysis.
+
+* **argument**
+    ```php
+round($number, 4);
+    ```
+* **array**
+    ```php
+$array = [200, 201];
+    ```
+* **assign**
+    ```php
+$var = 10;
+    ```
+* **default_parameter**
+    ```php
+function foo($default = 3);
+    ```
+* **operation**
+    ```php
+$bar = $foo * 20;
+    ```
+* **property**
+    ```php
+private $bar = 10;
+    ```
+* **return(default)**
+    ```php
+return 5;
+    ```
+* **condition(default)**
+    ```php
+$var < 7;
+    ```
+* **switch_case(default)**
+    ```php
+case 3;
+    ```
+
+You can use `all` to include all extensions. If an extension starts with minus (`-`) that means it will be removed from the code analysis.
+
+**hint**
+
+*Default: false*
+
+This parameter will suggest replacements for magic numbers based on your codebase constants.
+
+**ignore_numbers**
+
+*Default: []*
+
+This parameter will exclude numbers from the code analysis. By default PHP Magic Number Detector does not consider `0` and `1` to be magic numbers.
+
+**ignore_strings**
+
+*Default: []*
+
+This parameter will exclude strings from the code analysis when the parameter "strings" is enabled.
+
+**strings**
+
+*Default: false*
+
+This parameter will include strings literal search in the code analysis.
+
+**triggered_by**
+
+*Default: [php]*
+
+This is a list of extensions to be analyzed.

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -258,6 +258,15 @@ services:
         tags:
           - {name: grumphp.task, config: phpmd}
 
+    task.phpmnd:
+        class: GrumPHP\Task\PhpMnd
+        arguments:
+          - '@config'
+          - '@process_builder'
+          - '@formatter.raw_process'
+        tags:
+          - {name: grumphp.task, config: phpmnd}
+
     task.phpparser:
         class: GrumPHP\Task\PhpParser
         arguments:

--- a/spec/Task/PhpMndSpec.php
+++ b/spec/Task/PhpMndSpec.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace spec\GrumPHP\Task;
+
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
+use GrumPHP\Process\ProcessBuilder;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\PhpMnd;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Process\Process;
+
+class PhpMndSpec extends ObjectBehavior
+{
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
+    {
+        $grumPHP->getTaskConfiguration('phpmnd')->willReturn([]);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PhpMnd::class);
+    }
+
+    function it_should_have_a_name()
+    {
+        $this->getName()->shouldBe('phpmnd');
+    }
+
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf(OptionsResolver::class);
+        $options->getDefinedOptions()->shouldContain('directory');
+        $options->getDefinedOptions()->shouldContain('exclude');
+        $options->getDefinedOptions()->shouldContain('exclude_name');
+        $options->getDefinedOptions()->shouldContain('exclude_path');
+        $options->getDefinedOptions()->shouldContain('extensions');
+        $options->getDefinedOptions()->shouldContain('hint');
+        $options->getDefinedOptions()->shouldContain('ignore_numbers');
+        $options->getDefinedOptions()->shouldContain('ignore_strings');
+        $options->getDefinedOptions()->shouldContain('strings');
+        $options->getDefinedOptions()->shouldContain('triggered_by');
+    }
+
+    function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_run_in_run_context(RunContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder, ContextInterface $context)
+    {
+        $processBuilder->buildProcess('phpmnd')->shouldNotBeCalled();
+        $processBuilder->buildProcess()->shouldNotBeCalled();
+        $context->getFiles()->willReturn(new FilesCollection());
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->getResultCode()->shouldBe(TaskResult::SKIPPED);
+    }
+
+    function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
+    {
+        $arguments = new ProcessArgumentsCollection();
+        $processBuilder->createArgumentsForCommand('phpmnd')->willReturn($arguments);
+        $processBuilder->buildProcess($arguments)->willReturn($process);
+
+        $process->run()->shouldBeCalled();
+        $process->isSuccessful()->willReturn(true);
+
+        $context->getFiles()->willReturn(new FilesCollection([
+            new SplFileInfo('test.php', '.', 'test.php')
+        ]));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_throws_exception_if_the_process_fails(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
+    {
+        $arguments = new ProcessArgumentsCollection();
+        $processBuilder->createArgumentsForCommand('phpmnd')->willReturn($arguments);
+        $processBuilder->buildProcess($arguments)->willReturn($process);
+
+        $process->run()->shouldBeCalled();
+        $process->isSuccessful()->willReturn(false);
+
+        $context->getFiles()->willReturn(new FilesCollection([
+            new SplFileInfo('test.php', '.', 'test.php')
+        ]));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+}

--- a/src/Task/PhpMnd.php
+++ b/src/Task/PhpMnd.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace GrumPHP\Task;
+
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * PhpMnd task
+ */
+class PhpMnd extends AbstractExternalTask
+{
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'phpmnd';
+    }
+
+    /**
+     * @return OptionsResolver
+     */
+    public function getConfigurableOptions()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'directory' => '.',
+            'exclude' => [],
+            'exclude_name' => [],
+            'exclude_path' => [],
+            'extensions' => [],
+            'hint' => false,
+            'ignore_numbers' => [],
+            'ignore_strings' => [],
+            'strings' => false,
+            'triggered_by' => ['php']
+        ]);
+
+        $resolver->addAllowedTypes('directory', ['string']);
+        $resolver->addAllowedTypes('exclude', ['array']);
+        $resolver->addAllowedTypes('exclude_name', ['array']);
+        $resolver->addAllowedTypes('exclude_path', ['array']);
+        $resolver->addAllowedTypes('extensions', ['array']);
+        $resolver->addAllowedTypes('hint', ['bool']);
+        $resolver->addAllowedTypes('ignore_numbers', ['array']);
+        $resolver->addAllowedTypes('ignore_strings', ['array']);
+        $resolver->addAllowedTypes('strings', ['bool']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
+
+        return $resolver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canRunInContext(ContextInterface $context)
+    {
+        return ($context instanceof GitPreCommitContext || $context instanceof RunContext);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(ContextInterface $context)
+    {
+        $config = $this->getConfiguration();
+        $files = $context->getFiles()->extensions($config['triggered_by']);
+
+        if (0 === count($files)) {
+            return TaskResult::createSkipped($this, $context);
+        }
+
+        $config = $this->getConfiguration();
+
+        $arguments = $this->processBuilder->createArgumentsForCommand('phpmnd');
+        $arguments->addOptionalCommaSeparatedArgument('--exclude=%s', $config['exclude']);
+        $arguments->addOptionalCommaSeparatedArgument('--exclude-name=%s', $config['exclude_name']);
+        $arguments->addOptionalCommaSeparatedArgument('--exclude-path=%s', $config['exclude_path']);
+        $arguments->addOptionalCommaSeparatedArgument('--extensions=%s', $config['extensions']);
+        $arguments->addOptionalArgument('--hint', $config['hint']);
+        $arguments->addOptionalCommaSeparatedArgument('--ignore-numbers=%s', $config['ignore_numbers']);
+        $arguments->addOptionalCommaSeparatedArgument('--ignore-strings=%s', $config['ignore_strings']);
+        $arguments->addOptionalArgument('--strings', $config['strings']);
+        $arguments->addOptionalCommaSeparatedArgument('--suffixes=%s', $config['triggered_by']);
+        $arguments->add('--non-zero-exit-on-violation');
+        $arguments->add($config['directory']);
+
+        $process = $this->processBuilder->buildProcess($arguments);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | n/a

This PR adds support for [PHP Magic Number Detector](https://github.com/povils/phpmnd) (PHPMND).

> `phpmnd` is a tool that **helps** you detect magic numbers in PHP code.
>
> **What is Magic Number?**
>Magic number is a numeric literal that is not defined as a constant that may change at a later stage, but that can be therefore hard to update. It is a bad programming practice of using numbers directly in source code without explanation. In most cases this makes programs harder to read, understand, and maintain.

# New Task Checklist:

- [x] Is the README.md file updated?
- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpspec tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?
