### PR TITLE
Add the files as argument for Shell task

### DIFF
--- a/spec/Task/ShellSpec.php
+++ b/spec/Task/ShellSpec.php
@@ -44,6 +44,9 @@ class ShellSpec extends ObjectBehavior
         $options->shouldBeAnInstanceOf(OptionsResolver::class);
         $options->getDefinedOptions()->shouldContain('scripts');
         $options->getDefinedOptions()->shouldContain('triggered_by');
+        $options->getDefinedOptions()->shouldContain('include_files');
+        $options->getDefinedOptions()->shouldContain('include_files_with_comma');
+        $options->getDefinedOptions()->shouldContain('include_files_parameter');
     }
 
     function it_should_normalize_the_scripts_option()

--- a/src/Task/Shell.php
+++ b/src/Task/Shell.php
@@ -2,6 +2,7 @@
 
 namespace GrumPHP\Task;
 
+use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
@@ -30,11 +31,18 @@ class Shell extends AbstractExternalTask
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
             'scripts' => [],
-            'triggered_by' => ['php']
+            'triggered_by' => ['php'],
+            'include_files' => false,
+            'include_files_with_comma' => true,
+            'include_files_parameter' => null,
         ]);
 
         $resolver->addAllowedTypes('scripts', ['array']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
+        $resolver->addAllowedTypes('include_files', ['bool']);
+        $resolver->addAllowedTypes('include_files_with_comma', ['bool']);
+        $resolver->addAllowedTypes('include_files_parameter', ['null', 'string']);
+
         $resolver->setNormalizer('scripts', function ($resolver, $scripts) {
             return array_map(function ($script) {
                 return is_string($script) ? (array) $script : $script;
@@ -66,7 +74,7 @@ class Shell extends AbstractExternalTask
         $exceptions = [];
         foreach ($config['scripts'] as $script) {
             try {
-                $this->runShell($script);
+                $this->runShell($script, $files);
             } catch (RuntimeException $e) {
                 $exceptions[] = $e->getMessage();
             }
@@ -81,11 +89,26 @@ class Shell extends AbstractExternalTask
 
     /**
      * @param array $scriptArguments
+     * @param FilesCollection $files
      */
-    private function runShell(array $scriptArguments)
+    private function runShell(array $scriptArguments, FilesCollection $files)
     {
+        $config = $this->getConfiguration();
+
         $arguments = $this->processBuilder->createArgumentsForCommand('sh');
         $arguments->addArgumentArray('%s', $scriptArguments);
+
+        if ($config['include_files']) {
+            if ($config['include_files_parameter'] !== null) {
+                $arguments->addArgumentWithCommaSeparatedFiles($config['include_files_parameter'] . '=%s', $files);
+            } else {
+                if ($config['include_files_with_comma']) {
+                    $arguments->addCommaSeparatedFiles($files);
+                } else {
+                    $arguments->addFiles($files);
+                }
+            }
+        }
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | none

Add the possibility to append the files as an argument for the running scripts of Shell tasks.

**3 new options:** 

- include_files: append the files or not for the defined scripts / FALSE (default)
- include_files_parameter : name of the files argument if needed
- include_files_with_comma: files argument separated with a comma or not, if not, each file become a new argument for the script / TRUE (default)

**Examples:**

````yml
parameters:
  tasks:
    shell:
      scripts:
        - my_script
      include_files: true
````
Will be: `/bin/sh my_script file1,file2,...`

````yml
parameters:
  tasks:
    shell:
      scripts:
        - my_script
      include_files: true
      include_files_with_comma: false
````
Will be: `/bin/sh my_script file1 file2 ...`

````yml
parameters:
  tasks:
    shell:
      scripts:
        - my_script
      include_files: true
      include_files_parameter: 'arg-name'
````
Will be: `/bin/sh my_script arg-name=file1,file2,...`

