### PR TITLE
Add whitelist_patterns option to PhpMd task

### DIFF
--- a/doc/tasks/phpmd.md
+++ b/doc/tasks/phpmd.md
@@ -28,11 +28,11 @@ parameters:
 *Default: []*
 
 This is a list of regex patterns that will filter files to validate. With this option you can skip files like tests. This option is used in relation with the parameter `triggered_by`.
-For exemple to validate only files in your `src/App/` and `src/AppBundle/` directories in a Symfony you can use 
+For example: whitelist files in `src/FolderA/` and `src/FolderB/` you can use 
 ```yml
 whitelist_patterns:
-  - /^src\/App\/(.*)/
-  - /^src\/AppBundle\/(.*)/
+  - /^src\/FolderA\/(.*)/
+  - /^src\/FolderB\/(.*)/
 ```
 
 **exclude**

--- a/doc/tasks/phpmd.md
+++ b/doc/tasks/phpmd.md
@@ -17,9 +17,22 @@ The task lives under the `phpmd` namespace and has following configurable parame
 parameters:
     tasks:
         phpmd:
+            whitelist_patterns: []
             exclude: []
             ruleset: ['cleancode', 'codesize', 'naming']
             triggered_by: ['php']
+```
+
+**whitelist_patterns**
+
+*Default: []*
+
+This is a list of regex patterns that will filter files to validate. With this option you can skip files like tests. This option is used in relation with the parameter `triggered_by`.
+For exemple to validate only files in your `src/App/` and `src/AppBundle/` directories in a Symfony you can use 
+```yml
+whitelist_patterns:
+  - /^src\/App\/(.*)/
+  - /^src\/AppBundle\/(.*)/
 ```
 
 **exclude**

--- a/spec/Task/PhpMdSpec.php
+++ b/spec/Task/PhpMdSpec.php
@@ -40,6 +40,7 @@ class PhpMdSpec extends ObjectBehavior
     {
         $options = $this->getConfigurableOptions();
         $options->shouldBeAnInstanceOf(OptionsResolver::class);
+        $options->getDefinedOptions()->shouldContain('whitelist_patterns');
         $options->getDefinedOptions()->shouldContain('exclude');
         $options->getDefinedOptions()->shouldContain('ruleset');
         $options->getDefinedOptions()->shouldContain('triggered_by');

--- a/src/Task/PhpMd.php
+++ b/src/Task/PhpMd.php
@@ -55,14 +55,11 @@ class PhpMd extends AbstractExternalTask
      */
     public function run(ContextInterface $context)
     {
-        /** @var array $config */
         $config = $this->getConfiguration();
-        /** @var array $whitelistPatterns */
+
         $whitelistPatterns = $config['whitelist_patterns'];
-        /** @var array $extensions */
         $extensions = $config['triggered_by'];
 
-        /** @var \GrumPHP\Collection\FilesCollection $files */
         $files = $context->getFiles();
         if (0 !== count($whitelistPatterns)) {
             $files = $files->paths($whitelistPatterns);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | no

As for https://github.com/phpro/grumphp/pull/160 this PR add a new `whitelist_patterns`option to `PhpMd` task. It will be used to filter files to be validated.

Example for a Symfony, validate PHP files only in `src/` directory

``` yml
phpmd:
    whitelist_patterns: ["^src/(.*)"]
```