### PR TITLE
Write task progress to error output

### DIFF
--- a/src/Console/Helper/TaskRunnerHelper.php
+++ b/src/Console/Helper/TaskRunnerHelper.php
@@ -9,6 +9,7 @@ use GrumPHP\Runner\TaskRunner;
 use GrumPHP\Runner\TaskRunnerContext;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -93,6 +94,10 @@ class TaskRunnerHelper extends Helper
      */
     private function registerEventListeners(OutputInterface $output)
     {
+        if ($output instanceof ConsoleOutputInterface) {
+            $output = $output->getErrorOutput();
+        }
+        
         $this->eventDispatcher->addSubscriber(new ProgressSubscriber($output, new ProgressBar($output)));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | -
| Fixed tickets | -

Currently things that uses `$this->output` (like `✔` and `✘`) writes to _stdout_ while everything that utilizes ProgressBar usually writes to _stderr_. This PR simply replicates how ProgressBar handles output internally to make output a bit more consistent.
  