### PR TITLE
Allow multi-tasking w/o dedicated class.

### DIFF
--- a/spec/Task/AntSpec.php
+++ b/spec/Task/AntSpec.php
@@ -24,6 +24,7 @@ class AntSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('ant')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('ant');
     }
 
     function it_is_initializable()

--- a/spec/Task/AtoumSpec.php
+++ b/spec/Task/AtoumSpec.php
@@ -24,6 +24,7 @@ class AtoumSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('atoum')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('atoum');
     }
 
     function it_is_initializable()

--- a/spec/Task/BehatSpec.php
+++ b/spec/Task/BehatSpec.php
@@ -24,6 +24,7 @@ class BehatSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('behat')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('behat');
     }
 
     function it_is_initializable()

--- a/spec/Task/BrunchSpec.php
+++ b/spec/Task/BrunchSpec.php
@@ -24,6 +24,7 @@ class BrunchSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('brunch')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('brunch');
     }
 
     function it_is_initializable()

--- a/spec/Task/CloverCoverageSpec.php
+++ b/spec/Task/CloverCoverageSpec.php
@@ -19,6 +19,7 @@ class CloverCoverageSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('clover_coverage')->willReturn([]);
         $this->beConstructedWith($grumPHP, new Filesystem());
+        $this->setName('clover_coverage');
     }
 
     function it_is_initializable()

--- a/spec/Task/CodeceptionSpec.php
+++ b/spec/Task/CodeceptionSpec.php
@@ -24,6 +24,7 @@ class CodeceptionSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('codeception')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('codeception');
     }
 
     function it_is_initializable()

--- a/spec/Task/ComposerRequireCheckerSpec.php
+++ b/spec/Task/ComposerRequireCheckerSpec.php
@@ -24,6 +24,7 @@ class ComposerRequireCheckerSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('composer_require_checker')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('composer_require_checker');
     }
 
     function it_is_initializable()

--- a/spec/Task/ComposerScriptSpec.php
+++ b/spec/Task/ComposerScriptSpec.php
@@ -24,6 +24,7 @@ class ComposerScriptSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('composer_script')->willReturn(['script' => 'test']);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('composer_script');
     }
 
     function it_is_initializable()

--- a/spec/Task/ComposerSpec.php
+++ b/spec/Task/ComposerSpec.php
@@ -25,6 +25,7 @@ class ComposerSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('composer')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter, $filesystem);
+        $this->setName('composer');
     }
 
     function it_is_initializable()

--- a/spec/Task/DeptracSpec.php
+++ b/spec/Task/DeptracSpec.php
@@ -24,6 +24,7 @@ class DeptracSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('deptrac')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('deptrac');
     }
 
     function it_is_initializable()

--- a/spec/Task/DoctrineOrmSpec.php
+++ b/spec/Task/DoctrineOrmSpec.php
@@ -24,6 +24,7 @@ class DoctrineOrmSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('doctrine_orm')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('doctrine_orm');
     }
 
     function it_is_initializable()

--- a/spec/Task/FileSizeSpec.php
+++ b/spec/Task/FileSizeSpec.php
@@ -22,6 +22,7 @@ class FileSizeSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('file_size')->willReturn([]);
         $this->beConstructedWith($grumPHP);
+        $this->setName('file_size');
     }
 
     function it_is_initializable()

--- a/spec/Task/GherkinSpec.php
+++ b/spec/Task/GherkinSpec.php
@@ -24,6 +24,7 @@ class GherkinSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('gherkin')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('gherkin');
     }
 
     function it_is_initializable()

--- a/spec/Task/Git/BlacklistSpec.php
+++ b/spec/Task/Git/BlacklistSpec.php
@@ -24,6 +24,7 @@ class BlacklistSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('git_blacklist')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter, $consoleIO);
+        $this->setName('git_blacklist');
     }
 
     function it_is_initializable()

