### PR TITLE
Add ignore_parse_errors option to ComposerRequireChecker

### DIFF
--- a/doc/tasks/composer_require_checker.md
+++ b/doc/tasks/composer_require_checker.md
@@ -17,6 +17,7 @@ parameters:
         composer_require_checker:
             composer_file: 'composer.json'
             config_file: ~
+            ignore_parse_errors: false
             triggered_by: ['composer.json', 'composer.lock', '*.php']
 ```
 
@@ -32,6 +33,14 @@ The composer.json of your code base that should be checked.
 
 Composer Require Checker is configured to whitelist some symbols by default. You can now override this configuration
 with your own and tell GrumPHP to use that configuration file instead.
+
+**ignore_parse_errors**
+
+*Default: false*
+
+This will cause Composer Require Checker to ignore errors when files cannot be parsed, otherwise errors will be thrown.
+
+This option is only available in version 0.2.0 of `maglnet/composer-require-checker` and above.
 
 **triggered_by**
 

--- a/spec/Task/ComposerRequireCheckerSpec.php
+++ b/spec/Task/ComposerRequireCheckerSpec.php
@@ -42,6 +42,7 @@ class ComposerRequireCheckerSpec extends ObjectBehavior
         $options->shouldBeAnInstanceOf(OptionsResolver::class);
         $options->getDefinedOptions()->shouldContain('composer_file');
         $options->getDefinedOptions()->shouldContain('config_file');
+        $options->getDefinedOptions()->shouldContain('ignore_parse_errors');
         $options->getDefinedOptions()->shouldContain('triggered_by');
     }
 

--- a/src/Task/ComposerRequireChecker.php
+++ b/src/Task/ComposerRequireChecker.php
@@ -30,11 +30,13 @@ class ComposerRequireChecker extends AbstractExternalTask
         $resolver->setDefaults([
             'composer_file' => 'composer.json',
             'config_file' => null,
+            'ignore_parse_errors' => false,
             'triggered_by' => ['composer.json', 'composer.lock', '*.php'],
         ]);
 
         $resolver->addAllowedTypes('composer_file', ['string']);
         $resolver->addAllowedTypes('config_file', ['null', 'string']);
+        $resolver->addAllowedTypes('ignore_parse_errors', ['boolean']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
@@ -64,6 +66,7 @@ class ComposerRequireChecker extends AbstractExternalTask
 
         $arguments->add('check');
         $arguments->addOptionalArgument('--config-file=%s', $config['config_file']);
+        $arguments->addOptionalArgument('--ignore-parse-errors', $config['ignore_parse_errors']);
         $arguments->add('--no-interaction');
         $arguments->add($config['composer_file']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | -

This adds an option to enable `--ignore-parse-errors`, which is available in ComposerRequireChecker since 0.2.0.

One thing to note is that ~the world will crash and burn~ ComposerRequireChecker will throw a hissy fit if you have <0.2.0 installed and enable this. I think pointing this out in the docs should be good enough since the option is opt-in. We could always go down the route of version detection, but `composer-require-checker --version` identifies itself as `0.1.1-dev` on 0.2.0 :(
