### PR TITLE
Add a new extra parameter for task labels

### DIFF
--- a/src/Event/Subscriber/ProgressSubscriber.php
+++ b/src/Event/Subscriber/ProgressSubscriber.php
@@ -72,8 +72,12 @@ class ProgressSubscriber implements EventSubscriberInterface
      */
     public function advanceProgress(TaskEvent $event)
     {
-        $taskReflection = new ReflectionClass($event->getTask());
+        $task = $event->getTask();
+        $taskReflection = new ReflectionClass($task);
         $taskName = $taskReflection->getShortName();
+        if (method_exists($task, 'getExtraConfig') && $task->getExtraConfig('label')) {
+            $taskName = '[' . $taskName . '] ' . $task->getExtraConfig('label');
+        }
 
         $this->progressBar->setFormat($this->progressFormat);
         $this->progressBar->setMessage($taskName);

--- a/src/Task/AbstractExternalTask.php
+++ b/src/Task/AbstractExternalTask.php
@@ -8,6 +8,8 @@ use GrumPHP\Process\ProcessBuilder;
 
 abstract class AbstractExternalTask implements TaskInterface
 {
+    use TraitExtraConfigTask;
+
     /**
      * @var GrumPHP
      */
@@ -41,6 +43,7 @@ abstract class AbstractExternalTask implements TaskInterface
     public function getConfiguration()
     {
         $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+        $this->alterConfig($configured);
 
         return $this->getConfigurableOptions()->resolve($configured);
     }

--- a/src/Task/AbstractLinterTask.php
+++ b/src/Task/AbstractLinterTask.php
@@ -11,6 +11,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 abstract class AbstractLinterTask implements TaskInterface
 {
+    use TraitExtraConfigTask;
+
     /**
      * @var GrumPHP
      */
@@ -52,6 +54,7 @@ abstract class AbstractLinterTask implements TaskInterface
     public function getConfiguration()
     {
         $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+        $this->alterConfig($configured);
 
         return $this->getConfigurableOptions()->resolve($configured);
     }

--- a/src/Task/AbstractParserTask.php
+++ b/src/Task/AbstractParserTask.php
@@ -11,6 +11,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 abstract class AbstractParserTask implements TaskInterface
 {
+    use TraitExtraConfigTask;
+
     /**
      * @var GrumPHP
      */
@@ -60,6 +62,7 @@ abstract class AbstractParserTask implements TaskInterface
     public function getConfiguration()
     {
         $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+        $this->alterConfig($configured);
 
         return $this->getConfigurableOptions()->resolve($configured);
     }

--- a/src/Task/AbstractPhpCsFixerTask.php
+++ b/src/Task/AbstractPhpCsFixerTask.php
@@ -18,6 +18,8 @@ use GrumPHP\Task\Context\RunContext;
  */
 abstract class AbstractPhpCsFixerTask implements TaskInterface
 {
+    use TraitExtraConfigTask;
+
     /**
      * @var GrumPHP
      */
@@ -72,6 +74,7 @@ abstract class AbstractPhpCsFixerTask implements TaskInterface
     public function getConfiguration()
     {
         $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+        $this->alterConfig($configured);
 
         return $this->getConfigurableOptions()->resolve($configured);
     }

--- a/src/Task/CloverCoverage.php
+++ b/src/Task/CloverCoverage.php
@@ -17,6 +17,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class CloverCoverage implements TaskInterface
 {
+    use TraitExtraConfigTask;
+
     /**
      * @var GrumPHP
      */
@@ -43,6 +45,7 @@ class CloverCoverage implements TaskInterface
     public function getConfiguration()
     {
         $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+        $this->alterConfig($configured);
 
         return $this->getConfigurableOptions()->resolve($configured);
     }

--- a/src/Task/FileSize.php
+++ b/src/Task/FileSize.php
@@ -11,6 +11,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FileSize implements TaskInterface
 {
+    use TraitExtraConfigTask;
+
     /**
      * @var GrumPHP
      */
@@ -38,6 +40,7 @@ class FileSize implements TaskInterface
     public function getConfiguration()
     {
         $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+        $this->alterConfig($configured);
 
         return $this->getConfigurableOptions()->resolve($configured);
     }

--- a/src/Task/Git/BranchName.php
+++ b/src/Task/Git/BranchName.php
@@ -4,6 +4,7 @@ namespace GrumPHP\Task\Git;
 
 use Gitonomy\Git\Exception\ProcessException;
 use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\TraitExtraConfigTask;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -19,6 +20,7 @@ use Gitonomy\Git\Repository;
  */
 class BranchName implements TaskInterface
 {
+    use TraitExtraConfigTask;
 
     /**
      * @var GrumPHP
@@ -53,6 +55,7 @@ class BranchName implements TaskInterface
     public function getConfiguration()
     {
         $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+        $this->alterConfig($configured);
 
         return $this->getConfigurableOptions()->resolve($configured);
     }

--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -5,6 +5,7 @@ namespace GrumPHP\Task\Git;
 use GrumPHP\Configuration\GrumPHP;
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\TraitExtraConfigTask;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitCommitMsgContext;
 use GrumPHP\Task\TaskInterface;
@@ -17,6 +18,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class CommitMessage implements TaskInterface
 {
+    use TraitExtraConfigTask;
+
     /**
      * @var GrumPHP
      */
@@ -44,6 +47,7 @@ class CommitMessage implements TaskInterface
     public function getConfiguration()
     {
         $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+        $this->alterConfig($configured);
 
         return $this->getConfigurableOptions()->resolve($configured);
     }

--- a/src/Task/PhpVersion.php
+++ b/src/Task/PhpVersion.php
@@ -16,6 +16,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class PhpVersion implements TaskInterface
 {
+    use TraitExtraConfigTask;
+
     /**
      * @var PhpVersionUtility
      */
@@ -86,6 +88,7 @@ class PhpVersion implements TaskInterface
     public function getConfiguration()
     {
         $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+        $this->alterConfig($configured);
 
         return $this->getConfigurableOptions()->resolve($configured);
     }

--- a/src/Task/TraitExtraConfigTask.php
+++ b/src/Task/TraitExtraConfigTask.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace GrumPHP\Task;
+
+trait TraitExtraConfigTask
+{
+  /**
+   * @var boolean|array
+   */
+  protected $extraConfig;
+  
+  /**
+   * @return string
+   */
+  public function getExtraConfig($key)
+  {
+    if (!$this->extraConfig && $this->extraConfig !== FALSE) {
+      $this->extraConfig = FALSE;
+      $configured = $this->grumPHP->getTaskConfiguration($this->getName());
+      if (isset($configured['_extra'])) {
+        $this->extraConfig = $configured['_extra'];
+      }
+    }
+
+    return $this->extraConfig && isset($this->extraConfig[$key]) ? $this->extraConfig[$key] : NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterConfig(&$config)
+  {
+    if (array_key_exists('_extra', $config)) {
+      unset($config['_extra']);
+    }
+  }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | none

Following #565, add the possibility to define a custom label for more readability when multiple tasks are defined.

Usage in `grumphp.yml` would be:

````yml
parameters:
  tasks:
    shell:
      scripts:
        - scripts/ci/basic.sh
      _extra:
        label: 'Shell basic'
````
