### PR TITLE
Add parse_constant and parse_custom_tags options to yamllint task

### DIFF
--- a/doc/tasks/yamllint.md
+++ b/doc/tasks/yamllint.md
@@ -11,6 +11,8 @@ parameters:
             ignore_patterns: []
             object_support: false
             exception_on_invalid_type: false
+            parse_constant: false
+            parse_custom_tags: false
 ```
 
 **ignore_patterns**
@@ -34,3 +36,19 @@ This option indicates if the Yaml parser supports serialized PHP objects.
 
 By enabling this option, the types of the yaml values are validated. 
 When the value has an incorrect type, a lint error will be triggered.
+
+
+**parse_constant**
+
+*Default: false*
+
+By enabling this option, constants defined by the special `!php/const:` syntax is parsed and validated.
+When this option is not set, the constant syntax will trigger an error
+
+
+**parse_custom_tags**
+
+*Default: false*
+
+By enabling this option, custom tags in the yaml file will be parsed and validated (E.G `!my_tag { foo: bar }`).
+When this option is not set, using custom tags will trigger an error

--- a/spec/Task/YamlLintSpec.php
+++ b/spec/Task/YamlLintSpec.php
@@ -42,6 +42,8 @@ class YamlLintSpec extends AbstractLinterTaskSpec
         $options->shouldBeAnInstanceOf(OptionsResolver::class);
         $options->getDefinedOptions()->shouldContain('object_support');
         $options->getDefinedOptions()->shouldContain('exception_on_invalid_type');
+        $options->getDefinedOptions()->shouldContain('parse_custom_tags');
+        $options->getDefinedOptions()->shouldContain('parse_constant');
     }
 
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
@@ -70,6 +72,8 @@ class YamlLintSpec extends AbstractLinterTaskSpec
         $linter->isInstalled()->willReturn(true);
         $linter->setObjectSupport(false)->shouldBeCalled();
         $linter->setExceptionOnInvalidType(false)->shouldBeCalled();
+        $linter->setParseCustomTags(false)->shouldBeCalled();
+        $linter->setParseConstants(false)->shouldBeCalled();
         $linter->lint(Argument::type('SplFileInfo'))->willReturn(new LintErrorsCollection());
 
         $context->getFiles()->willReturn(new FilesCollection([
@@ -86,6 +90,8 @@ class YamlLintSpec extends AbstractLinterTaskSpec
         $linter->isInstalled()->willReturn(true);
         $linter->setObjectSupport(false)->shouldBeCalled();
         $linter->setExceptionOnInvalidType(false)->shouldBeCalled();
+        $linter->setParseCustomTags(false)->shouldBeCalled();
+        $linter->setParseConstants(false)->shouldBeCalled();
         $linter->lint(Argument::type('SplFileInfo'))->willReturn(new LintErrorsCollection([
             new YamlLintError(LintError::TYPE_ERROR, 0, 'error', 'file.yaml', 1, 1)
         ]));

--- a/src/Linter/Yaml/YamlLinter.php
+++ b/src/Linter/Yaml/YamlLinter.php
@@ -108,12 +108,8 @@ class YamlLinter implements LinterInterface
         $flags = 0;
         $flags |= $this->objectSupport ? Yaml::PARSE_OBJECT : 0;
         $flags |= $this->exceptionOnInvalidType ? Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE : 0;
-
-        // Yaml::PARSE_CONSTANT is only available in Symfony Yaml >= 3.2
-        $flags |= $this->parseConstants && defined('Symfony\Component\Yaml\Yaml::PARSE_CONSTANT') ? Yaml::PARSE_CONSTANT : 0;
-
-        // Yaml::PARSE_CUSTOM_TAGS is only available in Symfony Yaml >= 3.3
-        $flags |= $this->parseCustomTags && defined('Symfony\Component\Yaml\Yaml::PARSE_CUSTOM_TAGS') ? Yaml::PARSE_CUSTOM_TAGS : 0;
+        $flags |= $this->parseConstants ? Yaml::PARSE_CONSTANT : 0;
+        $flags |= $this->parseCustomTags ? Yaml::PARSE_CUSTOM_TAGS : 0;
         Yaml::parse($content, $flags);
     }
 
@@ -146,7 +142,8 @@ class YamlLinter implements LinterInterface
      */
     public function setParseCustomTags($parseCustomTags)
     {
-        $this->parseCustomTags = $parseCustomTags;
+        // Yaml::PARSE_CONSTANT is only available in Symfony Yaml >= 3.2
+        $this->parseCustomTags = $parseCustomTags && defined('Symfony\Component\Yaml\Yaml::PARSE_CONSTANT');
     }
 
     /**
@@ -154,6 +151,7 @@ class YamlLinter implements LinterInterface
      */
     public function setParseConstants($parseConstants)
     {
-        $this->parseConstants = $parseConstants;
+        // Yaml::PARSE_CUSTOM_TAGS is only available in Symfony Yaml >= 3.3
+        $this->parseConstants = $parseConstants && defined('Symfony\Component\Yaml\Yaml::PARSE_CUSTOM_TAGS');
     }
 }

--- a/src/Linter/Yaml/YamlLinter.php
+++ b/src/Linter/Yaml/YamlLinter.php
@@ -27,6 +27,20 @@ class YamlLinter implements LinterInterface
     private $exceptionOnInvalidType = false;
 
     /**
+     * True if custom tags needs to be parsed
+     *
+     * @var bool
+     */
+    private $parseCustomTags = false;
+
+    /**
+     * True if PHP constants needs to be parsed
+     *
+     * @var bool
+     */
+    private $parseConstants = false;
+
+    /**
      * @var Filesystem
      */
     private $filesystem;
@@ -92,8 +106,14 @@ class YamlLinter implements LinterInterface
 
         // Lint on Symfony Yaml >= 3.1
         $flags = 0;
-        $flags += $this->objectSupport ? Yaml::PARSE_OBJECT : 0;
-        $flags += $this->exceptionOnInvalidType ? Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE : 0;
+        $flags |= $this->objectSupport ? Yaml::PARSE_OBJECT : 0;
+        $flags |= $this->exceptionOnInvalidType ? Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE : 0;
+
+        // Yaml::PARSE_CONSTANT is only available in Symfony Yaml >= 3.2
+        $flags |= $this->parseConstants && defined('Symfony\Component\Yaml\Yaml::PARSE_CONSTANT') ? Yaml::PARSE_CONSTANT : 0;
+
+        // Yaml::PARSE_CUSTOM_TAGS is only available in Symfony Yaml >= 3.3
+        $flags |= $this->parseCustomTags && defined('Symfony\Component\Yaml\Yaml::PARSE_CUSTOM_TAGS') ? Yaml::PARSE_CUSTOM_TAGS : 0;
         Yaml::parse($content, $flags);
     }
 
@@ -119,5 +139,21 @@ class YamlLinter implements LinterInterface
     public function setExceptionOnInvalidType($exceptionOnInvalidType)
     {
         $this->exceptionOnInvalidType = $exceptionOnInvalidType;
+    }
+
+    /**
+     * @param bool $parseCustomTags
+     */
+    public function setParseCustomTags($parseCustomTags)
+    {
+        $this->parseCustomTags = $parseCustomTags;
+    }
+
+    /**
+     * @param bool $parseConstants
+     */
+    public function setParseConstants($parseConstants)
+    {
+        $this->parseConstants = $parseConstants;
     }
 }

--- a/src/Task/YamlLint.php
+++ b/src/Task/YamlLint.php
@@ -31,10 +31,14 @@ class YamlLint extends AbstractLinterTask
         $resolver->setDefaults([
             'object_support' => false,
             'exception_on_invalid_type' => false,
+            'parse_constant' => false,
+            'parse_custom_tags' => false,
         ]);
 
         $resolver->addAllowedTypes('object_support', ['bool']);
         $resolver->addAllowedTypes('exception_on_invalid_type', ['bool']);
+        $resolver->addAllowedTypes('parse_constant', ['bool']);
+        $resolver->addAllowedTypes('parse_custom_tags', ['bool']);
 
         return $resolver;
     }
@@ -60,6 +64,8 @@ class YamlLint extends AbstractLinterTask
         $config = $this->getConfiguration();
         $this->linter->setObjectSupport($config['object_support']);
         $this->linter->setExceptionOnInvalidType($config['exception_on_invalid_type']);
+        $this->linter->setParseCustomTags($config['parse_custom_tags']);
+        $this->linter->setParseConstants($config['parse_constant']);
 
         try {
             $lintErrors = $this->lint($files);

--- a/test/Linter/Yaml/YamlLinterTest.php
+++ b/test/Linter/Yaml/YamlLinterTest.php
@@ -83,6 +83,64 @@ class YamlLinterTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    function it_should_handle_exceptions_on_constants()
+    {
+        if (!YamlLinter::supportsFlags()) {
+            $this->markTestSkipped('Parsing constants is not supported by the current version of symfony/yaml');
+        }
+
+        $this->linter->setExceptionOnInvalidType(true);
+        $fixture = 'constant-support.yml';
+        $this->validateFixture($fixture, 1);
+    }
+
+    /**
+     * @test
+     */
+    function it_should_validate_constants()
+    {
+        if (!YamlLinter::supportsFlags()) {
+            $this->markTestSkipped('Parsing constants is not supported by the current version of symfony/yaml');
+        }
+
+        $this->linter->setExceptionOnInvalidType(true);
+        $this->linter->setParseConstants(true);
+        $fixture = 'constant-support.yml';
+        $this->validateFixture($fixture, 0);
+    }
+
+    /**
+     * @test
+     */
+    function it_should_handle_exceptions_on_custom_tags()
+    {
+        if (!YamlLinter::supportsFlags()) {
+            $this->markTestSkipped('Parsing custom tags is not supported by the current version of symfony/yaml');
+        }
+
+        $this->linter->setExceptionOnInvalidType(true);
+        $fixture = 'tags-support.yml';
+        $this->validateFixture($fixture, 1);
+    }
+
+    /**
+     * @test
+     */
+    function it_should_validate_custom_tags()
+    {
+        if (!YamlLinter::supportsFlags()) {
+            $this->markTestSkipped('Parsing custom tags is not supported by the current version of symfony/yaml');
+        }
+
+        $this->linter->setExceptionOnInvalidType(true);
+        $this->linter->setParseCustomTags(true);
+        $fixture = 'tags-support.yml';
+        $this->validateFixture($fixture, 0);
+    }
+
+    /**
      * @return array
      */
     function provideYamlValidation()

--- a/test/fixtures/linters/yaml/constant-support.yml
+++ b/test/fixtures/linters/yaml/constant-support.yml
@@ -1,0 +1,1 @@
+foo: !php/const:PHP_EOL

--- a/test/fixtures/linters/yaml/tags-support.yml
+++ b/test/fixtures/linters/yaml/tags-support.yml
@@ -1,0 +1,1 @@
+foo: !my_tag {foo: bar}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | N/A

In Symfont 3.2 and 3.3, the Yaml component added support for PHP constants and custom tags.
Currently when using constants or custom tags in a Yaml file, the yamllint task fails because the syntax is invalid (and the necessary flags is not passed through).

This PR adds 2 new options to the yamllint task: `parse_constant` & `parse_custom_tags`. These options default to false to keep current behaviour. If they are set to `true`, then the required flags is passed through to the Yaml::parse method so that the task doesn't fail.