### PR TITLE
Only add DIRECTORY_SEPARATOR if needed

### DIFF
--- a/src/Linter/Xml/XmlLinter.php
+++ b/src/Linter/Xml/XmlLinter.php
@@ -237,7 +237,10 @@ class XmlLinter implements LinterInterface
             return $this->loadFromNet ? $scheme : null;
         }
 
-        $schemeFile = new SplFileInfo($xmlFile->getPath() . DIRECTORY_SEPARATOR . $scheme);
+        $xmlFilePath = $xmlFile->getPath();
+        $schemePath = empty($xmlFilePath) ? $scheme : rtrim($xmlFilePath, '/') . DIRECTORY_SEPARATOR . $scheme;
+
+        $schemeFile = new SplFileInfo($schemePath);
 
         return $schemeFile->isReadable() ? $schemeFile->getPathname() : null;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | -
| Fixed tickets | -

The currently code isn't so friendly to relative paths since it always adds a `DIRECTORY_SEPARATOR`.

For example if I have `phpunit.xml` in the root of the project and add `vendor/phpunit/phpunit/phpunit.xsd` as a scheme in it, the linter would end up resolving its path as `/vendor/phpunit/phpunit/phpunit.xsd`. This is due to `$xmlFile->getPath()` returning an empty string, and thus the enforced `DIRECTORY_SEPARATOR` turns it into an absolute path.

This change will make sure that `DIRECTORY_SEPARATOR` is only added when the file actually has a path, and the `rtrim()` is there to make sure we don't end up with some `//` weirdness.