### PR TITLE
Use GrumPHP ProcessUtils over Symfonys, fixes Formatter not working w…

### DIFF
--- a/spec/Formatter/PhpCsFixerFormatterSpec.php
+++ b/spec/Formatter/PhpCsFixerFormatterSpec.php
@@ -6,7 +6,7 @@ use GrumPHP\Formatter\PhpCsFixerFormatter;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessUtils;
+use GrumPHP\Process\ProcessUtils;
 
 class PhpCsFixerFormatterSpec extends ObjectBehavior
 {

--- a/spec/Process/ProcessBuilderSpec.php
+++ b/spec/Process/ProcessBuilderSpec.php
@@ -10,7 +10,7 @@ use GrumPHP\Process\ProcessBuilder;
 use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessUtils;
+use GrumPHP\Process\ProcessUtils;
 
 class ProcessBuilderSpec extends ObjectBehavior
 {

--- a/src/Formatter/PhpCsFixerFormatter.php
+++ b/src/Formatter/PhpCsFixerFormatter.php
@@ -3,7 +3,7 @@
 namespace GrumPHP\Formatter;
 
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessUtils;
+use GrumPHP\Process\ProcessUtils;
 
 class PhpCsFixerFormatter implements ProcessFormatterInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | n/a

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
Fixes incompatibility with Symfony 4.x Process component when using php-cs-fixer