--- a/spec/Task/Git/BranchNameSpec.php
+++ b/spec/Task/Git/BranchNameSpec.php
@@ -18,6 +18,7 @@ class BranchNameSpec extends ObjectBehavior
     function let(GrumPHP $grumPHP, Repository $repository)
     {
         $this->beConstructedWith($grumPHP, $repository);
+        $this->setName('git_branch_name');
         $grumPHP->getTaskConfiguration('git_branch_name')->willReturn([
             'matchers' => ['test', '*es*', 'te[s][t]', '/^te(.*)/', '/(.*)st$/', '/t(e|a)st/', 'TEST'],
             'additional_modifiers' => 'i',

--- a/spec/Task/Git/CommitMessageSpec.php
+++ b/spec/Task/Git/CommitMessageSpec.php
@@ -15,6 +15,7 @@ class CommitMessageSpec extends ObjectBehavior
     function let(GrumPHP $grumPHP)
     {
         $this->beConstructedWith($grumPHP);
+        $this->setName('git_commit_message');
         $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
             'allow_empty_message' => true,
             'enforce_capitalized_subject' => false,

--- a/spec/Task/GruntSpec.php
+++ b/spec/Task/GruntSpec.php
@@ -24,6 +24,7 @@ class GruntSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('grunt')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('grunt');
     }
 
     function it_is_initializable()

--- a/spec/Task/GulpSpec.php
+++ b/spec/Task/GulpSpec.php
@@ -24,6 +24,7 @@ class GulpSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('gulp')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('gulp');
     }
 
     function it_is_initializable()

--- a/spec/Task/InfectionSpec.php
+++ b/spec/Task/InfectionSpec.php
@@ -24,6 +24,7 @@ class InfectionSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('infection')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('infection');
     }
 
     function it_is_initializable()

--- a/spec/Task/JsonLintSpec.php
+++ b/spec/Task/JsonLintSpec.php
@@ -24,6 +24,7 @@ class JsonLintSpec extends AbstractLinterTaskSpec
     {
         $grumPHP->getTaskConfiguration('jsonlint')->willReturn([]);
         $this->beConstructedWith($grumPHP, $linter);
+        $this->setName('jsonlint');
     }
 
     function it_is_initializable()

--- a/spec/Task/KahlanSpec.php
+++ b/spec/Task/KahlanSpec.php
@@ -27,6 +27,7 @@ class KahlanSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('kahlan')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('kahlan');
     }
 
     function it_is_initializable()

--- a/spec/Task/MakeSpec.php
+++ b/spec/Task/MakeSpec.php
@@ -24,6 +24,7 @@ class MakeSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('make')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('make');
     }
 
     function it_is_initializable()

--- a/spec/Task/NpmScriptSpec.php
+++ b/spec/Task/NpmScriptSpec.php
@@ -24,6 +24,7 @@ class NpmScriptSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('npm_script')->willReturn(['script' => 'test', 'working_directory' => './']);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('npm_script');
     }
 
     function it_is_initializable()

--- a/spec/Task/PhanSpec.php
+++ b/spec/Task/PhanSpec.php
@@ -24,6 +24,7 @@ class PhanSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('phan')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('phan');
     }
 
     function it_is_initializable()

--- a/spec/Task/PhingSpec.php
+++ b/spec/Task/PhingSpec.php
@@ -24,6 +24,7 @@ class PhingSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('phing')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('phing');
     }
 
     function it_is_initializable()

--- a/spec/Task/Php7ccSpec.php
+++ b/spec/Task/Php7ccSpec.php
@@ -24,6 +24,7 @@ class Php7ccSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('php7cc')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('php7cc');
     }
 
     function it_is_initializable()

--- a/spec/Task/PhpCpdSpec.php
+++ b/spec/Task/PhpCpdSpec.php
@@ -25,6 +25,7 @@ class PhpCpdSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('phpcpd')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('phpcpd');
     }
 
     function it_is_initializable()

--- a/spec/Task/PhpCsFixerSpec.php
+++ b/spec/Task/PhpCsFixerSpec.php
@@ -31,6 +31,7 @@ class PhpCsFixerSpec extends ObjectBehavior
         $formatter->formatErrorMessage(Argument::cetera())->willReturn('');
 
         $this->beConstructedWith($grumPHP, $processBuilder, $processRunner, $formatter);
