### PR TITLE
Use correct path to .git/COMMIT_EDITMSG when using non-standard .git dir location

### DIFF
--- a/src/Console/Command/Git/CommitMsgCommand.php
+++ b/src/Console/Command/Git/CommitMsgCommand.php
@@ -78,6 +78,11 @@ class CommitMsgCommand extends Command
         $gitUser = $input->getOption('git-user');
         $gitEmail = $input->getOption('git-email');
         $commitMsgPath = $input->getArgument('commit-msg-file');
+
+        if (!$this->filesystem->isAbsolutePath($commitMsgPath)) {
+            $commitMsgPath = $this->paths()->getGitDir() . $commitMsgPath;
+        }
+
         $commitMsgFile = new SplFileInfo($commitMsgPath);
         $commitMsg = $this->filesystem->readFromFileInfo($commitMsgFile);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | -

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
When grumphp is used with a `.git` dir in a non-standard location the `commit-msg` hook may look for the `.git/COMMIT_EDITMSG` file in the wrong location.

This PR prefixes the path with `git_dir` configured in `grumphp.yml` if it's a relative path, so the correct path is used in all cases.

Note: The path supplied to the hook by git may be absolute. In this case there is no need to fix it. This happens when grumphp is used inside a git submodule.