### PR TITLE
Ignore commented lines

### DIFF
--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -173,6 +173,9 @@ class CommitMessage implements TaskInterface
         }
 
         foreach (array_slice($lines, 2) as $index => $line) {
+            if (isset($line[0]) && $line[0] == '#') {
+                continue;   
+            }
             if (mb_strlen(rtrim($line)) > $config['max_body_width']) {
                 $errors[] = sprintf(
                     'Line %u of commit message has > %u characters.',


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | Not sure ? Its expected as its not saved


By default git commit gives some commented lines of what is going to happen. Remove any commented line from the check

