### PR TITLE
Fix travis composer cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 
 cache:
   directories:
-    - .composer/cache
+    - ~/.cache/composer
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Composer's default cache directory has changed, and now the travis.yml reflects that.

| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | None

This patch is a trivial fix to GrumPHP's travis configuration and shouldn't affect anything otherwise.
