### PR TITLE
Fix issue with set global path (~/.composer/vendor/bin) for bin_dir (For PHPStorm)

### DIFF
--- a/src/Locator/ExternalCommand.php
+++ b/src/Locator/ExternalCommand.php
@@ -14,7 +14,7 @@ class ExternalCommand
 
     public function __construct(string $binDir, ExecutableFinder $executableFinder)
     {
-        $this->binDir = rtrim($binDir, '/\\');
+        $this->binDir = str_replace('~', $_SERVER['HOME'], rtrim($binDir, '/\\'));
         $this->executableFinder = $executableFinder;
     }
 

--- a/src/Locator/ExternalCommand.php
+++ b/src/Locator/ExternalCommand.php
@@ -14,7 +14,12 @@ class ExternalCommand
 
     public function __construct(string $binDir, ExecutableFinder $executableFinder)
     {
-        $this->binDir = str_replace('~', $_SERVER['HOME'], rtrim($binDir, '/\\'));
+        $this->binDir = rtrim($binDir, '/\\');
+
+        if (!empty($_SERVER['HOME'])) {
+            $this->binDir = str_replace('~', $_SERVER['HOME'], rtrim($binDir, '/\\'));
+        }
+        
         $this->executableFinder = $executableFinder;
     }
 
@@ -30,8 +35,8 @@ class ExternalCommand
 
         // Make sure to add unix-style directory separators if unix-mode is enforced
         if ($forceUnix) {
-            $parts = pathinfo($executable);
-            $executable = $parts['dirname'].'/'.$parts['filename'];
+            $parts      = pathinfo($executable);
+            $executable = $parts['dirname'] . '/' . $parts['filename'];
         }
 
         return $executable;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no

This PR fix issue for PHPStorm and global install tasks. For example, phpcs installed to ~/.composer/vendor

When we try to create the commit via PHPStorm UI form we'll get the error: 'The executable for "phpcs" could not be found.'. This PR fix it.

