### PR TITLE
CloverCoverageTask; fixing devided by 0 warning 

### DIFF
--- a/src/Task/CloverCoverage.php
+++ b/src/Task/CloverCoverage.php
@@ -110,6 +110,10 @@ class CloverCoverage implements TaskInterface
         $totalElements   = (string)current($xml->xpath('/coverage/project/metrics/@elements'));
         $checkedElements = (string)current($xml->xpath('/coverage/project/metrics/@coveredelements'));
 
+        if ((int)$totalElements === 0) {
+            return TaskResult::createSkipped($this, $context);
+        }
+        
         $coverage = round(($checkedElements / $totalElements) * 100, 2);
 
         if ($coverage < $percentage) {


### PR DESCRIPTION
Added a skip Task when the total number of elements in the clover.xml file is zero.

| Q             | A
| ------------- | ---
| Branch        | master 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes/no
| Fixed tickets | none