### PR TITLE
Add phpcpd "paths_exclude" option

### DIFF
--- a/doc/tasks/phpcpd.md
+++ b/doc/tasks/phpcpd.md
@@ -20,6 +20,7 @@ parameters:
             directory: '.'
             exclude: ['vendor']
             names_exclude: []
+            paths_exclude: []
             fuzzy: false
             min_lines: 5
             min_tokens: 70
@@ -42,7 +43,18 @@ With this parameter you will be able to exclude one or multiple directories from
 
 *Default: []*
 
-With this parameter you will be able to exclude one or multiple files from code analysis (must be relative to `directory`).
+With this parameter you will be able to exclude one or multiple files from code analysis.
+The values of this option refer to the file names, not to the paths.
+
+You can use a regexp, a glob, or a string.
+
+**paths_exclude**
+
+*Default: []*
+
+With this parameter you will be able to exclude one or multiple files from code analysis.
+
+You can use patterns (delimited with / sign) or simple strings.
 
 **fuzzy**
 

--- a/doc/tasks/phpcpd.md
+++ b/doc/tasks/phpcpd.md
@@ -20,7 +20,7 @@ parameters:
             directory: '.'
             exclude: ['vendor']
             names_exclude: []
-            paths_exclude: []
+            regexps_exclude: []
             fuzzy: false
             min_lines: 5
             min_tokens: 70
@@ -48,7 +48,7 @@ The values of this option refer to the file names, not to the paths.
 
 You can use a regexp, a glob, or a string.
 
-**paths_exclude**
+**regexps_exclude**
 
 *Default: []*
 

--- a/spec/Task/PhpCpdSpec.php
+++ b/spec/Task/PhpCpdSpec.php
@@ -44,6 +44,7 @@ class PhpCpdSpec extends ObjectBehavior
         $options->getDefinedOptions()->shouldContain('directory');
         $options->getDefinedOptions()->shouldContain('exclude');
         $options->getDefinedOptions()->shouldContain('names_exclude');
+        $options->getDefinedOptions()->shouldContain('paths_exclude');
         $options->getDefinedOptions()->shouldContain('fuzzy');
         $options->getDefinedOptions()->shouldContain('min_lines');
         $options->getDefinedOptions()->shouldContain('min_tokens');
@@ -107,7 +108,7 @@ class PhpCpdSpec extends ObjectBehavior
         $result->isPassed()->shouldBe(false);
     }
 
