### PR TITLE
Add various enforcements to git_commit_message

### DIFF
--- a/doc/tasks/git_commit_message.md
+++ b/doc/tasks/git_commit_message.md
@@ -1,6 +1,6 @@
 # Git commit message
 
-The Git commit message task ensures commit messages match the specified patterns.  
+The Git commit message task ensures commit messages match the specified patterns.
 For example: if you are working with JIRA, it is possible to add a pattern for the JIRA issue number.
 
 ```yaml
@@ -8,12 +8,54 @@ For example: if you are working with JIRA, it is possible to add a pattern for t
 parameters:
     tasks:
         git_commit_message:
+            allow_empty_message: false
+            enforce_capitalized_subject: true
+            enforce_no_subject_trailing_period: true
+            enforce_single_lined_subject: true
+            max_body_width: 72
+            max_subject_width: 60
             matchers:
                 Must contain JIRA issue number: /JIRA-\d+/
             case_insensitive: true
             multiline: true
             additional_modifiers: ''
 ```
+
+**allow_empty_message**
+
+*Default: false*
+
+Controls whether or not empty commit messages are allowed.
+
+**enforce_capitalized_subject**
+
+*Default: true*
+
+Ensures that the commit message subject line starts with a capital letter.
+
+**enforce_no_subject_trailing_period**
+
+*Default: true*
+
+Ensures that the commit message subject line doesn't have a trailing period.
+
+**enforce_single_lined_subject**
+
+*Default: true*
+
+Ensures that the commit message subject line is followed by a blank line.
+
+**max_body_width**
+
+*Default: 72*
+
+Preferred limit on the commit message body lines.
+
+**max_subject_width**
+
+*Default: 60*
+
+Preferred limit on the commit message subject line.
 
 **matchers**
 

--- a/spec/Task/Git/CommitMessageSpec.php
+++ b/spec/Task/Git/CommitMessageSpec.php
@@ -16,7 +16,10 @@ class CommitMessageSpec extends ObjectBehavior
     {
         $this->beConstructedWith($grumPHP);
         $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
-            'matchers' => ['test', '*es*', 'te[s][t]', '/^te(.*)/', '/(.*)st$/', '/t(e|a)st/', 'TEST']
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => false,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
         ]);
     }
 
@@ -29,6 +32,12 @@ class CommitMessageSpec extends ObjectBehavior
     {
         $options = $this->getConfigurableOptions();
         $options->shouldBeAnInstanceOf(OptionsResolver::class);
+        $options->getDefinedOptions()->shouldContain('allow_empty_message');
+        $options->getDefinedOptions()->shouldContain('enforce_capitalized_subject');
+        $options->getDefinedOptions()->shouldContain('enforce_no_subject_trailing_period');
+        $options->getDefinedOptions()->shouldContain('max_body_width');
+        $options->getDefinedOptions()->shouldContain('max_subject_width');
+        $options->getDefinedOptions()->shouldContain('enforce_single_lined_subject');
         $options->getDefinedOptions()->shouldContain('case_insensitive');
         $options->getDefinedOptions()->shouldContain('multiline');
         $options->getDefinedOptions()->shouldContain('matchers');
@@ -50,8 +59,16 @@ class CommitMessageSpec extends ObjectBehavior
         $this->canRunInContext($context)->shouldReturn(true);
     }
 
-    function it_runs_the_suite(GitCommitMsgContext $context)
+    function it_runs_the_suite(GrumPHP $grumPHP, GitCommitMsgContext $context)
     {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => false,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
+            'matchers' => ['test', '*es*', 'te[s][t]', '/^te(.*)/', '/(.*)st$/', '/t(e|a)st/', 'TEST']
+        ]);
+
         $context->getCommitMessage()->willReturn('test');
 
         $result = $this->run($context);
@@ -59,7 +76,15 @@ class CommitMessageSpec extends ObjectBehavior
         $result->isPassed()->shouldBe(true);
     }
 
-    function it_throws_exception_if_the_process_fails(GitCommitMsgContext $context) {
+    function it_throws_exception_if_the_process_fails(GrumPHP $grumPHP, GitCommitMsgContext $context) {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => false,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
+            'matchers' => ['test', '*es*', 'te[s][t]', '/^te(.*)/', '/(.*)st$/', '/t(e|a)st/', 'TEST']
+        ]);
+
         $context->getCommitMessage()->willReturn('invalid');
 
         $result = $this->run($context);
