### PR TITLE
feat: Add option to disable all banners by setting ascii to null

### DIFF
--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -132,7 +132,15 @@ parameters:
             - resource/grumphp-happy3.txt
 ```
 
-To disable banner set ascii images path to `~`:
+To disable all banners set ascii to `~`:
+
+```yaml
+# grumphp.yml
+parameters:
+    ascii: ~
+```
+
+To disable a specific banner set ascii image path to `~`:
 
 ```yaml
 # grumphp.yml

--- a/src/Configuration/GrumPHP.php
+++ b/src/Configuration/GrumPHP.php
@@ -166,7 +166,7 @@ class GrumPHP
      */
     public function getAsciiContentPath($resource)
     {
-        if (is_null($this->container->getParameter('ascii'))) {
+        if (null === $this->container->getParameter('ascii')) {
             return null;
         }
 

--- a/src/Configuration/GrumPHP.php
+++ b/src/Configuration/GrumPHP.php
@@ -166,6 +166,10 @@ class GrumPHP
      */
     public function getAsciiContentPath($resource)
     {
+        if (is_null($this->container->getParameter('ascii'))) {
+            return null;
+        }
+
         $paths = $this->container->getParameter('ascii');
         if (!array_key_exists($resource, $paths)) {
             return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | None

To disable all banners set ascii to `~`:

```yaml
# grumphp.yml
parameters:
    ascii: ~
```
