### PR TITLE
[WIP] Add support for composer-bin-plugin

### DIFF
--- a/bin/grumphp
+++ b/bin/grumphp
@@ -4,10 +4,10 @@
 define('GRUMPHP_PATH', realpath(__DIR__ . '/..'));
 
 $autoloadLocations = [
-    getcwd() . '/vendor/autoload.php',
-    getcwd() . '/../../autoload.php',
     __DIR__ . '/../vendor/autoload.php',
     __DIR__ . '/../../../autoload.php',
+    getcwd() . '/vendor/autoload.php',
+    getcwd() . '/../../autoload.php',
 ];
 
 $loaded = false;
@@ -15,6 +15,7 @@ foreach ($autoloadLocations as $autoload) {
     if (is_file($autoload)) {
         require_once($autoload);
         $loaded = true;
+        break;
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | maybe
| Deprecations? | no
| Documented?   | not yet
| Fixed tickets | 

We are trying to move to a our development dependencies to use [composer-bin-plugin](https://github.com/bamarni/composer-bin-plugin) which allows to install different dependencies based on a namespace convention.  But this gives us some problems with GrumPHP.

Steps to use the bin plugin locally
```
composer require --dev bamarni/composer-bin-plugin
composer bin grumphp require phpro/grumphp 
```

This creates a directory structure like this.
- `./vendor/bamarni/composer-bin-plugin/*`
- `./vendor/autoload.php`
- `./vendor-bin/grumphp/vendor/phpro/grumphp/*`
- `./vendor-bin/grumphp/vendor/autoload.php`

The [composer-bin-plugin](https://github.com/bamarni/composer-bin-plugin) make sure that the bin file for GrumpPHP is installed in `./vendor/bin/grumphp` with a link to `./vendor-bin/grumphp/vendor/phpro/grumphp/bin/grumphp`. Which works like a charm and it allows to have 2 different versions of dependencies (example Symfony 3 project, but Symfony 4 for GrumpPHP). 

The first problem that this PR is trying to fix is the that we have 2 `autoload.php` files but GrumPHP loads both our project `./vendor/autoload.php` and the specifiek version `./vendor-bin/grumphp/vendor/autoload.php` which gives us the probleem that classes are used in mixed versions. I found this commit https://github.com/phpro/grumphp/commit/b23f63c7302febb97ae0a37ca0dc9e2368437436#diff-f8ebc1f2e38a53a8265708ae3ecbb694 which removes the break from autoloading but i'm not sure what the use case is for that. 

Other problems that we have not solved yet are;
1. When installing the `grumphp.yml` is created in `./vendor-bin/grumphp/grumphp.yml` instead of `./grumphp.yml`
1. The `git:init` during composer post install is trying to create it under `./vendor-bin/grumphp/.git/hooks/pre-commit` instead of `./.git/hooks/pre-commit`. But when we run `./vendor/bin/grumphp git:init` after the installation the hook is installed correctly. 

Both of these issues are stil on our list to look into but i wanted to create this PR to hear some feedback on the autoload already. 