+        $this->setName('phpcsfixer');
     }
 
     function it_is_initializable()

--- a/spec/Task/PhpCsFixerV2Spec.php
+++ b/spec/Task/PhpCsFixerV2Spec.php
@@ -30,6 +30,7 @@ class PhpCsFixerV2Spec extends ObjectBehavior
         $formatter->formatErrorMessage(Argument::cetera())->willReturn('');
 
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('phpcsfixer2');
     }
 
     function it_is_initializable()

--- a/spec/Task/PhpLintSpec.php
+++ b/spec/Task/PhpLintSpec.php
@@ -23,6 +23,7 @@ class PhpLintSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('phplint')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('phplint');
     }
 
     function it_is_initializable()

--- a/spec/Task/PhpMdSpec.php
+++ b/spec/Task/PhpMdSpec.php
@@ -24,6 +24,7 @@ class PhpMdSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('phpmd')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('phpmd');
     }
 
     function it_is_initializable()

--- a/spec/Task/PhpMndSpec.php
+++ b/spec/Task/PhpMndSpec.php
@@ -24,6 +24,7 @@ class PhpMndSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('phpmnd')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('phpmnd');
     }
 
     function it_is_initializable()

--- a/spec/Task/PhpParserSpec.php
+++ b/spec/Task/PhpParserSpec.php
@@ -16,6 +16,7 @@ class PhpParserSpec extends AbstractParserTaskSpec
         $parser->isInstalled()->willReturn(true);
         $grumPHP->getTaskConfiguration('phpparser')->willReturn([]);
         $this->beConstructedWith($grumPHP, $parser);
+        $this->setName('phpparser');
     }
 
     function it_is_initializable()

--- a/spec/Task/PhpStanSpec.php
+++ b/spec/Task/PhpStanSpec.php
@@ -24,6 +24,7 @@ class PhpStanSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('phpstan')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('phpstan');
     }
 
     function it_is_initializable()

--- a/spec/Task/PhpVersionSpec.php
+++ b/spec/Task/PhpVersionSpec.php
@@ -21,6 +21,7 @@ class PhpVersionSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('phpversion')->willReturn([]);
         $this->beConstructedWith($grumPHP, $phpVersionUtility);
+        $this->setName('phpversion');
     }
 
     function it_is_initializable()

--- a/spec/Task/PhpcsSpec.php
+++ b/spec/Task/PhpcsSpec.php
@@ -24,6 +24,7 @@ class PhpcsSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('phpcs')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('phpcs');
     }
 
     function it_is_initializable()

--- a/spec/Task/PhpspecSpec.php
+++ b/spec/Task/PhpspecSpec.php
@@ -24,6 +24,7 @@ class PhpspecSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('phpspec')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('phpspec');
     }
 
     function it_is_initializable()

--- a/spec/Task/PhpunitSpec.php
+++ b/spec/Task/PhpunitSpec.php
@@ -24,6 +24,7 @@ class PhpunitSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('phpunit')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('phpunit');
     }
 
     function it_is_initializable()

--- a/spec/Task/ProgpilotSpec.php
+++ b/spec/Task/ProgpilotSpec.php
@@ -24,6 +24,7 @@ class ProgpilotSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('progpilot')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('progpilot');
     }
 
     function it_is_initializable()

--- a/spec/Task/PsalmSpec.php
+++ b/spec/Task/PsalmSpec.php
@@ -24,6 +24,7 @@ class PsalmSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration(Psalm::TASK_NAME)->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName(Psalm::TASK_NAME);
     }
 
     function it_is_initializable()

--- a/spec/Task/RoboSpec.php
+++ b/spec/Task/RoboSpec.php
@@ -24,6 +24,7 @@ class RoboSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('robo')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('robo');
     }
 
     function it_is_initializable()

--- a/spec/Task/SecurityCheckerSpec.php
+++ b/spec/Task/SecurityCheckerSpec.php
@@ -25,6 +25,7 @@ class SecurityCheckerSpec extends ObjectBehavior
     {
         $grumPHP->getTaskConfiguration('securitychecker')->willReturn([]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('securitychecker');
     }
 
     function it_is_initializable()

--- a/spec/Task/ShellSpec.php
+++ b/spec/Task/ShellSpec.php
@@ -26,6 +26,7 @@ class ShellSpec extends ObjectBehavior
             'scripts' => ['script.sh']
         ]);
         $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+        $this->setName('shell');
     }
 
     function it_is_initializable()

