### PR TITLE
feat: Add additional info parameter

### DIFF
--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -13,6 +13,7 @@ parameters:
     process_async_limit: 10
     process_async_wait: 1000
     process_timeout: 60
+    additonal_info: ~
     ascii:
         failed: resource/grumphp-grumpy.txt
         succeeded: resource/grumphp-happy.txt
@@ -107,6 +108,28 @@ The component will trigger a timeout after 60 seconds by default.
 If you've got tools that run more then 60 seconds, you can increase this parameter.
 It is also possible to disable the timeout by setting the value to `null`.
 When receiving a `Symfony\Component\Process\Exception\ProcessTimedOutException` during the execution of GrumPHP, you probably need to increment this setting.
+
+**additional_info**
+
+*Default: null*
+
+This parameter will display additional information at the end of a `success` *or* `error` task.
+
+```yaml
+# grumphp.yml
+parameters:
+  additional_info: "\nTo get full documentation for the project!\nVisit https://docs.example.com\n"
+```
+
+*Example Result:*
+```
+GrumPHP is sniffing your code!
+Running task 1/1: Phpcs... ✔
+
+To get full documentation for the project!
+Visit https://docs.example.com
+
+```
 
 **ascii**
 

--- a/resources/config/parameters.yml
+++ b/resources/config/parameters.yml
@@ -3,6 +3,7 @@ parameters:
   git_dir: .
   hooks_dir: ~
   hooks_preset: local
+  additional_info: ~
   tasks: []
   testsuites: []
   stop_on_failure: false

--- a/spec/Configuration/GrumPHPSpec.php
+++ b/spec/Configuration/GrumPHPSpec.php
@@ -136,4 +136,12 @@ class GrumPHPSpec extends ObjectBehavior
         $container->getParameter('grumphp.testsuites')->willReturn($testSuites = new TestSuiteCollection());
         $this->getTestSuites()->shouldBe($testSuites);
     }
+
+    function it_knows_the_additional_info(ContainerInterface $container)
+    {
+        $container->getParameter('additional_info')
+            ->willReturn('https://docs.example.com');
+
+        $this->getAdditionalInfo()->shouldReturn('https://docs.example.com');
+    }
 }

--- a/spec/Console/Helper/TaskRunnerHelperSpec.php
+++ b/spec/Console/Helper/TaskRunnerHelperSpec.php
@@ -39,6 +39,7 @@ class TaskRunnerHelperSpec extends ObjectBehavior
         $runnerContext->hasTestSuite()->willReturn(false);
         $runnerContext->skipSuccessOutput()->willReturn(false);
 
+        $config->getAdditionalInfo()->willReturn(null);
         $config->hideCircumventionTip()->willReturn(false);
     }
 

--- a/src/Configuration/GrumPHP.php
+++ b/src/Configuration/GrumPHP.php
@@ -102,6 +102,14 @@ class GrumPHP
     }
 
     /**
+     * @return null|string
+     */
+    public function getAdditionalInfo()
+    {
+        return $this->container->getParameter('additional_info');
+    }
+
+    /**
      * @return array
      */
     public function getRegisteredTasks()

--- a/src/Console/Helper/TaskRunnerHelper.php
+++ b/src/Console/Helper/TaskRunnerHelper.php
@@ -168,7 +168,9 @@ class TaskRunnerHelper extends Helper
      */
     private function returnAdditionalInfo(OutputInterface $output)
     {
-        is_null($this->config->getAdditionalInfo()) ?: $output->writeln($this->config->getAdditionalInfo());
+        if (null !== $this->config->getAdditionalInfo()) {
+            $output->writeln($this->config->getAdditionalInfo());
+        }
     }
 
     /**

--- a/src/Console/Helper/TaskRunnerHelper.php
+++ b/src/Console/Helper/TaskRunnerHelper.php
@@ -126,6 +126,8 @@ class TaskRunnerHelper extends Helper
             );
         }
 
+        $this->returnAdditionalInfo($output);
+
         return self::CODE_ERROR;
     }
 
@@ -145,6 +147,7 @@ class TaskRunnerHelper extends Helper
 
 
         $this->returnWarningMessages($output, $warnings);
+        $this->returnAdditionalInfo($output);
 
         return self::CODE_SUCCESS;
     }
@@ -158,6 +161,14 @@ class TaskRunnerHelper extends Helper
         foreach ($warningMessages as $warningMessage) {
             $output->writeln('<fg=yellow>' . $warningMessage . '</fg=yellow>');
         }
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    private function returnAdditionalInfo(OutputInterface $output)
+    {
+        is_null($this->config->getAdditionalInfo()) ?: $output->writeln($this->config->getAdditionalInfo());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | none

Adds the ability to set additional information to be displayed after tasks have finished. Is useful for displaying resources ie: documentation urls

**additional_info**

*Default: null*

This parameter will display additional information at the end of a `success` *or* `error` task.

```yaml
# grumphp.yml
parameters:
  additional_info: "\nTo get full documentation for the project\nVisit https://docs.example.com\n"
```

*Example Result:*
```
GrumPHP is sniffing your code!
Running task 1/1: Phpcs... ✔

To get full documentation for the project
Visit https://docs.example.com

```
