### PR TITLE
Fix exclude_name parameter for phpmnd task

### DIFF
--- a/src/Task/PhpMnd.php
+++ b/src/Task/PhpMnd.php
@@ -78,7 +78,7 @@ class PhpMnd extends AbstractExternalTask
 
         $arguments = $this->processBuilder->createArgumentsForCommand('phpmnd');
         $arguments->addOptionalCommaSeparatedArgument('--exclude=%s', $config['exclude']);
-        $arguments->addOptionalCommaSeparatedArgument('--exclude-name=%s', $config['exclude_name']);
+        $arguments->addOptionalCommaSeparatedArgument('--exclude-file=%s', $config['exclude_name']);
         $arguments->addOptionalCommaSeparatedArgument('--exclude-path=%s', $config['exclude_path']);
         $arguments->addOptionalCommaSeparatedArgument('--extensions=%s', $config['extensions']);
         $arguments->addOptionalArgument('--hint', $config['hint']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | -
| Fixed tickets | -

Seems like the documentation for phpmnd ~is~ [was](https://github.com/povils/phpmnd/pull/58) wrong and the option for excluding files is actually named `exclude-file` (_gasp!_).

I chose to keep the name `exclude_name` for GrumPHP though to avoid unnecessary BC break.