--- a/spec/Task/XmlLintSpec.php
+++ b/spec/Task/XmlLintSpec.php
@@ -24,6 +24,7 @@ class XmlLintSpec extends AbstractLinterTaskSpec
     {
         $grumPHP->getTaskConfiguration('xmllint')->willReturn([]);
         $this->beConstructedWith($grumPHP, $linter);
+        $this->setName('xmllint');
     }
 
     function it_is_initializable()

--- a/spec/Task/YamlLintSpec.php
+++ b/spec/Task/YamlLintSpec.php
@@ -24,6 +24,7 @@ class YamlLintSpec extends AbstractLinterTaskSpec
     {
         $grumPHP->getTaskConfiguration('yamllint')->willReturn([]);
         $this->beConstructedWith($grumPHP, $linter);
+        $this->setName('yamllint');
     }
 
     function it_is_initializable()

--- a/src/Configuration/Compiler/TaskCompilerPass.php
+++ b/src/Configuration/Compiler/TaskCompilerPass.php
@@ -48,7 +48,7 @@ class TaskCompilerPass implements CompilerPassInterface
             $tasksConfiguration[$configKey] = $taskConfig;
 
             // Add the task to the task runner:
-            $definition->addMethodCall('addTask', [new Reference($id)]);
+            $definition->addMethodCall('addTask', [new Reference($id), $configKey]);
         }
 
         sort($tasksRegistered);

