### PR TITLE
allow tasks with large number of parameters to write command to file

### DIFF
--- a/doc/tasks/phpcs.md
+++ b/doc/tasks/phpcs.md
@@ -27,7 +27,7 @@ parameters:
             ignore_patterns: []
             sniffs: []
             triggered_by: [php]
-            
+            use_cmd_tmp_file: false
 ```
 
 **standard**
@@ -107,6 +107,14 @@ This is a list of sniffs that need to be executed. Leave this option blank to ru
 *Default: [php]:
 
 This is a list of extensions to be sniffed. 
+
+**use_cmd_tmp_file**
+
+*Default: false:
+
+Whether to first write the command to a file and execute that file. Use this if you want to scan a large codebase and the string of files is larger than the max cli imput.
+
+note: only works on unix (requires `sh`)
 
 ## Framework presets
 

--- a/doc/tasks/phplint.md
+++ b/doc/tasks/phplint.md
@@ -18,6 +18,7 @@ parameters:
             exclude: []
             jobs: ~
             triggered_by: ['php', 'phtml', 'php3', 'php4', 'php5']
+            use_cmd_tmp_file: false
 ```
 **exclude**
 
@@ -39,3 +40,11 @@ defaults to 10.
 *Default: ['php', 'phtml', 'php3', 'php4', 'php5']*
 
 Any file extensions that you wish to be passed to the linter.
+
+**use_cmd_tmp_file**
+
+*Default: false:
+
+Whether to first write the command to a file and execute that file. Use this if you want to scan a large codebase and the string of files is larger than the max cli imput.
+
+note: only works on unix (requires `sh`)

--- a/spec/Task/PhpLintSpec.php
+++ b/spec/Task/PhpLintSpec.php
@@ -42,6 +42,7 @@ class PhpLintSpec extends ObjectBehavior
         $options->getDefinedOptions()->shouldContain('jobs');
         $options->getDefinedOptions()->shouldContain('exclude');
         $options->getDefinedOptions()->shouldContain('triggered_by');
+        $options->getDefinedOptions()->shouldContain('use_cmd_tmp_file');
     }
 
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)

--- a/spec/Task/PhpcsSpec.php
+++ b/spec/Task/PhpcsSpec.php
@@ -50,6 +50,7 @@ class PhpcsSpec extends ObjectBehavior
         $options->getDefinedOptions()->shouldContain('ignore_patterns');
         $options->getDefinedOptions()->shouldContain('sniffs');
         $options->getDefinedOptions()->shouldContain('triggered_by');
+        $options->getDefinedOptions()->shouldContain('use_cmd_tmp_file');
     }
 
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
@@ -73,7 +74,7 @@ class PhpcsSpec extends ObjectBehavior
         $result->getResultCode()->shouldBe(TaskResult::SKIPPED);
     }
 
-    function it_does_not_runs_the_suite_with_invalid_extensions(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
+    function it_does_not_run_the_suite_with_invalid_extensions(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
     {
         $arguments = new ProcessArgumentsCollection();
         $processBuilder->createArgumentsForCommand('phpcs')->willReturn($arguments);

--- a/src/Process/ProcessBuilder.php
+++ b/src/Process/ProcessBuilder.php
@@ -71,6 +71,31 @@ class ProcessBuilder
     }
 
     /**
+     * @param ProcessArgumentsCollection $arguments
+     *
+     * @return Process
+     * @throws \GrumPHP\Exception\PlatformException
+     */
+    public function proxyThroughTmpFile(Process $process)
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'GRUMPHP');
+        $handle = fopen($tmpFile, "w");
+        fwrite($handle, $process->getCommandLine());
+        fclose($handle);
+
+        $process = ProcessFactory::fromArguments(new ProcessArgumentsCollection([
+            'sh',
+            $tmpFile,
+        ]));
+        $process->setTimeout($this->config->getProcessTimeout());
+
+        $this->logProcessInVerboseMode($process);
+        $this->guardWindowsCmdMaxInputStringLimitation($process);
+
+        return $process;
+    }
+
+    /**
      * @param Process $process
      *
      * @throws \GrumPHP\Exception\PlatformException

--- a/src/Task/PhpLint.php
+++ b/src/Task/PhpLint.php
@@ -31,11 +31,13 @@ class PhpLint extends AbstractExternalTask
             'jobs' => null,
             'exclude' => [],
             'triggered_by' => ['php', 'phtml', 'php3', 'php4', 'php5'],
+            'use_cmd_tmp_file' => false,
         ]);
 
         $resolver->setAllowedTypes('jobs', ['int', 'null']);
         $resolver->setAllowedTypes('exclude', 'array');
         $resolver->setAllowedTypes('triggered_by', 'array');
+        $resolver->setAllowedTypes('use_cmd_tmp_file', 'bool');
 
         return $resolver;
     }
@@ -63,6 +65,9 @@ class PhpLint extends AbstractExternalTask
         $arguments->addFiles($files);
 
         $process = $this->processBuilder->buildProcess($arguments);
+        if ($config['use_cmd_tmp_file']) {
+            $process = $this->processBuilder->proxyThroughTmpFile($process);
+        }
         $process->run();
 
         if (!$process->isSuccessful()) {

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -41,7 +41,8 @@ class Phpcs extends AbstractExternalTask
             'severity' => null,
             'error_severity' => null,
             'warning_severity' => null,
-            'triggered_by' => ['php']
+            'triggered_by' => ['php'],
+            'use_cmd_tmp_file' => false
         ]);
 
         $resolver->addAllowedTypes('standard', ['null', 'string']);
@@ -54,6 +55,7 @@ class Phpcs extends AbstractExternalTask
         $resolver->addAllowedTypes('error_severity', ['null', 'int']);
         $resolver->addAllowedTypes('warning_severity', ['null', 'int']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
+        $resolver->addAllowedTypes('use_cmd_tmp_file', ['bool']);
 
         return $resolver;
     }
@@ -96,6 +98,10 @@ class Phpcs extends AbstractExternalTask
         $arguments->addFiles($files);
 
         $process = $this->processBuilder->buildProcess($arguments);
+        if ($config['use_cmd_tmp_file']) {
+            $process = $this->processBuilder->proxyThroughTmpFile($process);
+        }
+        $process->run();
         $process->run();
 
         if (!$process->isSuccessful()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #523

When running grump on an entire codebase instead of only on commit files, phpcs and phplint tasks receive a huge string of files, making the command too long for CLI.

To bypass this, write the command to a file and execute this.

Current implementation will only work on *nix, since it executes the file with `sh`