### PR TITLE
Allow to filter with a regex pattern with the addition of whitelist pattern option to Yaml Lint task

### DIFF
--- a/doc/tasks/yamllint.md
+++ b/doc/tasks/yamllint.md
@@ -8,11 +8,24 @@ It lives under the `yamllint` namespace and has following configurable parameter
 parameters:
     tasks:
         yamllint:
+            whitelist_patterns: []
             ignore_patterns: []
             object_support: false
             exception_on_invalid_type: false
             parse_constant: false
             parse_custom_tags: false
+```
+
+**whitelist_patterns**
+
+*Default: []*
+
+This is a list of regex patterns that will filter files to validate. With this option you can skip files like tests. This option is used in relation with the parameter `triggered_by`.
+For example: whitelist files in `src/FolderA/` and `src/FolderB/` you can use 
+```yml
+whitelist_patterns:
+  - /^src\/FolderA\/(.*)/
+  - /^src\/FolderB\/(.*)/
 ```
 
 **ignore_patterns**

--- a/spec/Task/YamlLintSpec.php
+++ b/spec/Task/YamlLintSpec.php
@@ -40,6 +40,7 @@ class YamlLintSpec extends AbstractLinterTaskSpec
     {
         $options = $this->getConfigurableOptions();
         $options->shouldBeAnInstanceOf(OptionsResolver::class);
+        $options->getDefinedOptions()->shouldContain('whitelist_patterns');
         $options->getDefinedOptions()->shouldContain('object_support');
         $options->getDefinedOptions()->shouldContain('exception_on_invalid_type');
         $options->getDefinedOptions()->shouldContain('parse_custom_tags');

--- a/src/Task/YamlLint.php
+++ b/src/Task/YamlLint.php
@@ -56,7 +56,9 @@ class YamlLint extends AbstractLinterTask
      */
     public function run(ContextInterface $context)
     {
+        // @TODO : Whitelist here
         $files = $context->getFiles()->name('/\.(yaml|yml)$/i');
+
         if (0 === count($files)) {
             return TaskResult::createSkipped($this, $context);
         }

--- a/src/Task/YamlLint.php
+++ b/src/Task/YamlLint.php
@@ -33,12 +33,14 @@ class YamlLint extends AbstractLinterTask
             'exception_on_invalid_type' => false,
             'parse_constant' => false,
             'parse_custom_tags' => false,
+            'whitelist_patterns' => [],
         ]);
 
         $resolver->addAllowedTypes('object_support', ['bool']);
         $resolver->addAllowedTypes('exception_on_invalid_type', ['bool']);
         $resolver->addAllowedTypes('parse_constant', ['bool']);
         $resolver->addAllowedTypes('parse_custom_tags', ['bool']);
+        $resolver->addAllowedTypes('whitelist_patterns', ['array']);
 
         return $resolver;
     }
@@ -56,14 +58,20 @@ class YamlLint extends AbstractLinterTask
      */
     public function run(ContextInterface $context)
     {
-        // @TODO : Whitelist here
-        $files = $context->getFiles()->name('/\.(yaml|yml)$/i');
+        /** @var array $config */
+        $config = $this->getConfiguration();
+        $whitelistPatterns = isset($config['whitelist_patterns']) ? $config['whitelist_patterns'] : [];
+        $extensionPattern = '/\.(yaml|yml)$/i';
 
+        if (0 === count($whitelistPatterns)) {
+            $files = $context->getFiles()->name($extensionPattern);
+        } else {
+            $files = $context->getFiles()->paths($whitelistPatterns)->name($extensionPattern);
+        }
         if (0 === count($files)) {
             return TaskResult::createSkipped($this, $context);
         }
 
-        $config = $this->getConfiguration();
         $this->linter->setObjectSupport($config['object_support']);
         $this->linter->setExceptionOnInvalidType($config['exception_on_invalid_type']);
         $this->linter->setParseCustomTags($config['parse_custom_tags']);

--- a/src/Task/YamlLint.php
+++ b/src/Task/YamlLint.php
@@ -2,6 +2,7 @@
 
 namespace GrumPHP\Task;
 
+use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
@@ -63,9 +64,9 @@ class YamlLint extends AbstractLinterTask
         $whitelistPatterns = isset($config['whitelist_patterns']) ? $config['whitelist_patterns'] : [];
         $extensionPattern = '/\.(yaml|yml)$/i';
 
-        if (0 === count($whitelistPatterns)) {
-            $files = $context->getFiles()->name($extensionPattern);
-        } else {
+        /** @var FilesCollection $files */
+        $files = $context->getFiles()->name($extensionPattern);
+        if (count($whitelistPatterns) >= 1) {
             $files = $context->getFiles()->paths($whitelistPatterns)->name($extensionPattern);
         }
         if (0 === count($files)) {

--- a/src/Task/YamlLint.php
+++ b/src/Task/YamlLint.php
@@ -61,13 +61,13 @@ class YamlLint extends AbstractLinterTask
     {
         /** @var array $config */
         $config = $this->getConfiguration();
-        $whitelistPatterns = isset($config['whitelist_patterns']) ? $config['whitelist_patterns'] : [];
-        $extensionPattern = '/\.(yaml|yml)$/i';
+        $whitelistPatterns = $config['whitelist_patterns'];
+        $extensions = '/\.(yaml|yml)$/i';
 
         /** @var FilesCollection $files */
-        $files = $context->getFiles()->name($extensionPattern);
+        $files = $context->getFiles()->name($extensions);
         if (count($whitelistPatterns) >= 1) {
-            $files = $context->getFiles()->paths($whitelistPatterns)->name($extensionPattern);
+            $files = $context->getFiles()->paths($whitelistPatterns)->name($extensions);
         }
         if (0 === count($files)) {
             return TaskResult::createSkipped($this, $context);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | [#527](https://github.com/phpro/grumphp/issues/527)

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
As for PRs : 
- [#160](https://github.com/phpro/grumphp/pull/160) 
- [#494](https://github.com/phpro/grumphp/pull/494) 
- [#496](https://github.com/phpro/grumphp/pull/496) 
- [#498](https://github.com/phpro/grumphp/pull/498) 

This PR add a new whitelist_patternsoption to Yamllint task. It will be used to filter files to be validated.

Example for a Symfony, validate PHP files only in src/ directory
``` yml
yamllint:
    ignore_patterns: []
    object_support: false
    exception_on_invalid_type: false
    parse_constant: false
    parse_custom_tags: false
    whitelist_patterns: ["^src/(.*)"]
```
<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:
- [ ] Is the README.md file updated?
- [ ] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpspec tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?
