### PR TITLE
Fixes #592: Exotic structure with Composer and GrumPHP in subfolder compared to GIT

### DIFF
--- a/resources/hooks/local/commit-msg
+++ b/resources/hooks/local/commit-msg
@@ -10,7 +10,7 @@ GIT_EMAIL=$(git config user.email)
 COMMIT_MSG_FILE=$1
 
 # Fetch the GIT diff and format it as command input:
-DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged | cat)
+DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged --src-prefix="a/${HOOK_PREFIX}" --dst-prefix="b/${HOOK_PREFIX}" | cat)
 
 # Run GrumPHP
 (cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | exec $(HOOK_COMMAND) "--git-user=$GIT_USER" "--git-email=$GIT_EMAIL" "$COMMIT_MSG_FILE")

--- a/resources/hooks/local/pre-commit
+++ b/resources/hooks/local/pre-commit
@@ -6,7 +6,7 @@
 #
 
 # Fetch the GIT diff and format it as command input:
-DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged | cat)
+DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged --src-prefix="a/${HOOK_PREFIX}" --dst-prefix="b/${HOOK_PREFIX}" | cat)
 
 # Run GrumPHP
 (cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | exec $(HOOK_COMMAND) '--skip-success-output')

--- a/resources/hooks/vagrant/commit-msg
+++ b/resources/hooks/vagrant/commit-msg
@@ -13,7 +13,7 @@ COMMIT_MSG_FILE=$1
 COMMIT_MSG=$(cat "${COMMIT_MSG_FILE}")
 
 # Fetch the GIT diff and format it as command input:
-DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged | cat)
+DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged --src-prefix="a/${HOOK_PREFIX}" --dst-prefix="b/${HOOK_PREFIX}" | cat)
 
 # Copy the commit message and run GrumPHP
 vagrant ssh --command '$(which sh)' << COMMANDS

--- a/resources/hooks/vagrant/pre-commit
+++ b/resources/hooks/vagrant/pre-commit
@@ -6,7 +6,7 @@
 #
 
 # Fetch the GIT diff and format it as command input:
-DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged | cat)
+DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged --src-prefix="a/${HOOK_PREFIX}" --dst-prefix="b/${HOOK_PREFIX}" | cat)
 
 # Run GrumPHP
 vagrant ssh --command '$(which sh)' << COMMANDS

--- a/src/Console/Command/Git/InitCommand.php
+++ b/src/Console/Command/Git/InitCommand.php
@@ -112,6 +112,7 @@ class InitCommand extends Command
     {
         $content = $this->filesystem->readFromFileInfo($templateFile);
         $replacements = [
+            '${HOOK_PREFIX}' => $this->paths()->getGitPrefix(),
             '${HOOK_EXEC_PATH}' => $this->paths()->getGitHookExecutionPath(),
             '$(HOOK_COMMAND)' => $this->generateHookCommand('git:'.$hook),
         ];

--- a/src/Console/Helper/PathsHelper.php
+++ b/src/Console/Helper/PathsHelper.php
@@ -137,6 +137,14 @@ class PathsHelper extends Helper
     }
 
     /**
+     * Returns the git dir from the configfile with ONLY a trailing slash, no leading slash.
+     */
+    public function getGitPrefix(): string
+    {
+        return trim($this->config->getGitDir(), '/') . '/';
+    }
+
+    /**
      * Returns the directory where the git hooks are installed.
      */
     public function getGitHooksDir(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #592

This PR will make sure the paths generated by the git diff command in the `commit-msg` and the `pre-commit` hooks will be relative to where GrumPHP is being executed based on the `grumphp.yml` config file, see #592 for a full description of the problem.