### PR TITLE
Let symfony developers use phpunit-bridge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ parameters:
         phpspec: ~
         phpstan: ~
         phpunit: ~
+        phpunitbridge: ~
         phpversion: ~
         robo: ~
         securitychecker: ~

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "phpunit/phpunit": "^5.7.27|^6.4.4",
         "sebastian/comparator": "^1.2.4",
         "sensiolabs/security-checker": "^4.0",
-        "squizlabs/php_codesniffer": "~2.4"
+        "squizlabs/php_codesniffer": "~2.4",
+        "symfony/phpunit-bridge": "~2.7|~3.0|~4.0"
     },
     "suggest": {
         "atoum/atoum": "Lets GrumPHP run your unit tests.",
@@ -55,7 +56,8 @@
         "sebastian/phpcpd": "Lets GrumPHP find duplicated code.",
         "sensiolabs/security-checker": "Lets GrumPHP be sure that there are no known security issues.",
         "squizlabs/php_codesniffer": "Lets GrumPHP sniff on your code.",
-        "sstalle/php7cc": "Lets GrumPHP check PHP 5.3 - 5.6 code compatibility with PHP 7."
+        "sstalle/php7cc": "Lets GrumPHP check PHP 5.3 - 5.6 code compatibility with PHP 7.",
+        "symfony/phpunit-bridge": "Lets GrumPHP run your unit tests with the phpunit-bridge of Symfony."
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,7 @@
         "phpunit/phpunit": "^5.7.27|^6.4.4",
         "sebastian/comparator": "^1.2.4",
         "sensiolabs/security-checker": "^4.0",
-        "squizlabs/php_codesniffer": "~2.4",
-        "symfony/phpunit-bridge": "~2.7|~3.0|~4.0"
+        "squizlabs/php_codesniffer": "~2.4"
     },
     "suggest": {
         "atoum/atoum": "Lets GrumPHP run your unit tests.",

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -44,6 +44,7 @@ parameters:
         phpspec: ~
         phpstan: ~
         phpunit: ~
+        phpunitbridge: ~
         phpversion: ~
         robo: ~
         securitychecker: ~
@@ -93,6 +94,7 @@ Every task has it's own default configuration. It is possible to overwrite the p
 - [Phpspec](tasks/phpspec.md)
 - [PHPStan](tasks/phpstan.md)
 - [Phpunit](tasks/phpunit.md)
+- [Phpunit bridge](tasks/phpunitbridge.md)
 - [PhpVersion](tasks/phpversion.md)
 - [Robo](tasks/robo.md)
 - [Security Checker](tasks/securitychecker.md)

--- a/doc/tasks/phpunitbridge.md
+++ b/doc/tasks/phpunitbridge.md
@@ -1,22 +1,22 @@
 # Phpunit
 
-The Phpunit task will run your unit tests.
+The Phpunit Bridge task will run your unit tests thanks to the Symfony Phpunit Bridge.
 
 ***Composer***
 
 ```
-composer require --dev phpunit/phpunit
+composer require --dev symfony/phpunit-bridge
 ```
 
 ***Config***
 
-The task lives under the `phpunit` namespace and has following configurable parameters:
+The task lives under the `phpunitbridge` namespace and has following configurable parameters:
 
 ```yaml
 # grumphp.yml
 parameters:
     tasks:
-        phpunit:
+        phpunitbridge:
             config_file: ~
             testsuite: ~
             group: []

--- a/doc/tasks/phpunitbridge.md
+++ b/doc/tasks/phpunitbridge.md
@@ -1,4 +1,4 @@
-# Phpunit
+# Phpunit bridge
 
 The Phpunit Bridge task will run your unit tests thanks to the Symfony Phpunit Bridge.
 

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -327,6 +327,15 @@ services:
         tags:
             - {name: grumphp.task, config: phpunit}
 
+    task.phpunitbridge:
+        class: GrumPHP\Task\PhpunitBridge
+        arguments:
+            - '@config'
+            - '@process_builder'
+            - '@formatter.raw_process'
+        tags:
+            - {name: grumphp.task, config: phpunitbridge}
+
     task.phpversion:
         class: GrumPHP\Task\PhpVersion
         arguments:

--- a/spec/Task/PhpunitBridgeSpec.php
+++ b/spec/Task/PhpunitBridgeSpec.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace spec\GrumPHP\Task;
+
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
+use GrumPHP\Process\ProcessBuilder;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\Phpunit;
+use GrumPHP\Task\PhpunitBridge;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Process\Process;
+
+class PhpunitBridgeSpec extends ObjectBehavior
+{
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
+    {
+        $grumPHP->getTaskConfiguration('phpunitbridge')->willReturn([]);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PhpunitBridge::class);
+    }
+
+    function it_should_have_a_name()
+    {
+        $this->getName()->shouldBe('phpunitbridge');
+    }
+
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf(OptionsResolver::class);
+        $options->getDefinedOptions()->shouldContain('config_file');
+        $options->getDefinedOptions()->shouldContain('testsuite');
+        $options->getDefinedOptions()->shouldContain('group');
+        $options->getDefinedOptions()->shouldContain('always_execute');
+    }
+
+    function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_run_in_run_context(RunContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder, ContextInterface $context)
+    {
+        $processBuilder->buildProcess('phpunitbridge')->shouldNotBeCalled();
+        $processBuilder->buildProcess()->shouldNotBeCalled();
+        $context->getFiles()->willReturn(new FilesCollection());
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->getResultCode()->shouldBe(TaskResult::SKIPPED);
+    }
+
+    function it_runs_if_there_are_no_files_but_always_execute_is_passed(GrumPHP $grumPHP, Process $process, ProcessBuilder $processBuilder, ContextInterface $context)
+    {
+        $grumPHP->getTaskConfiguration('phpunitbridge')->willReturn([
+            'always_execute' => true,
+        ]);
+
+        $arguments = new ProcessArgumentsCollection();
+        $processBuilder->createArgumentsForCommand('simple-phpunit')->willReturn($arguments);
+        $processBuilder->buildProcess($arguments)->willReturn($process);
+
+        $process->run()->shouldBeCalled();
+        $process->isSuccessful()->willReturn(true);
+
+        $context->getFiles()->willReturn(new FilesCollection());
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_runs_the_suite(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
+    {
+        $arguments = new ProcessArgumentsCollection();
+        $processBuilder->createArgumentsForCommand('simple-phpunit')->willReturn($arguments);
+        $processBuilder->buildProcess($arguments)->willReturn($process);
+
+        $process->run()->shouldBeCalled();
+        $process->isSuccessful()->willReturn(true);
+
+        $context->getFiles()->willReturn(new FilesCollection([
+            new SplFileInfo('test.php', '.', 'test.php')
+        ]));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_throws_exception_if_the_process_fails(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
+    {
+        $arguments = new ProcessArgumentsCollection();
+        $processBuilder->createArgumentsForCommand('simple-phpunit')->willReturn($arguments);
+        $processBuilder->buildProcess($arguments)->willReturn($process);
+
+        $process->run()->shouldBeCalled();
+        $process->isSuccessful()->willReturn(false);
+
+        $context->getFiles()->willReturn(new FilesCollection([
+            new SplFileInfo('test.php', '.', 'test.php')
+        ]));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+}

--- a/src/Task/PhpunitBridge.php
+++ b/src/Task/PhpunitBridge.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace GrumPHP\Task;
+
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * PhpunitBridge task
+ *
+ * @link https://symfony.com/doc/current/components/phpunit_bridge.html
+ */
+class PhpunitBridge extends AbstractExternalTask
+{
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'phpunitbridge';
+    }
+
+    /**
+     * @return OptionsResolver
+     */
+    public function getConfigurableOptions()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'config_file' => null,
+            'testsuite' => null,
+            'group' => [],
+            'always_execute' => false,
+        ]);
+
+        $resolver->addAllowedTypes('config_file', ['null', 'string']);
+        $resolver->addAllowedTypes('testsuite', ['null', 'string']);
+        $resolver->addAllowedTypes('group', ['array']);
+        $resolver->addAllowedTypes('always_execute', ['bool']);
+
+        return $resolver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canRunInContext(ContextInterface $context)
+    {
+        return ($context instanceof GitPreCommitContext || $context instanceof RunContext);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(ContextInterface $context)
+    {
+        $config = $this->getConfiguration();
+
+        $files = $context->getFiles()->name('*.php');
+        if (0 === count($files) && !$config['always_execute']) {
+            return TaskResult::createSkipped($this, $context);
+        }
+
+        $arguments = $this->processBuilder->createArgumentsForCommand('simple-phpunit');
+        $arguments->addOptionalArgument('--configuration=%s', $config['config_file']);
+        $arguments->addOptionalArgument('--testsuite=%s', $config['testsuite']);
+        $arguments->addOptionalCommaSeparatedArgument('--group=%s', $config['group']);
+
+        $process = $this->processBuilder->buildProcess($arguments);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | 

`symfony/phpunit-bridge` doesn't work with grumphp. With this feature, you can specify the bin file to use for the phpunit task.
