### PR TITLE
Correct package-name of phan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "codegyre/robo": "Lets GrumPHP run your automated PHP tasks.",
         "designsecurity/progpilot": "Lets GrumPHP be sure that there are no vulnerabilities in your code.",
         "doctrine/orm": "Lets GrumPHP validate your Doctrine mapping files.",
-        "etsy/phan": "Lets GrumPHP unleash a static analyzer on your code",
+        "phan/phan": "Lets GrumPHP unleash a static analyzer on your code",
         "friendsofphp/php-cs-fixer": "Lets GrumPHP automatically fix your codestyle.",
         "infection/infection": "Lets GrumPHP evaluate the quality your unit tests",
         "jakub-onderka/php-parallel-lint": "Lets GrumPHP quickly lint your entire code base.",

--- a/doc/tasks/phan.md
+++ b/doc/tasks/phan.md
@@ -5,7 +5,7 @@ The Phan task will run your automated PHP tasks.
 ***Composer***
 
 ```
-composer require --dev etsy/phan
+composer require --dev phan/phan
 ```
 
 ***Config***


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Documented?   | yes
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

`etsy/phan` has been deprecated. Please use `phan/phan`.