### PR TITLE
Fix not found error in Windows

### DIFF
--- a/resources/hooks/local/pre-commit
+++ b/resources/hooks/local/pre-commit
@@ -9,4 +9,4 @@
 DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
 
 # Run GrumPHP
-(cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | exec $(HOOK_COMMAND) '--skip-success-output')
+(cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | exec "$(HOOK_COMMAND)" '--skip-success-output')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

without this fix on Windows 10 Pro (Powershell) the pre-commit hook fails with error:
.git/hooks/pre-commit: line 12: exec: C:UsersDellwwwelevationvendorbingrumphp: not found
