### PR TITLE
Remove deprecated warning for strpos with non-string needles

### DIFF
--- a/src/Locator/ConfigurationFile.php
+++ b/src/Locator/ConfigurationFile.php
@@ -72,7 +72,7 @@ class ConfigurationFile
      */
     private function locateConfigFileWithDistSupport($defaultPath)
     {
-        $distPath = (strpos($defaultPath, -5) !== '.dist') ? $defaultPath . '.dist' : $defaultPath;
+        $distPath = (substr($defaultPath, -5) !== '.dist') ? $defaultPath . '.dist' : $defaultPath;
         if ($this->filesystem->exists($defaultPath) || !$this->filesystem->exists($distPath)) {
             return $defaultPath;
         }


### PR DESCRIPTION
With PHP 7.3, the second parameter of `strpos` is always interpreted
as a string.
So the specification of -5 as second parameter, as in
`ConfigurationFile::locateConfigFileWithDistSupport`, deprecated.
At this point `substr` would be more obvious anyway and will be
replaced with this function.

| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Documented?   | /
| Fixed tickets | /
