### PR TITLE
Add names_exclude to GitBranchName

### DIFF
--- a/doc/tasks/git_branch_name.md
+++ b/doc/tasks/git_branch_name.md
@@ -11,6 +11,7 @@ parameters:
             matchers:
                 Branch name must contain JIRA issue number: /JIRA-\d+/
             additional_modifiers: ''
+            names_exclude: []
 ```
 
 **matchers**
@@ -44,3 +45,9 @@ additional_modifiers: 'xu'
 *Default: true*
 
 Set this to `false` if you wish the task to fail when ran on a detached HEAD. If set to `true` the task will always pass.
+
+**names_exclude**
+
+*Default: []*
+
+Use this parameter to exclude one or multiple branch names.

--- a/spec/Task/Git/BranchNameSpec.php
+++ b/spec/Task/Git/BranchNameSpec.php
@@ -36,6 +36,7 @@ class BranchNameSpec extends ObjectBehavior
         $options->shouldBeAnInstanceOf(OptionsResolver::class);
         $options->getDefinedOptions()->shouldContain('matchers');
         $options->getDefinedOptions()->shouldContain('additional_modifiers');
+        $options->getDefinedOptions()->shouldContain('names_exclude');
     }
 
     function it_is_initializable()

--- a/src/Task/Git/BranchName.php
+++ b/src/Task/Git/BranchName.php
@@ -67,11 +67,13 @@ class BranchName implements TaskInterface
             'matchers' => [],
             'additional_modifiers' => '',
             'allow_detached_head' => true,
+            'names_exclude' => [],
         ]);
 
         $resolver->addAllowedTypes('matchers', ['array']);
         $resolver->addAllowedTypes('additional_modifiers', ['string']);
         $resolver->addAllowedTypes('allow_detached_head', ['boolean']);
+        $resolver->addAllowedTypes('names_exclude', ['array']);
 
         return $resolver;
     }
@@ -115,6 +117,8 @@ class BranchName implements TaskInterface
     {
         $config = $this->getConfiguration();
         $exceptions = [];
+        /** @var array $namesExclude */
+        $namesExclude = $config['names_exclude'];
 
         try {
             $name = trim($this->repository->run('symbolic-ref', ['HEAD', '--short']));
@@ -124,6 +128,10 @@ class BranchName implements TaskInterface
             }
             $message = "Branch naming convention task is not allowed on a detached HEAD.";
             return TaskResult::createFailed($this, $context, $message);
+        }
+
+        if (in_array($name, $namesExclude)) {
+            return TaskResult::createPassed($this, $context);
         }
 
         foreach ($config['matchers'] as $ruleName => $rule) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | no

This PR add a new `names_exclude`option to `GitBranchName` task. It will be used to filter branch name to be validated.

``` yml
git_branch_name:
    names_exclude: 
        - master
        - feature
```