### PR TITLE
Host our own version of the symfony XSDs

### DIFF
--- a/test/fixtures/linters/xml/xsd-url-invalid.xml
+++ b/test/fixtures/linters/xml/xsd-url-invalid.xml
@@ -2,7 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services
-            http://symfony.com/schema/dic/services/services-1.0.xsd"
+            https://gist.githubusercontent.com/veewee/6e65062d2db2795b5be80ef702a9bb11/raw/199e96652e2b06ee7faaadc1f430f86feca7925e/symfony-services.xsd"
 >
     <services>
         <service id="my_mailer" class="Acme\HelloBundle\Mailer">

--- a/test/fixtures/linters/xml/xsd-url-valid.xml
+++ b/test/fixtures/linters/xml/xsd-url-valid.xml
@@ -2,7 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services
-            http://symfony.com/schema/dic/services/services-1.0.xsd"
+            https://gist.githubusercontent.com/veewee/6e65062d2db2795b5be80ef702a9bb11/raw/199e96652e2b06ee7faaadc1f430f86feca7925e/symfony-services.xsd"
 >
     <services>
         <service id="my_mailer" class="Acme\HelloBundle\Mailer">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 

Currently tests are failing based on a XSD that isn't available anymore.
I've moved them to a gist which I won't remove.