### PR TITLE
Maintain PHP 7.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "doctrine/collections": "~1.2",
         "gitonomy/gitlib": "~1.0",
         "monolog/monolog": "~1.16",
-        "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
+        "ocramius/proxy-manager": "~0.4|~1.0|~2.0.0",
         "seld/jsonlint": "~1.1",
         "symfony/config": "~2.7|~3.0",
         "symfony/console": "~2.7|~3.0",


### PR DESCRIPTION
Update ocramius/proxy-manager dependency to minor version v2.0.* to maintain PHP 7.0 support. As of version ocramius/proxy-manager v2.1.* PHP 7.1 is required.