### PR TITLE
Remove Warning for array_key_exists

### DIFF
--- a/src/Configuration/Compiler/TaskCompilerPass.php
+++ b/src/Configuration/Compiler/TaskCompilerPass.php
@@ -34,7 +34,7 @@ class TaskCompilerPass implements CompilerPassInterface
             }
 
             $tasksRegistered[] = $configKey;
-            if (!array_key_exists($configKey, $configuration)) {
+            if (!array_key_exists($configKey, $configuration?:[])) {
                 continue;
             }
 

--- a/src/Configuration/Compiler/TaskCompilerPass.php
+++ b/src/Configuration/Compiler/TaskCompilerPass.php
@@ -19,7 +19,7 @@ class TaskCompilerPass implements CompilerPassInterface
     {
         $definition = $container->findDefinition('task_runner');
         $taggedServices = $container->findTaggedServiceIds(self::TAG_GRUMPHP_TASK);
-        $configuration = $container->getParameter('tasks');
+        $configuration = $container->getParameter('tasks') ?: [];
 
         $tasksRegistered = [];
         $tasksMetadata = [];
@@ -34,7 +34,7 @@ class TaskCompilerPass implements CompilerPassInterface
             }
 
             $tasksRegistered[] = $configKey;
-            if (!array_key_exists($configKey, $configuration?:[])) {
+            if (!array_key_exists($configKey, $configuration)) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master, 0.13.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | -


On install of grumphp without an grumphp.yml file I get this Warning:
Warning: array_key_exists() expects parameter 2 to be array, null given in /var/www/secure_login/vendor/phpro/grumphp/src/Configuration/Compiler/TaskCompilerPass.php on line 37

Wit my Proposed Changes this warning will be removed.