### PR TITLE
Fix: changing visibility of grumphp.logger service/alias to public

### DIFF
--- a/resources/config/services.yml
+++ b/resources/config/services.yml
@@ -90,6 +90,7 @@ services:
         arguments:
           - 'GrumPHP'
           - ['@grumphp.logger.handler.nullhandler']
+        public: true
 
     grumphp.logger.handler.nullhandler:
         class: Monolog\Handler\NullHandler


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | n/a
| Fixed tickets | n/a

When you install a fresh copy of grumphp into a symfony 4 app, and run grumphp run with super verbosity (-vvv) you'll get the next error:
`[Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]
  The "grumphp.logger" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using t
  he container directly and use dependency injection instead.`