### PR TITLE
Changed phpcpd "names_exclude" option

### DIFF
--- a/src/Task/PhpCpd.php
+++ b/src/Task/PhpCpd.php
@@ -74,7 +74,7 @@ class PhpCpd extends AbstractExternalTask
         }, $config['triggered_by']);
 
         $arguments->addArgumentArray('--exclude=%s', $config['exclude']);
-        $arguments->addArgumentArray('--names-exclude=%s', $config['names_exclude']);
+        $arguments->addOptionalCommaSeparatedArgument('--names-exclude=%s', $config['names_exclude']);
         $arguments->addRequiredArgument('--min-lines=%u', $config['min_lines']);
         $arguments->addRequiredArgument('--min-tokens=%u', $config['min_tokens']);
         $arguments->addOptionalCommaSeparatedArgument('--names=%s', $extensions);


### PR DESCRIPTION
Previous formatting of the option did not match the "phpcpd" interface.

| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #475

Changed `phpcpd` "names_exclude" option formatting so that it matches the `phpcpd` interface.