-    function it_does_not_apply_names_exclude_option_if_it_is_not_passed(
+    function it_does_not_apply_paths_exclude_option_if_it_is_not_passed(
         ProcessBuilder $processBuilder,
         Process $process,
         RunContext $context
@@ -116,7 +117,7 @@ class PhpCpdSpec extends ObjectBehavior
 
         $processBuilder->createArgumentsForCommand('phpcpd')->willReturn(new ProcessArgumentsCollection());
         $processBuilder->buildProcess(Argument::that(function (ProcessArgumentsCollection $arguments) {
-            return !$arguments->contains('--names-exclude');
+            return !$arguments->contains('--regexps-exclude');
         }))->willReturn($process);
 
         $process->run()->shouldBeCalled();
@@ -127,21 +128,21 @@ class PhpCpdSpec extends ObjectBehavior
         $result->isPassed()->shouldBe(true);
     }
 
-    function it_applies_names_exclude_option_in_the_correct_way(
+    function it_applies_paths_exclude_option_if_it_is_passed(
         GrumPHP $grumPHP,
         ProcessBuilder $processBuilder,
         Process $process,
         RunContext $context
     ) {
         $grumPHP->getTaskConfiguration('phpcpd')->willReturn([
-            'names_exclude' => ['foo.php', 'bar.php'],
+            'paths_exclude' => ['path/to/foo.php', 'path/to/bar.php'],
         ]);
 
         $context->getFiles()->willReturn(new FilesCollection([new SplFileInfo('file1.php', '.', 'file1.php')]));
 
         $processBuilder->createArgumentsForCommand('phpcpd')->willReturn(new ProcessArgumentsCollection());
         $processBuilder->buildProcess(Argument::that(function (ProcessArgumentsCollection $arguments) {
-            return $arguments->contains('--names-exclude=foo.php,bar.php');
+            return $arguments->contains('--regexps-exclude=path/to/foo.php,path/to/bar.php');
         }))->willReturn($process);
 
         $process->run()->shouldBeCalled();

--- a/spec/Task/PhpCpdSpec.php
+++ b/spec/Task/PhpCpdSpec.php
@@ -44,7 +44,7 @@ class PhpCpdSpec extends ObjectBehavior
         $options->getDefinedOptions()->shouldContain('directory');
         $options->getDefinedOptions()->shouldContain('exclude');
         $options->getDefinedOptions()->shouldContain('names_exclude');
-        $options->getDefinedOptions()->shouldContain('paths_exclude');
+        $options->getDefinedOptions()->shouldContain('regexps_exclude');
         $options->getDefinedOptions()->shouldContain('fuzzy');
         $options->getDefinedOptions()->shouldContain('min_lines');
         $options->getDefinedOptions()->shouldContain('min_tokens');
@@ -108,7 +108,7 @@ class PhpCpdSpec extends ObjectBehavior
         $result->isPassed()->shouldBe(false);
     }
 
-    function it_does_not_apply_paths_exclude_option_if_it_is_not_passed(
+    function it_does_not_apply_regexps_exclude_option_if_it_is_not_passed(
         ProcessBuilder $processBuilder,
         Process $process,
         RunContext $context
@@ -128,14 +128,14 @@ class PhpCpdSpec extends ObjectBehavior
         $result->isPassed()->shouldBe(true);
     }
 
-    function it_applies_paths_exclude_option_if_it_is_passed(
+    function it_applies_regexps_exclude_option_if_it_is_passed(
         GrumPHP $grumPHP,
         ProcessBuilder $processBuilder,
         Process $process,
         RunContext $context
     ) {
         $grumPHP->getTaskConfiguration('phpcpd')->willReturn([
-            'paths_exclude' => ['path/to/foo.php', 'path/to/bar.php'],
+            'regexps_exclude' => ['path/to/foo.php', 'path/to/bar.php'],
         ]);
 
         $context->getFiles()->willReturn(new FilesCollection([new SplFileInfo('file1.php', '.', 'file1.php')]));

--- a/src/Task/PhpCpd.php
+++ b/src/Task/PhpCpd.php
@@ -31,6 +31,7 @@ class PhpCpd extends AbstractExternalTask
             'directory' => '.',
             'exclude' => ['vendor'],
             'names_exclude' => [],
+            'paths_exclude' => [],
             'fuzzy' => false,
             'min_lines' => 5,
             'min_tokens' => 70,
@@ -40,6 +41,7 @@ class PhpCpd extends AbstractExternalTask
         $resolver->addAllowedTypes('directory', ['string']);
         $resolver->addAllowedTypes('exclude', ['array']);
         $resolver->addAllowedTypes('names_exclude', ['array']);
+        $resolver->addAllowedTypes('paths_exclude', ['array']);
         $resolver->addAllowedTypes('fuzzy', ['bool']);
         $resolver->addAllowedTypes('min_lines', ['int']);
         $resolver->addAllowedTypes('min_tokens', ['int']);
@@ -74,7 +76,8 @@ class PhpCpd extends AbstractExternalTask
         }, $config['triggered_by']);
 
         $arguments->addArgumentArray('--exclude=%s', $config['exclude']);
-        $arguments->addOptionalCommaSeparatedArgument('--names-exclude=%s', $config['names_exclude']);
+        $arguments->addArgumentArray('--names-exclude=%s', $config['names_exclude']);
+        $arguments->addOptionalCommaSeparatedArgument('--regexps-exclude=%s', $config['paths_exclude']);
         $arguments->addRequiredArgument('--min-lines=%u', $config['min_lines']);
         $arguments->addRequiredArgument('--min-tokens=%u', $config['min_tokens']);
         $arguments->addOptionalCommaSeparatedArgument('--names=%s', $extensions);

--- a/src/Task/PhpCpd.php
+++ b/src/Task/PhpCpd.php
@@ -31,7 +31,7 @@ class PhpCpd extends AbstractExternalTask
             'directory' => '.',
             'exclude' => ['vendor'],
             'names_exclude' => [],
-            'paths_exclude' => [],
+            'regexps_exclude' => [],
             'fuzzy' => false,
             'min_lines' => 5,
             'min_tokens' => 70,
@@ -41,7 +41,7 @@ class PhpCpd extends AbstractExternalTask
         $resolver->addAllowedTypes('directory', ['string']);
         $resolver->addAllowedTypes('exclude', ['array']);
         $resolver->addAllowedTypes('names_exclude', ['array']);
-        $resolver->addAllowedTypes('paths_exclude', ['array']);
+        $resolver->addAllowedTypes('regexps_exclude', ['array']);
         $resolver->addAllowedTypes('fuzzy', ['bool']);
         $resolver->addAllowedTypes('min_lines', ['int']);
         $resolver->addAllowedTypes('min_tokens', ['int']);
@@ -77,7 +77,7 @@ class PhpCpd extends AbstractExternalTask
 
         $arguments->addArgumentArray('--exclude=%s', $config['exclude']);
         $arguments->addArgumentArray('--names-exclude=%s', $config['names_exclude']);
-        $arguments->addOptionalCommaSeparatedArgument('--regexps-exclude=%s', $config['paths_exclude']);
+        $arguments->addOptionalCommaSeparatedArgument('--regexps-exclude=%s', $config['regexps_exclude']);
         $arguments->addRequiredArgument('--min-lines=%u', $config['min_lines']);
         $arguments->addRequiredArgument('--min-tokens=%u', $config['min_tokens']);
         $arguments->addOptionalCommaSeparatedArgument('--names=%s', $extensions);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #477

Added the phpcpd "paths_exclude" option, which corresponds to the `--regexps-exclude` console option of phpcpd.