### PR TITLE
[FIX] Windows path issue

### DIFF
--- a/spec/Process/ProcessUtilsSpec.php
+++ b/spec/Process/ProcessUtilsSpec.php
@@ -3,6 +3,7 @@
 namespace spec\GrumPHP\Process;
 
 use GrumPHP\Process\ProcessUtils;
+use GrumPHP\Util\Platform;
 use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
 
@@ -15,7 +16,7 @@ class ProcessUtilsSpec extends ObjectBehavior
 
     function it_escapes_arguments_on_windows_platform()
     {
-        if ('\\' !== DIRECTORY_SEPARATOR) {
+        if (('\\' !== DIRECTORY_SEPARATOR) || Platform::isWindows() === false) {
             throw new SkippingException('Test requires a Windows platform.');
         }
 
@@ -29,6 +30,7 @@ class ProcessUtilsSpec extends ObjectBehavior
         self::escapeArgument('a^b c!')->shouldReturn('"a"^^"b c"^!""');
         self::escapeArgument("a!b\tc")->shouldReturn("\"a\"^!\"b\tc\"");
         self::escapeArgument('a\\\\"\\"')->shouldReturn('"a\\\\""\"""');
+        self::escapeArgument("c:\users\phpro\grumphp")->shouldReturn("'c:\users\phpro\grumphp'");
     }
 
     function it_escapes_arguments_on_other_platforms()

--- a/src/Process/ProcessUtils.php
+++ b/src/Process/ProcessUtils.php
@@ -2,6 +2,8 @@
 
 namespace GrumPHP\Process;
 
+use GrumPHP\Util\Platform;
+
 /**
  * ProcessUtils is a bunch of utility methods.
  *
@@ -30,7 +32,7 @@ final class ProcessUtils
      */
     public static function escapeArgument($argument)
     {
-        if ('\\' !== DIRECTORY_SEPARATOR) {
+        if ('\\' !== DIRECTORY_SEPARATOR || Platform::isWindows()) {
             return "'".str_replace("'", "'\\''", $argument)."'";
         }
         if ('' === $argument = (string) $argument) {
@@ -43,6 +45,7 @@ final class ProcessUtils
             return $argument;
         }
         $argument = preg_replace('/(\\\\+)$/', '$1$1', $argument);
+
         return '"'.str_replace(['"', '^', '%', '!', "\n"], ['""', '"^^"', '"^%"', '"^!"', '!LF!'], $argument).'"';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | n/a
| Fixed tickets | #447

The path to the executable wasn't quoted by escapeArgument, it will be quoted now if the  hook is generated on a Windows platform.

Hope this fixes the problem (worked on my old-student-laptop)

#AKebabADayKeepsTheBugsAway /ping @veewee 