--- a/src/Event/Subscriber/ProgressSubscriber.php
+++ b/src/Event/Subscriber/ProgressSubscriber.php
@@ -72,8 +72,9 @@ class ProgressSubscriber implements EventSubscriberInterface
      */
     public function advanceProgress(TaskEvent $event)
     {
-        $taskReflection = new ReflectionClass($event->getTask());
-        $taskName = $taskReflection->getShortName();
+        $task = $event->getTask();
+        $taskReflection = new ReflectionClass($task);
+        $taskName = $taskReflection->getShortName() . ' (' . $task->getName() . ')';
 
         $this->progressBar->setFormat($this->progressFormat);
         $this->progressBar->setMessage($taskName);

--- a/src/Runner/TaskRunner.php
+++ b/src/Runner/TaskRunner.php
@@ -49,13 +49,16 @@ class TaskRunner
 
     /**
      * @param TaskInterface $task
+     * @param string $configKey
      */
-    public function addTask(TaskInterface $task)
+    public function addTask(TaskInterface $task, $configKey = NULL)
     {
         if ($this->tasks->contains($task)) {
             return;
         }
-
+        if ($configKey !== NULL && method_exists($task, 'setName')) {
+            $task->setName($configKey);
+        }
         $this->tasks->add($task);
     }
 

--- a/src/Runner/TaskRunner.php
+++ b/src/Runner/TaskRunner.php
@@ -51,12 +51,12 @@ class TaskRunner
      * @param TaskInterface $task
      * @param string $configKey
      */
-    public function addTask(TaskInterface $task, $configKey = NULL)
+    public function addTask(TaskInterface $task, $configKey = null)
     {
         if ($this->tasks->contains($task)) {
             return;
         }
-        if ($configKey !== NULL && method_exists($task, 'setName')) {
+        if ($configKey !== null && method_exists($task, 'setName')) {
             $task->setName($configKey);
         }
         $this->tasks->add($task);

--- a/src/Task/AbstractExternalTask.php
+++ b/src/Task/AbstractExternalTask.php
@@ -8,6 +8,8 @@ use GrumPHP\Process\ProcessBuilder;
 
 abstract class AbstractExternalTask implements TaskInterface
 {
+    use TraitTaskName;
+
     /**
      * @var GrumPHP
      */

--- a/src/Task/AbstractLinterTask.php
+++ b/src/Task/AbstractLinterTask.php
@@ -11,6 +11,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 abstract class AbstractLinterTask implements TaskInterface
 {
+    use TraitTaskName;
+
     /**
      * @var GrumPHP
      */

--- a/src/Task/AbstractParserTask.php
+++ b/src/Task/AbstractParserTask.php
@@ -11,6 +11,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 abstract class AbstractParserTask implements TaskInterface
 {
+    use TraitTaskName;
+
     /**
      * @var GrumPHP
      */

--- a/src/Task/AbstractPhpCsFixerTask.php
+++ b/src/Task/AbstractPhpCsFixerTask.php
@@ -18,6 +18,8 @@ use GrumPHP\Task\Context\RunContext;
  */
 abstract class AbstractPhpCsFixerTask implements TaskInterface
 {
+    use TraitTaskName;
+
     /**
      * @var GrumPHP
      */

--- a/src/Task/Ant.php
+++ b/src/Task/Ant.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Ant extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'ant';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Atoum.php
+++ b/src/Task/Atoum.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Atoum extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'atoum';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Behat.php
+++ b/src/Task/Behat.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Behat extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'behat';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Brunch.php
+++ b/src/Task/Brunch.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Brunch extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'brunch';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/CloverCoverage.php
+++ b/src/Task/CloverCoverage.php
@@ -17,6 +17,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class CloverCoverage implements TaskInterface
 {
+    use TraitTaskName;
+
     /**
      * @var GrumPHP
      */
@@ -45,14 +47,6 @@ class CloverCoverage implements TaskInterface
         $configured = $this->grumPHP->getTaskConfiguration($this->getName());
 
         return $this->getConfigurableOptions()->resolve($configured);
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'clover_coverage';
     }
 
     /**

--- a/src/Task/Codeception.php
+++ b/src/Task/Codeception.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Codeception extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'codeception';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Composer.php
+++ b/src/Task/Composer.php
@@ -42,14 +42,6 @@ class Composer extends AbstractExternalTask
     }
 
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'composer';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/ComposerRequireChecker.php
+++ b/src/Task/ComposerRequireChecker.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ComposerRequireChecker extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'composer_require_checker';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/ComposerScript.php
+++ b/src/Task/ComposerScript.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ComposerScript extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'composer_script';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Deptrac.php
+++ b/src/Task/Deptrac.php
@@ -15,14 +15,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Deptrac extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'deptrac';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/DoctrineOrm.php
+++ b/src/Task/DoctrineOrm.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class DoctrineOrm extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'doctrine_orm';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/FileSize.php
+++ b/src/Task/FileSize.php
@@ -11,6 +11,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FileSize implements TaskInterface
 {
+    use TraitTaskName;
+
     /**
      * @var GrumPHP
      */
@@ -22,14 +24,6 @@ class FileSize implements TaskInterface
     public function __construct(GrumPHP $grumPHP)
     {
         $this->grumPHP = $grumPHP;
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'file_size';
     }
 
     /**

--- a/src/Task/Gherkin.php
+++ b/src/Task/Gherkin.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Gherkin extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'gherkin';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Git/Blacklist.php
+++ b/src/Task/Git/Blacklist.php
@@ -40,14 +40,6 @@ class Blacklist extends AbstractExternalTask
     }
 
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'git_blacklist';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Git/BranchName.php
+++ b/src/Task/Git/BranchName.php
@@ -4,6 +4,7 @@ namespace GrumPHP\Task\Git;
 
 use Gitonomy\Git\Exception\ProcessException;
 use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\TraitTaskName;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -19,6 +20,7 @@ use Gitonomy\Git\Repository;
  */
 class BranchName implements TaskInterface
 {
+    use TraitTaskName;
 
     /**
      * @var GrumPHP
@@ -37,14 +39,6 @@ class BranchName implements TaskInterface
     {
         $this->grumPHP = $grumPHP;
         $this->repository = $repository;
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'git_branch_name';
     }
 
     /**

--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -5,6 +5,7 @@ namespace GrumPHP\Task\Git;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\TraitTaskName;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitCommitMsgContext;
 use GrumPHP\Task\TaskInterface;
@@ -17,6 +18,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class CommitMessage implements TaskInterface
 {
+    use TraitTaskName;
+
     /**
      * @var GrumPHP
      */
@@ -28,14 +31,6 @@ class CommitMessage implements TaskInterface
     public function __construct(GrumPHP $grumPHP)
     {
         $this->grumPHP = $grumPHP;
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'git_commit_message';
     }
 
     /**

--- a/src/Task/Grunt.php
+++ b/src/Task/Grunt.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Grunt extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'grunt';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Gulp.php
+++ b/src/Task/Gulp.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Gulp extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'gulp';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Infection.php
+++ b/src/Task/Infection.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Infection extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'infection';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/JsonLint.php
+++ b/src/Task/JsonLint.php
@@ -15,14 +15,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class JsonLint extends AbstractLinterTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'jsonlint';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Kahlan.php
+++ b/src/Task/Kahlan.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Kahlan extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'kahlan';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Make.php
+++ b/src/Task/Make.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Make extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'make';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/NpmScript.php
+++ b/src/Task/NpmScript.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class NpmScript extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'npm_script';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Phan.php
+++ b/src/Task/Phan.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Phan extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'phan';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Phing.php
+++ b/src/Task/Phing.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Phing extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'phing';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Php7cc.php
+++ b/src/Task/Php7cc.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Php7cc extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'php7cc';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/PhpCpd.php
+++ b/src/Task/PhpCpd.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class PhpCpd extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'phpcpd';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/PhpCsFixer.php
+++ b/src/Task/PhpCsFixer.php
@@ -13,14 +13,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class PhpCsFixer extends AbstractPhpCsFixerTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'phpcsfixer';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/PhpCsFixerV2.php
+++ b/src/Task/PhpCsFixerV2.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class PhpCsFixerV2 extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'phpcsfixer2';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/PhpLint.php
+++ b/src/Task/PhpLint.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class PhpLint extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'phplint';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/PhpMd.php
+++ b/src/Task/PhpMd.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class PhpMd extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'phpmd';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/PhpMnd.php
+++ b/src/Task/PhpMnd.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class PhpMnd extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'phpmnd';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/PhpParser.php
+++ b/src/Task/PhpParser.php
@@ -17,14 +17,6 @@ class PhpParser extends AbstractParserTask
     const KIND_PHP7 = 'php7';
 
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'phpparser';
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getConfigurableOptions()

--- a/src/Task/PhpStan.php
+++ b/src/Task/PhpStan.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class PhpStan extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'phpstan';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/PhpVersion.php
+++ b/src/Task/PhpVersion.php
@@ -16,6 +16,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class PhpVersion implements TaskInterface
 {
+    use TraitTaskName;
+
     /**
      * @var PhpVersionUtility
      */
@@ -35,6 +37,32 @@ class PhpVersion implements TaskInterface
     {
         $this->grumPHP = $grumPHP;
         $this->phpVersionUtility = $phpVersionUtility;
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfiguration()
+    {
+        $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+
+        return $this->getConfigurableOptions()->resolve($configured);
+    }
+
+    /**
+     * @return OptionsResolver
+     */
+    public function getConfigurableOptions()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults(
+          [
+            'project' => null,
+          ]
+        );
+        $resolver->addAllowedTypes('project', ['null', 'string']);
+
+        return $resolver;
     }
 
     /**
@@ -78,39 +106,5 @@ class PhpVersion implements TaskInterface
         }
 
         return TaskResult::createPassed($this, $context);
-    }
-
-    /**
-     * @return array
-     */
-    public function getConfiguration()
-    {
-        $configured = $this->grumPHP->getTaskConfiguration($this->getName());
-
-        return $this->getConfigurableOptions()->resolve($configured);
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'phpversion';
-    }
-
-    /**
-     * @return OptionsResolver
-     */
-    public function getConfigurableOptions()
-    {
-        $resolver = new OptionsResolver();
-        $resolver->setDefaults(
-            [
-                'project' => null,
-            ]
-        );
-        $resolver->addAllowedTypes('project', ['null', 'string']);
-
-        return $resolver;
     }
 }

--- a/src/Task/PhpVersion.php
+++ b/src/Task/PhpVersion.php
@@ -55,11 +55,9 @@ class PhpVersion implements TaskInterface
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(
-          [
+        $resolver->setDefaults([
             'project' => null,
-          ]
-        );
+        ]);
         $resolver->addAllowedTypes('project', ['null', 'string']);
 
         return $resolver;

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -18,14 +18,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Phpcs extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'phpcs';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Phpspec.php
+++ b/src/Task/Phpspec.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Phpspec extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'phpspec';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Phpunit.php
+++ b/src/Task/Phpunit.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Phpunit extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'phpunit';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Progpilot.php
+++ b/src/Task/Progpilot.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Progpilot extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'progpilot';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/Psalm.php
+++ b/src/Task/Psalm.php
@@ -19,14 +19,6 @@ class Psalm extends AbstractExternalTask
     /**
      * {@inheritdoc}
      */
-    public function getName()
-    {
-        return self::TASK_NAME;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();

--- a/src/Task/Robo.php
+++ b/src/Task/Robo.php
@@ -14,14 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Robo extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'robo';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/SecurityChecker.php
+++ b/src/Task/SecurityChecker.php
@@ -16,14 +16,6 @@ class SecurityChecker extends AbstractExternalTask
     /**
      * {@inheritdoc}
      */
-    public function getName()
-    {
-        return 'securitychecker';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getConfigurableOptions()
     {
         $resolver = new OptionsResolver();

--- a/src/Task/Shell.php
+++ b/src/Task/Shell.php
@@ -15,14 +15,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Shell extends AbstractExternalTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'shell';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/TraitTaskName.php
+++ b/src/Task/TraitTaskName.php
@@ -15,7 +15,8 @@ trait TraitTaskName
     /**
      * @param string $name
      */
-    public function setName($name) {
+    public function setName($name)
+    {
         $this->name = $name;
     }
 

--- a/src/Task/TraitTaskName.php
+++ b/src/Task/TraitTaskName.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace GrumPHP\Task;
+
+/**
+ * Trait TraitTaskName
+ */
+trait TraitTaskName
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @param string $name
+     */
+    public function setName($name) {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/src/Task/XmlLint.php
+++ b/src/Task/XmlLint.php
@@ -15,14 +15,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class XmlLint extends AbstractLinterTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'xmllint';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()

--- a/src/Task/YamlLint.php
+++ b/src/Task/YamlLint.php
@@ -16,14 +16,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class YamlLint extends AbstractLinterTask
 {
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'yamllint';
-    }
-
-    /**
      * @return OptionsResolver
      */
     public function getConfigurableOptions()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets |  #309, #501

No BC-break proposal to allow re-use of existing tasks without the need to create a package with new redundant classes, for more versatility.

The `grumphp.yml` file should like:

````yml
parameters:
  tasks:
    shell:
      scripts:
        - scripts/ci/global.sh
    shell.myspecifictask1:
      scripts:
        - scripts/ci/some-script.sh
      triggered_by: [scss]
    shell.myspecifictask2:
      scripts:
        - scripts/ci/some-other-script.sh
      triggered_by: [js]

services:
  task.shell.newservice1:
    parent: task.shell
    tags:
      - {name: grumphp.task, config: shell.myspecifictask1}
  task.shell.newservice2:
    parent: task.shell
    tags:
      - {name: grumphp.task, config: shell.myspecifictask2}
````

I'm just using the possibility of Symfony services to extend an existing service with the "parent" key (i'm absolutely not a Symfony expert, but it seems to be the best method). For me, it was making sense to keep this direction and re-use the existing possibilities offered by Symfony. It allows to almost not change the current code managing the service + tasks, very few lines.
[https://symfony.com/doc/current/service_container/parent_services.html](url)

When time of a BC break will come, `getName` should be added in the interface and the method_exists test for `addTask` in `TaskRunner` should be removed.

If accepted, I will add a new section in the existing "_Run the same task twice with different configuration_" of `tasks.md`.

Help / contribution welcome! Cheers.