### PR TITLE
Make detection of strict types compatible with PhpParser 4.

### DIFF
--- a/src/Parser/Php/Visitor/DeclareStrictTypesVisitor.php
+++ b/src/Parser/Php/Visitor/DeclareStrictTypesVisitor.php
@@ -23,7 +23,12 @@ class DeclareStrictTypesVisitor extends AbstractVisitor
         }
 
         foreach ($node->declares as $id => $declare) {
-            if ($declare->key !== 'strict_types') {
+            // In PhpParser 3 and lower the key used in a `declare()` statement
+            // is represented as a string value. Starting with PhpParser 4 this
+            // key is represented by a 'PhpParser\Node\Identifier' object. To
+            // support backwards compatibility with older versions the object
+            // can be cast to a string to get the original string value.
+            if ((string) $declare->key !== 'strict_types') {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #508 

As described in #508 the visitor that checks the `declare(strict_types = 1);` directive currently only works with PhpParser 3 and below, and always fails on PhpParser 4.

This PR makes sure it is compatible with PhpParser 4 and above.