### PR TITLE
Issue #532: Allow to set max_subject_width and max_body_width to 0

### DIFF
--- a/doc/tasks/git_commit_message.md
+++ b/doc/tasks/git_commit_message.md
@@ -49,13 +49,13 @@ Ensures that the commit message subject line is followed by a blank line.
 
 *Default: 72*
 
-Preferred limit on the commit message body lines.
+Preferred limit on the commit message body lines. Set to 0 to disable the check.
 
 **max_subject_width**
 
 *Default: 60*
 
-Preferred limit on the commit message subject line.
+Preferred limit on the commit message subject line. Set to 0 to disable the check.
 
 **matchers**
 

--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -166,19 +166,23 @@ class CommitMessage implements TaskInterface
         $lines = $this->getCommitMessageLinesWithoutComments($commitMessage);
 
         $subject = rtrim($lines[0]);
-        $maxSubjectWidth = $config['max_subject_width'] + $this->getSpecialPrefixLength($subject);
+        if ($config['max_subject_width'] > 0) {
+            $maxSubjectWidth = $config['max_subject_width'] + $this->getSpecialPrefixLength($subject);
 
-        if (mb_strlen($subject) > $maxSubjectWidth) {
-            $errors[] = sprintf('Please keep the subject <= %u characters.', $maxSubjectWidth);
+            if (mb_strlen($subject) > $maxSubjectWidth) {
+                $errors[] = sprintf('Please keep the subject <= %u characters.', $maxSubjectWidth);
+            }
         }
 
-        foreach (array_slice($lines, 2) as $index => $line) {
-            if (mb_strlen(rtrim($line)) > $config['max_body_width']) {
-                $errors[] = sprintf(
-                    'Line %u of commit message has > %u characters.',
-                    $index + 3,
-                    $config['max_body_width']
-                );
+        if ($config['max_body_width'] > 0) {
+            foreach (array_slice($lines, 2) as $index => $line) {
+                if (mb_strlen(rtrim($line)) > $config['max_body_width']) {
+                    $errors[] = sprintf(
+                        'Line %u of commit message has > %u characters.',
+                        $index + 3,
+                        $config['max_body_width']
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? |  no
| Documented?   | yes
| Fixed tickets | 532

The PR adds a simple check that allows users to set the max_subject_width and max_body_width variables from the git_commit_msg task to 0. Like this we allow them to disable the check altogether.
