### PR TITLE
Add whitelist_patterns to GitBlacklist

### DIFF
--- a/doc/tasks/git_blacklist.md
+++ b/doc/tasks/git_blacklist.md
@@ -12,6 +12,7 @@ parameters:
                 - "die("
                 - "var_dump("
                 - "exit;"
+            whitelist_patterns: []
             triggered_by: ['php']
             regexp_type: G
 ```
@@ -22,6 +23,17 @@ parameters:
 
 Use this parameter to specify your blacklisted keywords list.
 
+**whitelist_patterns**
+
+*Default: []*
+
+This is a list of regex patterns that will filter files to validate. With this option you can skip files like tests. This option is used in relation with the parameter `triggered_by`.
+For exemple to validate only files in your `src/App/` and `src/AppBundle/` directories in a Symfony you can use 
+```yml
+whitelist_patterns:
+  - /^src\/App\/(.*)/
+  - /^src\/AppBundle\/(.*)/
+```
 
 **triggered_by**
 

--- a/doc/tasks/git_blacklist.md
+++ b/doc/tasks/git_blacklist.md
@@ -28,11 +28,11 @@ Use this parameter to specify your blacklisted keywords list.
 *Default: []*
 
 This is a list of regex patterns that will filter files to validate. With this option you can skip files like tests. This option is used in relation with the parameter `triggered_by`.
-For exemple to validate only files in your `src/App/` and `src/AppBundle/` directories in a Symfony you can use 
+For example: whitelist files in `src/FolderA/` and `src/FolderB/` you can use 
 ```yml
 whitelist_patterns:
-  - /^src\/App\/(.*)/
-  - /^src\/AppBundle\/(.*)/
+  - /^src\/FolderA\/(.*)/
+  - /^src\/FolderB\/(.*)/
 ```
 
 **triggered_by**

--- a/spec/Task/Git/BlacklistSpec.php
+++ b/spec/Task/Git/BlacklistSpec.php
@@ -41,6 +41,7 @@ class BlacklistSpec extends ObjectBehavior
         $options = $this->getConfigurableOptions();
         $options->shouldBeAnInstanceOf(OptionsResolver::class);
         $options->getDefinedOptions()->shouldContain('keywords');
+        $options->getDefinedOptions()->shouldContain('whitelist_patterns');
         $options->getDefinedOptions()->shouldContain('triggered_by');
         $options->getDefinedOptions()->shouldContain('regexp_type');
     }

--- a/src/Task/Git/Blacklist.php
+++ b/src/Task/Git/Blacklist.php
@@ -83,14 +83,11 @@ class Blacklist extends AbstractExternalTask
      */
     public function run(ContextInterface $context)
     {
-        /** @var array $config */
         $config = $this->getConfiguration();
-        /** @var array $whitelistPatterns */
+
         $whitelistPatterns = $config['whitelist_patterns'];
-        /** @var array $extensions */
         $extensions = $config['triggered_by'];
 
-        /** @var \GrumPHP\Collection\FilesCollection $files */
         $files = $context->getFiles();
         if (0 !== count($whitelistPatterns)) {
             $files = $files->paths($whitelistPatterns);

--- a/src/Task/Git/Blacklist.php
+++ b/src/Task/Git/Blacklist.php
@@ -55,11 +55,13 @@ class Blacklist extends AbstractExternalTask
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
             'keywords' => [],
+            'whitelist_patterns' => [],
             'triggered_by' => ['php'],
             'regexp_type' => 'G'
         ]);
 
         $resolver->addAllowedTypes('keywords', ['array']);
+        $resolver->addAllowedTypes('whitelist_patterns', ['array']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
         $resolver->addAllowedTypes('regexp_type', ['string']);
 
@@ -81,8 +83,20 @@ class Blacklist extends AbstractExternalTask
      */
     public function run(ContextInterface $context)
     {
+        /** @var array $config */
         $config = $this->getConfiguration();
-        $files = $context->getFiles()->extensions($config['triggered_by']);
+        /** @var array $whitelistPatterns */
+        $whitelistPatterns = $config['whitelist_patterns'];
+        /** @var array $extensions */
+        $extensions = $config['triggered_by'];
+
+        /** @var \GrumPHP\Collection\FilesCollection $files */
+        $files = $context->getFiles();
+        if (0 !== count($whitelistPatterns)) {
+            $files = $files->paths($whitelistPatterns);
+        }
+        $files = $files->extensions($extensions);
+
         if (0 === count($files) || empty($config['keywords'])) {
             return TaskResult::createSkipped($this, $context);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | no

As for https://github.com/phpro/grumphp/pull/160 this PR add a new `whitelist_patterns`option to `GitBlacklist` task. It will be used to filter files to be validated.

Example for a Symfony, validate PHP files only in `src/` directory

``` yml
git_blacklist:
    whitelist_patterns: ["^src/(.*)"]
```