### PR TITLE
Add docker-compose support

### DIFF
--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -54,6 +54,7 @@ GrumPHP comes with following presets:
 
 - `local`: All checks will run on your local computer.
 - `vagrant`: All checks will run in your vagrant box (your certainly want to customize `git_hook_variables` default values in this case).
+- `docker-compose`: All checks will run in your docker-compose container (you need to specify container name in `git_hook_variables`)
 
 **git_hook_variables**
 
@@ -61,6 +62,7 @@ This parameter will allow you to customize git hooks templates. For now, those p
 
 -  `VAGRANT_HOST_DIR` : specifies the vagrant location on your host machine (_default_ `.`)
 -  `VAGRANT_PROJECT_DIR` : specifies the project dir location **inside** the vagrant box (_default_ `/var/www`)
+-  `DOCKER_COMPOSE_CONTAINER` : specifies the container name to use (*default `php`*)
 
 **stop_on_failure**
 

--- a/resources/hooks/docker-compose/commit-msg
+++ b/resources/hooks/docker-compose/commit-msg
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+#
+# Run the hook command.
+# Note: this will be replaced by the real command during copy.
+#
+
+GIT_USER=$(git config user.name)
+GIT_EMAIL=$(git config user.email)
+COMMIT_MSG_FILE=$1
+
+# Fetch the GIT diff and format it as command input:
+DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged | cat)
+
+# Run GrumPHP
+(cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | exec "docker-compose" "run" "--rm" "--no-deps" $(DOCKER_COMPOSE_CONTAINER) $(HOOK_COMMAND) "--git-user=\"$GIT_USER\"" "--git-email=$GIT_EMAIL" "$COMMIT_MSG_FILE")

--- a/resources/hooks/docker-compose/pre-commit
+++ b/resources/hooks/docker-compose/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+#
+# Run the hook command.
+# Note: this will be replaced by the real command during copy.
+#
+
+# Fetch the GIT diff and format it as command input:
+DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged | cat)
+
+# Run GrumPHP
+(cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | exec 'docker-compose' 'run' '--rm' '--no-deps' $(DOCKER_COMPOSE_CONTAINER) $(HOOK_COMMAND) '--skip-success-output')

--- a/spec/Configuration/GrumPHPSpec.php
+++ b/spec/Configuration/GrumPHPSpec.php
@@ -48,7 +48,8 @@ class GrumPHPSpec extends ObjectBehavior
     {
         $data = [
             'VAGRANT_HOST_DIR' => '.',
-            'VAGRANT_PROJECT_DIR' => '/var/www'
+            'VAGRANT_PROJECT_DIR' => '/var/www',
+            'DOCKER_COMPOSE_CONTAINER' => 'php'
         ];
         $container->getParameter('git_hook_variables')->willReturn($data);
         $this->getGitHookVariables()->shouldReturn($data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #152 

Add `docker-compose` support:
- add new hooks template dedicated to docker-compose
- add new parameter `DOCKER_COMPOSE_CONTAINER` to specify in which container the hooks should be executed
- update corresponding documentation

