### PR TITLE
Ignore symlinks when registering files.

### DIFF
--- a/src/Locator/RegisteredFiles.php
+++ b/src/Locator/RegisteredFiles.php
@@ -31,9 +31,8 @@ class RegisteredFiles
 
         $files = [];
         foreach ($filePaths as $file) {
-            $fileInfo = new SplFileInfo($file, dirname($file), $file);
-
-            if (! $fileInfo->isLink()) {
+            $fileInfo = new SplFileInfo($file, \dirname($file), $file);
+            if (!$fileInfo->isLink()) {
                 $files[] = $fileInfo;
             }
         }

--- a/src/Locator/RegisteredFiles.php
+++ b/src/Locator/RegisteredFiles.php
@@ -31,7 +31,11 @@ class RegisteredFiles
 
         $files = [];
         foreach ($filePaths as $file) {
-            $files[] = new SplFileInfo($file, dirname($file), $file);
+            $fileInfo = new SplFileInfo($file, dirname($file), $file);
+
+            if (! $fileInfo->isLink()) {
+                $files[] = $fileInfo;
+            }
         }
 
         return new FilesCollection($files);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | yes| BC breaks?    | yes/no
| Deprecations? | /no
| Documented?   | no
| Fixed tickets | n/a

While using the **file_size** task i got this unexpected message:
```
Large files detected:
- images exceeded the maximum size of 10M.
```
"images" is a symlink to my assets:
`lrwxrwxrwx 1 user user   17 Jan 24 08:45 images -> ../assets/images/`
The task **file_size** does not complain about the directory "assets/images" but about the symlink "images".

It makes no sense to add files which are symlinks to the collection of registered files because we do not need to check the files twice, they will be tested on their real location.