### PR TITLE
Added severity levels to phpcs task

### DIFF
--- a/doc/tasks/phpcs.md
+++ b/doc/tasks/phpcs.md
@@ -12,15 +12,15 @@ composer require --dev squizlabs/php_codesniffer
 
 The task lives under the `phpcs` namespace and has following configurable parameters:
 
-sebastian/phpcpd
-
 ```yaml
 # grumphp.yml
 parameters:
     tasks:
         phpcs:
             standard: ~
-            show_warnings: true
+            severity: ~
+            error_severity: ~
+            warning_severity: ~
             tab_width: ~
             whitelist_patterns: []
             encoding: ~
@@ -46,13 +46,23 @@ You can get a list of all installed phpcs standards with the command:
 phpcs -i
 ```
 
+**severity**
 
-**show_warnings**
+*Default: null*
 
-*Default: true*
+Global severity level that should be used by `phpcs` (default is 5).
 
-Triggers an error when there are warnings.
+**error_severity**
 
+*Default: null*
+
+Error severity that should be used by `phpcs` (default is 5).
+
+**warning_severity**
+
+*Default: null*
+
+Warning severity that should be used by `phpcs` (default is 5).
 
 **tab_width**
 

--- a/spec/Task/PhpcsSpec.php
+++ b/spec/Task/PhpcsSpec.php
@@ -41,7 +41,9 @@ class PhpcsSpec extends ObjectBehavior
         $options = $this->getConfigurableOptions();
         $options->shouldBeAnInstanceOf(OptionsResolver::class);
         $options->getDefinedOptions()->shouldContain('standard');
-        $options->getDefinedOptions()->shouldContain('show_warnings');
+        $options->getDefinedOptions()->shouldContain('severity');
+        $options->getDefinedOptions()->shouldContain('error_severity');
+        $options->getDefinedOptions()->shouldContain('warning_severity');
         $options->getDefinedOptions()->shouldContain('tab_width');
         $options->getDefinedOptions()->shouldContain('encoding');
         $options->getDefinedOptions()->shouldContain('whitelist_patterns');

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -33,22 +33,26 @@ class Phpcs extends AbstractExternalTask
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
             'standard' => null,
-            'show_warnings' => true,
             'tab_width' => null,
             'encoding' => null,
             'whitelist_patterns' => [],
             'ignore_patterns' => [],
             'sniffs' => [],
+            'severity' => null,
+            'error_severity' => null,
+            'warning_severity' => null,
             'triggered_by' => ['php']
         ]);
 
         $resolver->addAllowedTypes('standard', ['null', 'string']);
-        $resolver->addAllowedTypes('show_warnings', ['bool']);
         $resolver->addAllowedTypes('tab_width', ['null', 'int']);
         $resolver->addAllowedTypes('encoding', ['null', 'string']);
         $resolver->addAllowedTypes('whitelist_patterns', ['array']);
         $resolver->addAllowedTypes('ignore_patterns', ['array']);
         $resolver->addAllowedTypes('sniffs', ['array']);
+        $resolver->addAllowedTypes('severity', ['null', 'int']);
+        $resolver->addAllowedTypes('error_severity', ['null', 'int']);
+        $resolver->addAllowedTypes('warning_severity', ['null', 'int']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
@@ -111,17 +115,22 @@ class Phpcs extends AbstractExternalTask
 
     /**
      * @param ProcessArgumentsCollection $arguments
+     *
      * @param array $config
+     *
      * @return ProcessArgumentsCollection
      */
     protected function addArgumentsFromConfig(ProcessArgumentsCollection $arguments, array $config)
     {
         $arguments->addOptionalArgument('--standard=%s', $config['standard']);
-        $arguments->addOptionalArgument('--warning-severity=0', !$config['show_warnings']);
         $arguments->addOptionalArgument('--tab-width=%s', $config['tab_width']);
         $arguments->addOptionalArgument('--encoding=%s', $config['encoding']);
+        $arguments->addOptionalArgument('--severity=%s', $config['severity']);
+        $arguments->addOptionalArgument('--error-severity=%s', $config['error_severity']);
+        $arguments->addOptionalArgument('--warning-severity=%s', $config['warning_severity']);
         $arguments->addOptionalCommaSeparatedArgument('--sniffs=%s', $config['sniffs']);
         $arguments->addOptionalCommaSeparatedArgument('--ignore=%s', $config['ignore_patterns']);
+
         return $arguments;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes (show_warnings option is deprecated)
| Documented?   | yes
| Fixed tickets | #449

Added the ability to pass error severities, show_warnings option is deprecated since it was using the task parameter --warning-severity.