@@ -70,11 +95,475 @@ class CommitMessageSpec extends ObjectBehavior
     function it_runs_with_additional_modifiers(GrumPHP $grumPHP, GitCommitMsgContext $context)
     {
         $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => false,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
             'matchers' => ['/.*ümlaut/'],
             'additional_modifiers' => 'u',
         ]);
 
         $context->getCommitMessage()->willReturn('message containing ümlaut');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_commit_message_is_empty(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => true,
+            'enforce_no_subject_trailing_period' => true,
+            'enforce_single_lined_subject' => true,
+        ]);
+
+        $context->getCommitMessage()->willReturn('');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_subject_starts_with_a_capital_letter(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => true,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
+        ]);
+
+        $commitMessage = <<<'MSG'
+Initial commit
+
+Mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_subject_starts_with_a_utf8_capital_letter(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => true,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
+        ]);
+
+        $commitMessage = <<<'MSG'
+Årsgång
+
+Mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_subject_starts_with_punctuation_and_a_capital_letter(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => true,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
+        ]);
+
+        $commitMessage = <<<'MSG'
+"Initial" commit
+
+Mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_fail_when_subject_starts_with_a_lowercase_letter(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => true,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
+        ]);
+
+        $commitMessage = <<<'MSG'
+initial commit
+
+I forget about commit message standards and decide to not capitalize my
+subject. Still mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+
+    function it_should_fail_when_subject_starts_with_a_utf8_lowercase_letter(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => true,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
+        ]);
+
+        $commitMessage = <<<'MSG'
+årsgång
+
+I forget about commit message standards and decide to not capitalize my
+subject. Still mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+
+    function it_should_fail_when_subject_starts_with_punctuation_and_a_lowercase_letter(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => true,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
+        ]);
+
+        $commitMessage = <<<'MSG'
+"initial" commit
+
+I forget about commit message standards and decide to not capitalize my
+subject. Still mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+
+    function it_should_pass_when_subject_starts_with_special_fixup_prefix(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => true,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
+        ]);
+
+        $commitMessage = <<<'MSG'
+fixup! commit
+
+This was created by running git commit --fixup=...
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_subject_starts_with_special_squash_prefix(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => true,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
+        ]);
+
+        $commitMessage = <<<'MSG'
+squash! commit
+
+This was created by running git commit --squash=...
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_first_line_of_commit_message_is_an_empty_line(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => true,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
+        ]);
+
+        $commitMessage = <<<'MSG'
+
+There was no first line
+
+This is a mistake.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_fail_when_commit_message_is_empty(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => false,
+            'enforce_capitalized_subject' => false,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
+        ]);
+
+        $context->getCommitMessage()->willReturn('');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+
+    function it_should_fail_when_commit_message_contains_only_whitespace(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => false,
+            'enforce_capitalized_subject' => false,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
+        ]);
+
+        $context->getCommitMessage()->willReturn(' ');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+
+    function it_should_pass_when_commit_message_is_not_empty(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => false,
+            'enforce_capitalized_subject' => false,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => false,
+        ]);
+
+        $context->getCommitMessage()->willReturn('when commit message is not empty');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_subject_is_separated_from_body_by_a_blank_line(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => false,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => true,
+        ]);
+
+        $commitMessage = <<<'MSG'
+Initial commit
+
+Mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_fail_when_subject_is_not_kept_to_one_line(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => false,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => true,
+        ]);
+
+        $commitMessage = <<<'MSG'
+Initial commit where I forget about commit message
+standards and decide to hard-wrap my subject
+
+Still mostly cats so far.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+
+    function it_should_fail_when_subject_is_longer_than_60_characters(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn(str_repeat('A', 61));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+        $result->getMessage()->shouldMatch('/subject/');
+    }
+
+    function it_should_pass_when_subject_is_60_characters_or_fewer(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn(str_repeat('A', 60));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_subject_starts_with_special_fixup_and_is_longer_than_60_characters(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn('fixup! '.str_repeat('A', 60));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_subject_starts_with_special_squash_and_is_longer_than_60_characters(GitCommitMsgContext $context)
+    {
+        $context->getCommitMessage()->willReturn('squash! '.str_repeat('A', 60));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_the_subject_is_60_characters_followed_by_a_newline(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+This is 60 characters, or 61 if the newline is counted
+
+A reasonable line.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_pass_when_a_line_in_the_message_is_72_characters_followed_by_a_newline(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+Some summary
+
+This line has 72 characters, but with newline it has 73 characters
+That shouldn't be a problem.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_fail_when_a_line_in_the_message_is_longer_than_72_characters(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+Some summary
+
+This line is longer than 72 characters which is clearly be seen by count.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+        $result->getMessage()->shouldBe('Line 3 of commit message has > 72 characters.');
+    }
+
+    function it_should_pass_when_all_lines_in_the_message_are_fewer_than_72_characters(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+Some summary
+
+A reasonable line.
+
+Another reasonable line.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_fail_when_subject_and_a_line_in_the_message_is_longer_than_the_limits(GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+A subject line that is way too long. A subject line that is way too long.
+
+A message line that is way too long. A message line that is way too long.
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+        $result->getMessage()->shouldMatch('/keep.*subject <= 60.*\n.*line 3.*> 72.*/im');
+    }
+
+    function it_should_fail_when_subject_contains_a_trailing_period(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => false,
+            'enforce_no_subject_trailing_period' => true,
+            'enforce_single_lined_subject' => false,
+        ]);
+
+        $context->getCommitMessage()->willReturn('This subject has a period.');
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+
+    function it_should_pass_when_subject_does_not_contain_a_trailing_period(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => true,
+            'enforce_capitalized_subject' => false,
+            'enforce_no_subject_trailing_period' => true,
+            'enforce_single_lined_subject' => false,
+        ]);
+
+        $context->getCommitMessage()->willReturn('This subject has no period');
 
         $result = $this->run($context);
         $result->shouldBeAnInstanceOf(TaskResultInterface::class);

--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -54,12 +54,24 @@ class CommitMessage implements TaskInterface
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
+            'allow_empty_message' => false,
+            'enforce_capitalized_subject' => true,
+            'enforce_no_subject_trailing_period' => true,
+            'enforce_single_lined_subject' => true,
+            'max_body_width' => 72,
+            'max_subject_width' => 60,
             'case_insensitive' => true,
             'multiline' => true,
             'matchers' => [],
             'additional_modifiers' => ''
         ]);
 
+        $resolver->addAllowedTypes('allow_empty_message', ['bool']);
+        $resolver->addAllowedTypes('enforce_capitalized_subject', ['bool']);
+        $resolver->addAllowedTypes('enforce_no_subject_trailing_period', ['bool']);
+        $resolver->addAllowedTypes('enforce_single_lined_subject', ['bool']);
+        $resolver->addAllowedTypes('max_body_width', ['int']);
+        $resolver->addAllowedTypes('max_subject_width', ['int']);
         $resolver->addAllowedTypes('case_insensitive', ['bool']);
         $resolver->addAllowedTypes('multiline', ['bool']);
         $resolver->addAllowedTypes('matchers', ['array']);
@@ -89,6 +101,38 @@ class CommitMessage implements TaskInterface
         $commitMessage = $context->getCommitMessage();
         $exceptions = [];
 
+        if (!(bool) $config['allow_empty_message'] && trim($commitMessage) === '') {
+            return TaskResult::createFailed(
+                $this,
+                $context,
+                'Commit message should not be empty.'
+            );
+        }
+
+        if ((bool) $config['enforce_capitalized_subject'] && !$this->subjectIsCapitalized($context)) {
+            return TaskResult::createFailed(
+                $this,
+                $context,
+                'Subject should start with a capital letter.'
+            );
+        }
+
+        if ((bool) $config['enforce_single_lined_subject'] && !$this->subjectIsSingleLined($context)) {
+            return TaskResult::createFailed(
+                $this,
+                $context,
+                'Subject should be one line and followed by a blank line.'
+            );
+        }
+
+        if ((bool) $config['enforce_no_subject_trailing_period'] && $this->subjectHasTrailingPeriod($context)) {
+            return TaskResult::createFailed(
+                $this,
+                $context,
+                'Please omit trailing period from commit message subject.'
+            );
+        }
+
         foreach ($config['matchers'] as $ruleName => $rule) {
             try {
                 $this->runMatcher($config, $commitMessage, $rule, $ruleName);
@@ -99,6 +143,46 @@ class CommitMessage implements TaskInterface
 
         if (count($exceptions)) {
             return TaskResult::createFailed($this, $context, implode(PHP_EOL, $exceptions));
+        }
+
+        return $this->enforceTextWidth($context);
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return TaskResult
+     */
+    private function enforceTextWidth(ContextInterface $context)
+    {
+        $commitMessage = $context->getCommitMessage();
+        $config = $this->getConfiguration();
+
+        if (trim($commitMessage) === '') {
+            return TaskResult::createPassed($this, $context);
+        }
+
+        $errors = [];
+        $lines = preg_split('/\R/u', $commitMessage);
+        $subject = rtrim($lines[0]);
+        $maxSubjectWidth = $config['max_subject_width'] + $this->getSpecialPrefixLength($subject);
+
+        if (mb_strlen($subject) > $maxSubjectWidth) {
+            $errors[] = sprintf('Please keep the subject <= %u characters.', $maxSubjectWidth);
+        }
+
+        foreach (array_slice($lines, 2) as $index => $line) {
+            if (mb_strlen(rtrim($line)) > $config['max_body_width']) {
+                $errors[] = sprintf(
+                    'Line %u of commit message has > %u characters.',
+                    $index + 3,
+                    $config['max_body_width']
+                );
+            }
+        }
+
+        if (count($errors) > 0) {
+            return TaskResult::createFailed($this, $context, implode(PHP_EOL, $errors));
         }
 
         return TaskResult::createPassed($this, $context);
@@ -130,5 +214,103 @@ class CommitMessage implements TaskInterface
         if (!preg_match((string) $regex, $commitMessage)) {
             throw new RuntimeException("Rule not matched: \"$ruleName\" $rule");
         }
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return int
+     */
+    private function getSpecialPrefixLength($string)
+    {
+        if (preg_match('/^(fixup|squash)! /', $string, $match) !== 1) {
+            return 0;
+        }
+
+        return mb_strlen($match[0]);
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    private function subjectHasTrailingPeriod(ContextInterface $context)
+    {
+        $commitMessage = $context->getCommitMessage();
+
+        if (trim($commitMessage) === '') {
+            return false;
+        }
+
+        $lines = preg_split('/\R/u', $commitMessage);
+
+        if (mb_substr(rtrim($lines[0]), -1) !== '.') {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    private function subjectIsCapitalized(ContextInterface $context)
+    {
+        $commitMessage = $context->getCommitMessage();
+
+        if (trim($commitMessage) === '') {
+            return true;
+        }
+
+        $lines = preg_split('/\R/u', $commitMessage);
+        $subject = array_reduce($lines, function ($subject, $line) {
+            if ($subject !== null) {
+                return $subject;
+            }
+
+            if (trim($line) === '') {
+                return null;
+            }
+
+            return $line;
+        }, null);
+
+
+        if ($subject === null || preg_match('/^[[:punct:]]*(.)/u', $subject, $match) !== 1) {
+            return false;
+        }
+
+        $firstLetter = $match[1];
+
+        if (preg_match('/^(fixup|squash)!/u', $subject) !== 1 && preg_match('/[[:upper:]]/u', $firstLetter) !== 1) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    private function subjectIsSingleLined(ContextInterface $context)
+    {
+        $commitMessage = $context->getCommitMessage();
+
+        if (trim($commitMessage) === '') {
+            return true;
+        }
+
+        $lines = preg_split('/\R/u', $commitMessage);
+
+        if (array_key_exists(1, $lines) && trim($lines[1]) !== '') {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | -

These are the same enforcements introduced by the tasks in #319, but built into the existing `git_commit_message` task instead (as discussed [here](https://github.com/phpro/grumphp/pull/319#issuecomment-284313781)).

While I agree that it's probably a good idea to drop `case_insensitive`, `multiline` and `additional_modifiers` and let the matchers define their desired modifiers themselves, that is a breaking change and not really in the scope of this PR. 
