### PR TITLE
Fix symfony progressbar issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
   - nightly
 
 env:

--- a/src/Task/PhpStan.php
+++ b/src/Task/PhpStan.php
@@ -2,14 +2,11 @@
 
 namespace GrumPHP\Task;
 
-use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
-use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Process\Process;
 
 /**
  * PhpStan task


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 

Symfony 3.3.0 makes the ProgressBar final. This causes all mocked ProgressBar objects to crash in phpspec.

Additional info:  https://github.com/symfony/symfony/pull/20487


