### PR TITLE
Fix issue when .git file has absolute path

### DIFF
--- a/src/Console/Helper/PathsHelper.php
+++ b/src/Console/Helper/PathsHelper.php
@@ -170,7 +170,8 @@ class PathsHelper extends Helper
         if (is_file($gitRepoPath)) {
             $fileContent = $this->fileSystem->readFromFileInfo(new SplFileInfo($gitRepoPath));
             if (preg_match('/gitdir:\s+(\S+)/', $fileContent, $matches)) {
-                return $this->getRelativePath($gitPath . $matches[1] . '/hooks/');
+                $relativePath = $this->getRelativePath($matches[1]);
+                return $this->getRelativePath($gitPath . $relativePath . '/hooks/');
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no

In the rare instance that a person has an absolute path in their .git file, grumphp fails to handle the issue.
This one-liner ensures that the path is always parsed as relative first.