### PR TITLE
Allow PHPLint to handle large number of files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/filesystem": "~2.7|~3.0|~4.0",
         "symfony/finder": "~2.7|~3.0|~4.0",
         "symfony/options-resolver": "~2.7|~3.0|~4.0",
-        "symfony/process": "~2.7|~3.0|~4.0",
+        "symfony/process": "~3.2|~4.0",
         "symfony/yaml": "~2.7|~3.0|~4.0"
     },
     "require-dev": {

--- a/spec/Task/PhpLintSpec.php
+++ b/spec/Task/PhpLintSpec.php
@@ -15,6 +15,7 @@ use GrumPHP\Task\PhpLint;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Process\InputStream;
 use Symfony\Component\Process\Process;
 
 class PhpLintSpec extends ObjectBehavior
@@ -60,7 +61,9 @@ class PhpLintSpec extends ObjectBehavior
         $processBuilder->createArgumentsForCommand('parallel-lint')->willReturn($arguments);
         $processBuilder->buildProcess($arguments)->willReturn($process);
 
-        $process->run()->shouldBeCalled();
+        $process->setInput(null)->shouldBeCalled()->withArguments([new \Prophecy\Argument\Token\TypeToken(InputStream::class)]);
+        $process->start()->shouldBeCalled();
+        $process->wait()->shouldBeCalled();
         $process->isSuccessful()->willReturn(true);
 
         $context->getFiles()->willReturn(new FilesCollection([
@@ -78,7 +81,9 @@ class PhpLintSpec extends ObjectBehavior
         $processBuilder->createArgumentsForCommand('parallel-lint')->willReturn($arguments);
         $processBuilder->buildProcess($arguments)->willReturn($process);
 
-        $process->run()->shouldBeCalled();
+        $process->setInput(null)->shouldBeCalled()->withArguments([new \Prophecy\Argument\Token\TypeToken(InputStream::class)]);;
+        $process->start()->shouldBeCalled();
+        $process->wait()->shouldBeCalled();
         $process->isSuccessful()->willReturn(false);
 
         $context->getFiles()->willReturn(new FilesCollection([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | gsomoza/grumphp:phplint-input-stream
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | not needed
| Fixed tickets | none, but see #524

See #524: this task allows phplint to work with large number of files.