### PR TITLE
Made "git diff" behave more predictably

### DIFF
--- a/resources/hooks/local/commit-msg
+++ b/resources/hooks/local/commit-msg
@@ -10,7 +10,7 @@ GIT_EMAIL=$(git config user.email)
 COMMIT_MSG_FILE=$1
 
 # Fetch the GIT diff and format it as command input:
-DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
+DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged | cat)
 
 # Run GrumPHP
 (cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | exec $(HOOK_COMMAND) "--git-user=$GIT_USER" "--git-email=$GIT_EMAIL" "$COMMIT_MSG_FILE")

--- a/resources/hooks/local/pre-commit
+++ b/resources/hooks/local/pre-commit
@@ -6,7 +6,7 @@
 #
 
 # Fetch the GIT diff and format it as command input:
-DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
+DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged | cat)
 
 # Run GrumPHP
 (cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | exec $(HOOK_COMMAND) '--skip-success-output')

--- a/resources/hooks/vagrant/commit-msg
+++ b/resources/hooks/vagrant/commit-msg
@@ -13,7 +13,7 @@ COMMIT_MSG_FILE=$1
 COMMIT_MSG=$(cat "${COMMIT_MSG_FILE}")
 
 # Fetch the GIT diff and format it as command input:
-DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
+DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged | cat)
 
 # Copy the commit message and run GrumPHP
 vagrant ssh --command '$(which sh)' << COMMANDS

--- a/resources/hooks/vagrant/pre-commit
+++ b/resources/hooks/vagrant/pre-commit
@@ -6,7 +6,7 @@
 #
 
 # Fetch the GIT diff and format it as command input:
-DIFF=$(git diff -r -p -m -M --full-index --staged | cat)
+DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged | cat)
 
 # Run GrumPHP
 vagrant ssh --command '$(which sh)' << COMMANDS


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #164

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
If anyone has git settings like `color.ui=always` or `diff.mnemonicprefix=true` (and maybe using a pager) this may break diff output like we see in #164. In order to not make users change their git settings I propose this PR that standardizes git settings to some extent upon starting `git diff`.
