### PR TITLE
Changed phpcsfixer2 default options

### DIFF
--- a/doc/tasks/phpcsfixer2.md
+++ b/doc/tasks/phpcsfixer2.md
@@ -17,11 +17,11 @@ The task lives under the `phpcsfixer2` namespace and has following configurable 
 parameters:
     tasks:
         phpcsfixer2:
-            allow_risky: false
+            allow_risky: ~
             cache_file: ~
             config: ~
             rules: []
-            using_cache: true
+            using_cache: ~
             config_contains_finder: true
             verbose: true
             diff: false
@@ -31,12 +31,11 @@ parameters:
 
 **allow_risky**
 
-*Default: false*
+*Default: null*
 
-The allow_risky option allows you to set whether riskys fixer may run.
-Risky fixer is a fixer, which could change code behaviour.
-By default no risky fixers are run.
-
+The allow_risky option allows you to set whether risky rules may run.
+Risky rule is a rule, which could change code behaviour.
+If not set, the default value is taken from config file (if it exists). By default no risky rules are run.
 
 **cache_file**
 
@@ -89,9 +88,10 @@ is incorrect.
 
 **using_cache**
 
-*Default: true*
+*Default: null*
 
-The caching mechanism is enabled by default.
+By using using_cache option you can set if the caching mechanism should be used.
+If not set, the default value is taken from config file (if it exists). The caching mechanism is enabled by default.
 This will speed up further runs by fixing only files that were modified since the last run.
 The tool will fix all files if the tool version has changed or the list of fixers has changed.
 Cache is supported only for tool downloaded as phar file or installed via composer.

--- a/spec/Collection/ProcessArgumentsCollectionSpec.php
+++ b/spec/Collection/ProcessArgumentsCollectionSpec.php
@@ -122,4 +122,22 @@ class ProcessArgumentsCollectionSpec extends ObjectBehavior
 
         $this->getValues()->shouldBe(['--argument=file1.txt,file2.txt']);
     }
+
+    function it_should_be_able_to_add_boolean_nullable_argument_with_null_value()
+    {
+        $this->addOptionalBooleanArgument('--argument=%s', null, 'yes', 'no');
+        $this->getValues()->shouldBe([]);
+    }
+
+    function it_should_be_able_to_add_boolean_nullable_argument_with_true_value()
+    {
+        $this->addOptionalBooleanArgument('--argument=%s', true, 'yes', 'no');
+        $this->getValues()->shouldBe(['--argument=yes']);
+    }
+
+    function it_should_be_able_to_add_boolean_nullable_argument_with_false_value()
+    {
+        $this->addOptionalBooleanArgument('--argument=%s', false, 'yes', 'no');
+        $this->getValues()->shouldBe(['--argument=no']);
+    }
 }

--- a/src/Collection/ProcessArgumentsCollection.php
+++ b/src/Collection/ProcessArgumentsCollection.php
@@ -150,4 +150,19 @@ class ProcessArgumentsCollection extends ArrayCollection
 
         $this->add(sprintf($argument, implode(',', $paths)));
     }
+
+    /**
+     * @param string      $argument
+     * @param string|null $value
+     * @param string      $trueFormat
+     * @param string      $falseFormat
+     */
+    public function addOptionalBooleanArgument($argument, $value, $trueFormat, $falseFormat)
+    {
+        if (null === $value) {
+            return;
+        }
+
+        $this->add(sprintf($argument, $value ? $trueFormat : $falseFormat));
+    }
 }

--- a/src/Task/PhpCsFixerV2.php
+++ b/src/Task/PhpCsFixerV2.php
@@ -28,22 +28,22 @@ class PhpCsFixerV2 extends AbstractExternalTask
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
-            'allow_risky' => false,
+            'allow_risky' => null,
             'cache_file' => null,
             'config' => null,
             'rules' => [],
-            'using_cache' => true,
+            'using_cache' => null,
             'config_contains_finder' => true,
             'verbose' => true,
             'diff' => false,
             'triggered_by' => ['php'],
         ]);
 
-        $resolver->addAllowedTypes('allow_risky', ['bool']);
+        $resolver->addAllowedTypes('allow_risky', ['null', 'bool']);
         $resolver->addAllowedTypes('cache_file', ['null', 'string']);
         $resolver->addAllowedTypes('config', ['null', 'string']);
         $resolver->addAllowedTypes('rules', ['array']);
-        $resolver->addAllowedTypes('using_cache', ['bool']);
+        $resolver->addAllowedTypes('using_cache', ['null', 'bool']);
         $resolver->addAllowedTypes('config_contains_finder', ['bool']);
         $resolver->addAllowedTypes('verbose', ['bool']);
         $resolver->addAllowedTypes('diff', ['bool']);
@@ -76,7 +76,7 @@ class PhpCsFixerV2 extends AbstractExternalTask
         $arguments = $this->processBuilder->createArgumentsForCommand('php-cs-fixer');
         $arguments->add('--format=json');
         $arguments->add('--dry-run');
-        $arguments->addOptionalArgument('--allow-risky=%s', $config['allow_risky'] ? 'yes' : 'no');
+        $arguments->addOptionalBooleanArgument('--allow-risky=%s', $config['allow_risky'], 'yes', 'no');
         $arguments->addOptionalArgument('--cache-file=%s', $config['cache_file']);
         $arguments->addOptionalArgument('--config=%s', $config['config']);
 
@@ -90,7 +90,7 @@ class PhpCsFixerV2 extends AbstractExternalTask
 
         $canUseIntersection = !($context instanceof RunContext) && $config['config_contains_finder'];
 
-        $arguments->addOptionalArgument('--using-cache=%s', $config['using_cache'] ? 'yes' : 'no');
+        $arguments->addOptionalBooleanArgument('--using-cache=%s', $config['using_cache'], 'yes', 'no');
         $arguments->addOptionalArgument('--path-mode=intersection', $canUseIntersection);
         $arguments->addOptionalArgument('--verbose', $config['verbose']);
         $arguments->addOptionalArgument('--diff', $config['diff']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #469

Existed non-null default values of "allow_risky" and "using_cache" options were overriding the values from .php_cs config.

The current behavior is that if these options are not specified, the values will be taken from the .php_cs config.