### PR TITLE
Commit Message Features and Add new Util class

### DIFF
--- a/doc/tasks/git_commit_message.md
+++ b/doc/tasks/git_commit_message.md
@@ -10,8 +10,12 @@ parameters:
         git_commit_message:
             allow_empty_message: false
             enforce_capitalized_subject: true
+            enforce_no_subject_punctuations: false
             enforce_no_subject_trailing_period: true
             enforce_single_lined_subject: true
+            enforce_type_scope_conventions: false
+            types: []
+            scopes: []
             max_body_width: 72
             max_subject_width: 60
             matchers:
@@ -32,6 +36,12 @@ Controls whether or not empty commit messages are allowed.
 *Default: true*
 
 Ensures that the commit message subject line starts with a capital letter.
+
+**enforce_no_subject_punctuations**
+
+*Default: false*
+
+Ensures that the commit message subject line doesn't have any punctuations characters.
 
 **enforce_no_subject_trailing_period**
 
@@ -95,3 +105,65 @@ additional_modifiers: 'u'
 
 additional_modifiers: 'xu'
 ```
+
+**enforce_type_scope_conventions**
+
+*Default: false*
+
+Enable a commonly used convention for the subject line.
+
+Format is as follows:
+```
+type[(scope)]: subject
+```
+*The scope is optional*
+
+Good examples:
+```
+fix: Security issue with password hashing
+fix(Password): Security issue with password hashing  
+```
+
+**types**
+
+*Default: []*
+
+*To be used when `enforce_type_scope_conventions: true`*
+
+Specify a list of acceptable types. Default allows ***all*** types.
+
+Add one or multiple types like:
+```yaml
+types:
+    - build
+    - ci
+    - chore
+    - docs
+    - feat
+    - fix
+    - perf
+    - refactor
+    - revert
+    - style
+    - test
+```
+
+**scopes**
+
+*Default: []*
+
+*To be used when `enforce_type_scope_conventions: true`*
+
+Specify a list of acceptable scopes. Default allows ***all*** scopes.
+
+Add one or multiple scopes like:
+```yaml
+scopes:
+    - api
+    - index
+    - user
+    - language
+    - browser
+    - environment
+```
+

--- a/src/Util/Str.php
+++ b/src/Util/Str.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GrumPHP\Util;
+
+class Str
+{
+    public static function contains($haystack, $needles)
+    {
+        foreach ((array) $needles as $needle) {
+            if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | None

This PR addresses a few things:

## New String Helper Util Class
**Str::contains($haystack, $needles)**
```php
// Can pass an `array` of needles or a single `string`
Str::contains($subject, ['.', '!', '?', ','])
Str::contains($subject, '!')
```

## The ability to `enforce no subject punctuation`

**enforce_no_subject_punctuations**

*Default: false*

Ensures that the commit message subject line doesn't have any punctuations characters.

## The ability to `Enforce Type Scope Conventions`
I'm sure you know of this convention, but just in-case you don't ...

**enforce_type_scope_conventions**

*Default: false*

Enable a commonly used convention for the subject line.

Format is as follows:
```
type[(scope)]: subject
```
*The scope is optional*

Good examples:
```
fix: Security issue with password hashing
fix(Password): Security issue with password hashing  
```

**types**

*Default: []*

*To be used when `enforce_type_scope_conventions: true`*

Specify a list of acceptable types. Default allows ***all*** types.

Add one or multiple types like:
```yaml
types:
    - build
    - ci
    - chore
    - docs
    - feat
    - fix
    - perf
    - refactor
    - revert
    - style
    - test
```

**scopes**

*Default: []*

*To be used when `enforce_type_scope_conventions: true`*

Specify a list of acceptable scopes. Default allows ***all*** scopes.

Add one or multiple scopes like:
```yaml
scopes:
    - api
    - index
    - user
    - language
    - browser
    - environment
```