### PR TITLE
Added addOptionalIntegerArgument to fix issue with phpcs warning_severity

### DIFF
--- a/spec/Collection/ProcessArgumentsCollectionSpec.php
+++ b/spec/Collection/ProcessArgumentsCollectionSpec.php
@@ -140,4 +140,22 @@ class ProcessArgumentsCollectionSpec extends ObjectBehavior
         $this->addOptionalBooleanArgument('--argument=%s', false, 'yes', 'no');
         $this->getValues()->shouldBe(['--argument=no']);
     }
+
+    function it_should_be_able_to_add_optional_integer_argument_with_null_value()
+    {
+        $this->addOptionalIntegerArgument('--argument=%s', null);
+        $this->getValues()->shouldBe([]);
+    }
+
+    function it_should_be_able_to_add_optional_integer_argument_with_a_value()
+    {
+        $this->addOptionalIntegerArgument('--argument=%s', 100);
+        $this->getValues()->shouldBe(['--argument=100']);
+    }
+
+    function it_should_be_able_to_add_optional_integer_argument_with_zero_as_value()
+    {
+        $this->addOptionalIntegerArgument('--argument=%s', 0);
+        $this->getValues()->shouldBe(['--argument=0']);
+    }
 }

--- a/src/Collection/ProcessArgumentsCollection.php
+++ b/src/Collection/ProcessArgumentsCollection.php
@@ -165,4 +165,17 @@ class ProcessArgumentsCollection extends ArrayCollection
 
         $this->add(sprintf($argument, $value ? $trueFormat : $falseFormat));
     }
+
+    /**
+     * @param string      $argument
+     * @param int|null    $value
+     */
+    public function addOptionalIntegerArgument($argument, $value)
+    {
+        if (null === $value) {
+            return;
+        }
+        
+        $this->add(sprintf($argument, $value));
+    }
 }

--- a/src/Collection/ProcessArgumentsCollection.php
+++ b/src/Collection/ProcessArgumentsCollection.php
@@ -167,15 +167,15 @@ class ProcessArgumentsCollection extends ArrayCollection
     }
 
     /**
-     * @param string      $argument
-     * @param int|null    $value
+     * @param string   $argument
+     * @param int|null $value
      */
     public function addOptionalIntegerArgument($argument, $value)
     {
         if (null === $value) {
             return;
         }
-        
+
         $this->add(sprintf($argument, $value));
     }
 }

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -127,7 +127,7 @@ class Phpcs extends AbstractExternalTask
         $arguments->addOptionalArgument('--encoding=%s', $config['encoding']);
         $arguments->addOptionalArgument('--severity=%s', $config['severity']);
         $arguments->addOptionalArgument('--error-severity=%s', $config['error_severity']);
-        $arguments->addOptionalArgument('--warning-severity=%s', $config['warning_severity']);
+        $arguments->addOptionalIntegerArgument('--warning-severity=%s', $config['warning_severity']);
         $arguments->addOptionalCommaSeparatedArgument('--sniffs=%s', $config['sniffs']);
         $arguments->addOptionalCommaSeparatedArgument('--ignore=%s', $config['ignore_patterns']);
 

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -125,8 +125,8 @@ class Phpcs extends AbstractExternalTask
         $arguments->addOptionalArgument('--standard=%s', $config['standard']);
         $arguments->addOptionalArgument('--tab-width=%s', $config['tab_width']);
         $arguments->addOptionalArgument('--encoding=%s', $config['encoding']);
-        $arguments->addOptionalArgument('--severity=%s', $config['severity']);
-        $arguments->addOptionalArgument('--error-severity=%s', $config['error_severity']);
+        $arguments->addOptionalIntegerArgument('--severity=%s', $config['severity']);
+        $arguments->addOptionalIntegerArgument('--error-severity=%s', $config['error_severity']);
         $arguments->addOptionalIntegerArgument('--warning-severity=%s', $config['warning_severity']);
         $arguments->addOptionalCommaSeparatedArgument('--sniffs=%s', $config['sniffs']);
         $arguments->addOptionalCommaSeparatedArgument('--ignore=%s', $config['ignore_patterns']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 466

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

Related to #466, I added \GrumPHP\Collection\ProcessArgumentsCollection::addOptionalIntegerArgument() method and changed the calls in the phpcs task to use this.