### PR TITLE
Add memory-limit parameter to PhpStan

### DIFF
--- a/doc/tasks/phpstan.md
+++ b/doc/tasks/phpstan.md
@@ -20,6 +20,7 @@ parameters:
             force_patterns: []
             ignore_patterns: []
             triggered_by: ['php']
+            memory_limit: -1
 ```
 
 **autoload_file**
@@ -57,3 +58,9 @@ This is a list of patterns that will be ignored by phpstan. With this option you
 *Default: [php]*
 
 This is a list of extensions to be sniffed.
+
+**memory_limit**
+
+*Default: -1*
+
+With this parameter you can specify the memory limit.

--- a/doc/tasks/phpstan.md
+++ b/doc/tasks/phpstan.md
@@ -61,6 +61,6 @@ This is a list of extensions to be sniffed.
 
 **memory_limit**
 
-*Default: -1*
+*Default: null*
 
 With this parameter you can specify the memory limit.

--- a/spec/Task/PhpStanSpec.php
+++ b/spec/Task/PhpStanSpec.php
@@ -46,6 +46,7 @@ class PhpStanSpec extends ObjectBehavior
         $options->getDefinedOptions()->shouldContain('force_patterns');
         $options->getDefinedOptions()->shouldContain('level');
         $options->getDefinedOptions()->shouldContain('triggered_by');
+        $options->getDefinedOptions()->shouldContain('memory_limit');
     }
 
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)

--- a/src/Task/PhpStan.php
+++ b/src/Task/PhpStan.php
@@ -34,11 +34,13 @@ class PhpStan extends AbstractExternalTask
             'ignore_patterns' => [],
             'force_patterns' => [],
             'triggered_by' => ['php'],
+            'memory_limit' => '-1',
         ]);
 
         $resolver->addAllowedTypes('autoload_file', ['null', 'string']);
         $resolver->addAllowedTypes('configuration', ['null', 'string']);
         $resolver->addAllowedTypes('level', ['int']);
+        $resolver->addAllowedTypes('memory_limit', ['string']);
         $resolver->addAllowedTypes('ignore_patterns', ['array']);
         $resolver->addAllowedTypes('force_patterns', ['array']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
@@ -81,6 +83,7 @@ class PhpStan extends AbstractExternalTask
         $arguments->addOptionalArgument('--autoload-file=%s', $config['autoload_file']);
         $arguments->addOptionalArgument('--configuration=%s', $config['configuration']);
         $arguments->add(sprintf('--level=%u', $config['level']));
+        $arguments->add(sprintf('--memory-limit=%s', $config['memory_limit']));
         $arguments->add('--no-ansi');
         $arguments->add('--no-interaction');
         $arguments->add('--no-progress');

--- a/src/Task/PhpStan.php
+++ b/src/Task/PhpStan.php
@@ -82,8 +82,8 @@ class PhpStan extends AbstractExternalTask
         $arguments->add('analyse');
         $arguments->addOptionalArgument('--autoload-file=%s', $config['autoload_file']);
         $arguments->addOptionalArgument('--configuration=%s', $config['configuration']);
+        $arguments->addOptionalArgument('--memory-limit=%s', $config['memory_limit']);
         $arguments->add(sprintf('--level=%u', $config['level']));
-        $arguments->add(sprintf('--memory-limit=%s', $config['memory_limit']));
         $arguments->add('--no-ansi');
         $arguments->add('--no-interaction');
         $arguments->add('--no-progress');

--- a/src/Task/PhpStan.php
+++ b/src/Task/PhpStan.php
@@ -34,13 +34,13 @@ class PhpStan extends AbstractExternalTask
             'ignore_patterns' => [],
             'force_patterns' => [],
             'triggered_by' => ['php'],
-            'memory_limit' => '-1',
+            'memory_limit' => null
         ]);
 
         $resolver->addAllowedTypes('autoload_file', ['null', 'string']);
         $resolver->addAllowedTypes('configuration', ['null', 'string']);
+        $resolver->addAllowedTypes('memory_limit', ['null', 'string']);
         $resolver->addAllowedTypes('level', ['int']);
-        $resolver->addAllowedTypes('memory_limit', ['string']);
         $resolver->addAllowedTypes('ignore_patterns', ['array']);
         $resolver->addAllowedTypes('force_patterns', ['array']);
         $resolver->addAllowedTypes('triggered_by', ['array']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | none

This adds the option for PhpStan to set a memory-limit for the analyser.

