### PR TITLE
Add whitelist_patterns option to PhpMnd task

### DIFF
--- a/doc/tasks/phpmnd.md
+++ b/doc/tasks/phpmnd.md
@@ -18,6 +18,7 @@ parameters:
     tasks:
         phpmnd:
             directory: .
+            whitelist_patterns: []
             exclude: []
             exclude_name: []
             exclude_path: []
@@ -34,6 +35,18 @@ parameters:
 *Default: .*
 
 With this parameter you can define which directory you want to run `phpmnd` in (must be relative to cwd).
+
+**whitelist_patterns**
+
+*Default: []*
+
+This is a list of regex patterns that will filter files to validate. With this option you can skip files like tests. This option is used in relation with the parameter `triggered_by`.
+For exemple to validate only files in your `src/App/` and `src/AppBundle/` directories in a Symfony you can use 
+```yml
+whitelist_patterns:
+  - /^src\/App\/(.*)/
+  - /^src\/AppBundle\/(.*)/
+```
 
 **exclude**
 

--- a/spec/Task/PhpMndSpec.php
+++ b/spec/Task/PhpMndSpec.php
@@ -41,6 +41,7 @@ class PhpMndSpec extends ObjectBehavior
         $options = $this->getConfigurableOptions();
         $options->shouldBeAnInstanceOf(OptionsResolver::class);
         $options->getDefinedOptions()->shouldContain('directory');
+        $options->getDefinedOptions()->shouldContain('whitelist_patterns');
         $options->getDefinedOptions()->shouldContain('exclude');
         $options->getDefinedOptions()->shouldContain('exclude_name');
         $options->getDefinedOptions()->shouldContain('exclude_path');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | no

As for https://github.com/phpro/grumphp/pull/160 this PR add a new `whitelist_patterns`option to `PhpMnd` task. It will be used to filter files to be validated.

Example for a Symfony, validate PHP files only in `src/` directory

``` yml
phpmnd:
    whitelist_patterns: ["^src/(.*)"]
    triggered_by: [php]
```