### PR TITLE
Force git hooks to contain unix styled commands

### DIFF
--- a/spec/Process/ProcessBuilderSpec.php
+++ b/spec/Process/ProcessBuilderSpec.php
@@ -27,9 +27,19 @@ class ProcessBuilderSpec extends ObjectBehavior
 
     function it_should_be_able_to_create_process_arguments_based_on_taskname(ExternalCommand $externalCommandLocator)
     {
-        $externalCommandLocator->locate('grumphp')->willReturn('/usr/bin/grumphp');
+        $externalCommandLocator->locate('grumphp', false)->willReturn('/usr/bin/grumphp');
 
-        $arguments = $this->createArgumentsForCommand('grumphp');
+        $arguments = $this->createArgumentsForCommand('grumphp', false);
+        $arguments->shouldHaveType(ProcessArgumentsCollection::class);
+        $arguments[0]->shouldBe('/usr/bin/grumphp');
+        $arguments->count()->shouldBe(1);
+    }
+
+    function it_should_be_able_to_create_process_arguments_based_on_taskname_and_force_unix_path(ExternalCommand $externalCommandLocator)
+    {
+        $externalCommandLocator->locate('grumphp', true)->willReturn('/usr/bin/grumphp');
+
+        $arguments = $this->createArgumentsForCommand('grumphp', true);
         $arguments->shouldHaveType(ProcessArgumentsCollection::class);
         $arguments[0]->shouldBe('/usr/bin/grumphp');
         $arguments->count()->shouldBe(1);

--- a/src/Console/Command/Git/InitCommand.php
+++ b/src/Console/Command/Git/InitCommand.php
@@ -141,7 +141,7 @@ class InitCommand extends Command
     {
         $configFile = $this->useExoticConfigFile();
 
-        $arguments = $this->processBuilder->createArgumentsForCommand('grumphp');
+        $arguments = $this->processBuilder->createArgumentsForCommand('grumphp', true);
         $arguments->add($command);
         $arguments->addOptionalArgument('--config=%s', $configFile);
 

--- a/src/Process/ProcessBuilder.php
+++ b/src/Process/ProcessBuilder.php
@@ -42,8 +42,8 @@ class ProcessBuilder
 
     /**
      * @param string $command
-     *
      * @param bool $forceUnix
+     *
      * @return ProcessArgumentsCollection
      */
     public function createArgumentsForCommand($command, $forceUnix = false)

--- a/src/Process/ProcessBuilder.php
+++ b/src/Process/ProcessBuilder.php
@@ -43,11 +43,12 @@ class ProcessBuilder
     /**
      * @param string $command
      *
+     * @param bool $forceUnix
      * @return ProcessArgumentsCollection
      */
-    public function createArgumentsForCommand($command)
+    public function createArgumentsForCommand($command, $forceUnix = false)
     {
-        $executable = $this->getCommandLocation($command);
+        $executable = $this->externalCommandLocator->locate($command, $forceUnix);
 
         return ProcessArgumentsCollection::forExecutable($executable);
     }
@@ -85,16 +86,6 @@ class ProcessBuilder
         }
 
         throw PlatformException::commandLineStringLimit($process);
-    }
-
-    /**
-     * @param string $command
-     *
-     * @return string
-     */
-    private function getCommandLocation($command)
-    {
-        return $this->externalCommandLocator->locate($command);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #458, #462, #447

This bug was introduced in version 0.13 : before we used to force the git hook command to be unix styled. 

(reference: https://github.com/phpro/grumphp/commit/415fd1a9c70f5905326f0651ac5009a70d42441e#diff-aed6b638f2d7de8614c3516d7939c1a0L135 )
