### PR TITLE
Add a key 'public: true' for the service 'subscriber.stash_unstaged_c…

### DIFF
--- a/resources/config/subscribers.yml
+++ b/resources/config/subscribers.yml
@@ -7,3 +7,5 @@ services:
       - '@grumphp.io'
     tags:
       - { name: grumphp.event_subscriber }
+    public: true
+


### PR DESCRIPTION
I've added a key 'public: true' for the service 'subscriber.stash_unstaged_changes' because we have a problem with symphony DI vendor of 4.0 version

There is the message about an error that i've got when i updated my symphony DI to 4.0 version:
The "subscriber.stash_unstaged_changes" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.

But it looks like this service is never used maybe a better way is to remove it from the config...

| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no