### PR TITLE
Add support for custom location of .git directory

### DIFF
--- a/src/Console/Helper/PathsHelper.php
+++ b/src/Console/Helper/PathsHelper.php
@@ -163,10 +163,10 @@ class PathsHelper extends Helper
      */
     public function getGitHooksDir()
     {
-        $gitPath         = $this->getGitDir();
+        $gitPath = $this->getGitDir();
         $absoluteGitPath = $this->getAbsolutePath($gitPath);
-
         $gitRepoPath = $absoluteGitPath . '/.git';
+
         if (is_file($gitRepoPath)) {
             $fileContent = $this->fileSystem->readFromFileInfo(new SplFileInfo($gitRepoPath));
             if (preg_match('/gitdir:\s+(\S+)/', $fileContent, $matches)) {

--- a/src/Console/Helper/PathsHelper.php
+++ b/src/Console/Helper/PathsHelper.php
@@ -163,7 +163,18 @@ class PathsHelper extends Helper
      */
     public function getGitHooksDir()
     {
-        return $this->getGitDir() . '.git/hooks/';
+        $gitPath         = $this->getGitDir();
+        $absoluteGitPath = $this->getAbsolutePath($gitPath);
+
+        $gitRepoPath = $absoluteGitPath . '/.git';
+        if (is_file($gitRepoPath)) {
+            $fileContent = $this->fileSystem->readFromFileInfo(new SplFileInfo($gitRepoPath));
+            if (preg_match('/gitdir:\s+(\S+)/', $fileContent, $matches)) {
+                return $this->getRelativePath($gitPath . $matches[1] . '/hooks/');
+            }
+        }
+
+        return $gitPath . '.git/hooks/';
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | -

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

git supports using a custom path for the `.git` directory. When used, `.git` is a file containing `gitdir: <path>` to point at the real directory.

Currently grumphp does not support this, because the path used to install the git hooks is incorrect (there obviously can't be a `.git/hooks` in this case). This also can't be worked around with the config param `git-dir` (which by the way is badly named) because the path used will always end with `.git/hooks`, but the custom directory may be named differently (not `.git`).

This PR adds support for custom repository paths by reading `.git` if it's a file and using the path contained.