### PR TITLE
Fix deprecated ProcessBuilder

### DIFF
--- a/src/Composer/DevelopmentIntegrator.php
+++ b/src/Composer/DevelopmentIntegrator.php
@@ -4,7 +4,7 @@ namespace GrumPHP\Composer;
 
 use Composer\Script\Event;
 use GrumPHP\Util\Filesystem;
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 
 class DevelopmentIntegrator
 {
@@ -23,7 +23,7 @@ class DevelopmentIntegrator
             self::noramlizePath($composerExecutable)
         );
 
-        $process = ProcessBuilder::create([$composerExecutable, 'git:init'])->getProcess();
+        $process = new Process($composerExecutable.' git:init');
         $process->run();
         if (!$process->isSuccessful()) {
             $event->getIO()->write(

--- a/src/Composer/GrumPHPPlugin.php
+++ b/src/Composer/GrumPHPPlugin.php
@@ -19,7 +19,7 @@ use GrumPHP\Console\Command\Git\DeInitCommand;
 use GrumPHP\Console\Command\Git\InitCommand;
 use GrumPHP\Locator\ExternalCommand;
 use Symfony\Component\Process\ExecutableFinder;
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 
 class GrumPHPPlugin implements PluginInterface, EventSubscriberInterface
 {
@@ -178,8 +178,7 @@ class GrumPHPPlugin implements PluginInterface, EventSubscriberInterface
         $commandLocator = new ExternalCommand($config->get('bin-dir'), new ExecutableFinder());
         $executable = $commandLocator->locate('grumphp');
 
-        $builder = new ProcessBuilder([$executable, $command, '--no-interaction']);
-        $process = $builder->getProcess();
+        $process = new Process($executable.' '.$command.' --no-interaction');
 
         // Check executable which is running:
         if ($this->io->isVeryVerbose()) {


### PR DESCRIPTION
I have trouble using grumphp with Laravel 5.5 (related issue https://github.com/laravel/framework/issues/20995#issuecomment-327647935).

The problem seems the usage of deprecated method to exec process, instead using `ProcessBuilder` I used  directly `new Process` and this fix the issue.
