### PR TITLE
Use argument arrays for phpmnd's exclude options

### DIFF
--- a/src/Task/PhpMnd.php
+++ b/src/Task/PhpMnd.php
@@ -77,9 +77,9 @@ class PhpMnd extends AbstractExternalTask
         $config = $this->getConfiguration();
 
         $arguments = $this->processBuilder->createArgumentsForCommand('phpmnd');
-        $arguments->addOptionalCommaSeparatedArgument('--exclude=%s', $config['exclude']);
-        $arguments->addOptionalCommaSeparatedArgument('--exclude-file=%s', $config['exclude_name']);
-        $arguments->addOptionalCommaSeparatedArgument('--exclude-path=%s', $config['exclude_path']);
+        $arguments->addArgumentArray('--exclude=%s', $config['exclude']);
+        $arguments->addArgumentArray('--exclude-file=%s', $config['exclude_name']);
+        $arguments->addArgumentArray('--exclude-path=%s', $config['exclude_path']);
         $arguments->addOptionalCommaSeparatedArgument('--extensions=%s', $config['extensions']);
         $arguments->addOptionalArgument('--hint', $config['hint']);
         $arguments->addOptionalCommaSeparatedArgument('--ignore-numbers=%s', $config['ignore_numbers']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | -
| Fixed tickets | -

Another fix for the phpmnd task. Unlike some of the other options, the three for excluding files wants one argument per file instead of a comma-separated list (so `--exclude=a.php --exclude=b.php` instead of `--exclude=a.php,b.php`).