### PR TITLE
Blacklisted keywords on lines bigger then 80 chars will now display their error message correctly.

### DIFF
--- a/spec/Formatter/GitBlacklistFormatterSpec.php
+++ b/spec/Formatter/GitBlacklistFormatterSpec.php
@@ -64,4 +64,14 @@ class GitBlacklistFormatterSpec extends ObjectBehavior
             . "  1\033[36m:\033[m149\033[36m:\033[m options.debug===!0&&\033[1;31mvar_dump(\033[m\"Pushed state \"+g\033[m"
         );
     }
+
+    function it_displays_stdout_special_correctly(Process $process)
+    {
+        $process->getOutput()->willReturn('normal/file.php' . "\n" . "8\033[36m:\033[m\t\033[1;31mprivate $\033[m' . \$this->callSomeVeryVeryVeryLongMethodName() . ' = null;" . "\n");
+        $process->getErrorOutput()->willReturn('');
+        $this->format($process)->shouldReturn(
+            "\033[mnormal/file.php" . PHP_EOL
+            . "  1\033[36m:\033[m20\033[36m:\033[m 8\033[36m:\033[m\t\033[1;31mprivate $\033[m' . \$this->callSo\033[m"
+        );
+    }
 }

--- a/src/Formatter/GitBlacklistFormatter.php
+++ b/src/Formatter/GitBlacklistFormatter.php
@@ -93,6 +93,10 @@ class GitBlacklistFormatter implements ProcessFormatterInterface
             } while ($pos2 < $pos);
 
             $pos -= static::SPACE_BEFORE;
+            //$pos can't be lower then 0 else we start at the end of the string instead of the beginning
+            if ($pos < 0) {
+                $pos = 0;
+            }
             $pos2 += static::SPACE_AFTER;
 
             $part = '  ' . $lineNumber . static::COLON_COLOR . ':' . static::RESET_COLOR;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #293 

For blacklisted keywords on lines longer then 80 characters the output
was not well formatted. The wrong starting position was used
within the mb_substr method, a negative one which resulted that the substr started
at the end of the error message. This has been
resolved by making sure the starting position will not be negative.

The outcome is now the following:
```
You have blacklisted keywords in your commit:
t.php
1:20: 8:    private $' . $this->callSo
```
The last number is the actual line number where the keyword is in.