### PR TITLE
Add more options for the 'phpcs' task, in particular the 'report' one.

### DIFF
--- a/doc/tasks/phpcs.md
+++ b/doc/tasks/phpcs.md
@@ -22,6 +22,8 @@ parameters:
             error_severity: ~
             warning_severity: ~
             tab_width: ~
+            report: full
+            report_width: ~
             whitelist_patterns: []
             encoding: ~
             ignore_patterns: []
@@ -75,6 +77,19 @@ By default, the standard will specify the optimal tab-width of the code. If you 
 *Default: null*
 
 The default encoding used by PHP_CodeSniffer (is ISO-8859-1).
+
+**report**
+
+*Default: full*
+
+The report type output by PHP_CodeSniffer, put `code` to see a code snippet of the offending code.
+Consult the [complete list](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-default-report-format) for more formats.
+
+**report_width**
+
+*Default: null*
+
+PHP_CodeSniffer will print all screen-based reports 80 characters wide. You may override this size so that long lines do not wrap.
 
 **whitelist_patterns**
 

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -41,7 +41,9 @@ class Phpcs extends AbstractExternalTask
             'severity' => null,
             'error_severity' => null,
             'warning_severity' => null,
-            'triggered_by' => ['php']
+            'triggered_by' => ['php'],
+            'report' => 'full',
+            'report_width' => null,
         ]);
 
         $resolver->addAllowedTypes('standard', ['null', 'string']);
@@ -54,6 +56,8 @@ class Phpcs extends AbstractExternalTask
         $resolver->addAllowedTypes('error_severity', ['null', 'int']);
         $resolver->addAllowedTypes('warning_severity', ['null', 'int']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
+        $resolver->addAllowedTypes('report', ['null', 'string']);
+        $resolver->addAllowedTypes('report_width', ['null', 'int']);
 
         return $resolver;
     }
@@ -91,7 +95,6 @@ class Phpcs extends AbstractExternalTask
 
         $arguments = $this->processBuilder->createArgumentsForCommand('phpcs');
         $arguments = $this->addArgumentsFromConfig($arguments, $config);
-        $arguments->add('--report-full');
         $arguments->add('--report-json');
         $arguments->addFiles($files);
 
@@ -125,6 +128,8 @@ class Phpcs extends AbstractExternalTask
         $arguments->addOptionalArgument('--standard=%s', $config['standard']);
         $arguments->addOptionalArgument('--tab-width=%s', $config['tab_width']);
         $arguments->addOptionalArgument('--encoding=%s', $config['encoding']);
+        $arguments->addOptionalArgument('--report=%s', $config['report']);
+        $arguments->addOptionalIntegerArgument('--report-width=%s', $config['report_width']);
         $arguments->addOptionalIntegerArgument('--severity=%s', $config['severity']);
         $arguments->addOptionalIntegerArgument('--error-severity=%s', $config['error_severity']);
         $arguments->addOptionalIntegerArgument('--warning-severity=%s', $config['warning_severity']);


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | none, direct PR

Adds two more options for the `phpcs` task, `report` and `report_width`which lets the final user choose values for these options that will be passed downwards to `phpcs`.

