### PR TITLE
add Ecs (EasyCodingStandard) Task

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
         "squizlabs/php_codesniffer": "Lets GrumPHP sniff on your code.",
         "sstalle/php7cc": "Lets GrumPHP check PHP 5.3 - 5.6 code compatibility with PHP 7.",
         "symfony/phpunit-bridge": "Lets GrumPHP run your unit tests with the phpunit-bridge of Symfony.",
-        "vimeo/psalm": "Lets GrumPHP discover errors in your code without running it."
+        "vimeo/psalm": "Lets GrumPHP discover errors in your code without running it.",
+        "symplify/easycodingstandard": "Lets GrumPHP check coding standard."
     },
     "authors": [
         {

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -18,6 +18,7 @@ parameters:
         composer_script: ~
         deptrac: ~
         doctrine_orm: ~
+        ecs: ~
         file_size: ~
         gherkin: ~
         git_blacklist: ~
@@ -69,6 +70,7 @@ Every task has it's own default configuration. It is possible to overwrite the p
 - [Composer Require Checker](tasks/composer_require_checker.md)
 - [Composer Script](tasks/composer_script.md)
 - [Doctrine ORM](tasks/doctrine_orm.md)
+- [Ecs EasyCodingStandard](tasks/ecs.md)
 - [File size](tasks/file_size.md)
 - [Deptrac](tasks/deptrac.md)
 - [Gherkin](tasks/gherkin.md)

--- a/doc/tasks/ecs.md
+++ b/doc/tasks/ecs.md
@@ -21,7 +21,6 @@ parameters:
             level: ~
             whitelist_patterns: []
             triggered_by: ['php']
-            fix: false
             clear-cache: false
             no-progress-bar: true
 
@@ -52,13 +51,6 @@ If you want to run on particular directories only, specify it with this option.
 *Default: [php]*
 
 This option will specify which file extensions will trigger this task.
-
-
-**fix**
-
-*Default: false*
-
-Fix found violations.
 
 
 **clear-cache**

--- a/doc/tasks/ecs.md
+++ b/doc/tasks/ecs.md
@@ -17,9 +17,10 @@ The task lives under the `ecs` namespace and has following configurable paramete
 parameters:
     tasks:
         ecs:
-            config:
-            level:
-            whitelist_patterns:
+            config: ~
+            level: ~
+            whitelist_patterns: []
+            triggered_by: ['php']
             fix: false
             clear-cache: false
             no-progress-bar: true
@@ -42,9 +43,15 @@ If you want to use a different level than the default one, specify it with this 
 
 **whitelist_patterns**
 
-*Default: null*
+*Default: []*
 
 If you want to run on particular directories only, specify it with this option.
+
+**triggered_by**
+
+*Default: [php]*
+
+This option will specify which file extensions will trigger this task.
 
 
 **fix**

--- a/doc/tasks/ecs.md
+++ b/doc/tasks/ecs.md
@@ -1,0 +1,69 @@
+#  Ecs - EasyCodingStandard
+
+Check coding standard in one or more directories.
+
+***Composer***
+
+```
+composer require --dev symplify/easycodingstandard
+```
+
+***Config***
+
+The task lives under the `ecs` namespace and has following configurable parameters:
+
+```yaml
+# grumphp.yml
+parameters:
+    tasks:
+        ecs:
+            config:
+            level:
+            whitelist_patterns:
+            fix: false
+            clear-cache: false
+            no-progress-bar: true
+
+```
+
+**config**
+
+*Default: null*
+
+If you want to use a different config file than the default easy-coding-standard.yml, you can specify your custom config file location with this option.
+
+
+**level**
+
+*Default: null*
+
+If you want to use a different level than the default one, specify it with this option.
+
+
+**whitelist_patterns**
+
+*Default: null*
+
+If you want to run on particular directories only, specify it with this option.
+
+
+**fix**
+
+*Default: false*
+
+Fix found violations.
+
+
+**clear-cache**
+
+*Default: false*
+
+Clear cache for already checked files.
+
+
+**no-progress-bar**
+
+*Default: false*
+
+Hide progress bar. Useful e.g. for nicer CI output.
+

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -98,6 +98,15 @@ services:
         tags:
           - {name: grumphp.task, config: doctrine_orm}
 
+    task.ecs:
+        class: GrumPHP\Task\Ecs
+        arguments:
+            - '@config'
+            - '@process_builder'
+            - '@formatter.raw_process'
+        tags:
+            - {name: grumphp.task, config: ecs}
+
     task.git.gherkin:
         class: GrumPHP\Task\Gherkin
         arguments:

--- a/spec/Task/EcsSpec.php
+++ b/spec/Task/EcsSpec.php
@@ -43,7 +43,7 @@ class EcsSpec extends ObjectBehavior
         $options->getDefinedOptions()->shouldContain('config');
         $options->getDefinedOptions()->shouldContain('level');
         $options->getDefinedOptions()->shouldContain('whitelist_patterns');
-        $options->getDefinedOptions()->shouldContain('fix');
+        $options->getDefinedOptions()->shouldContain('triggered_by');
         $options->getDefinedOptions()->shouldContain('clear-cache');
         $options->getDefinedOptions()->shouldContain('no-progress-bar');
     }

--- a/spec/Task/EcsSpec.php
+++ b/spec/Task/EcsSpec.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace spec\GrumPHP\Task;
+
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Configuration\GrumPHP;
+use GrumPHP\Formatter\ProcessFormatterInterface;
+use GrumPHP\Process\ProcessBuilder;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Ecs;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Process\Process;
+
+class EcsSpec extends ObjectBehavior
+{
+    function let(GrumPHP $grumPHP, ProcessBuilder $processBuilder, ProcessFormatterInterface $formatter)
+    {
+        $grumPHP->getTaskConfiguration('ecs')->willReturn([]);
+        $this->beConstructedWith($grumPHP, $processBuilder, $formatter);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(Ecs::class);
+    }
+
+    function it_should_have_a_name()
+    {
+        $this->getName()->shouldBe('ecs');
+    }
+
+    function it_should_have_configurable_options()
+    {
+        $options = $this->getConfigurableOptions();
+        $options->shouldBeAnInstanceOf(OptionsResolver::class);
+        $options->getDefinedOptions()->shouldContain('config');
+        $options->getDefinedOptions()->shouldContain('level');
+        $options->getDefinedOptions()->shouldContain('whitelist_patterns');
+        $options->getDefinedOptions()->shouldContain('fix');
+        $options->getDefinedOptions()->shouldContain('clear-cache');
+        $options->getDefinedOptions()->shouldContain('no-progress-bar');
+    }
+
+    function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_should_run_in_run_context(RunContext $context)
+    {
+        $this->canRunInContext($context)->shouldReturn(true);
+    }
+
+    function it_does_not_do_anything_if_there_are_no_files(ProcessBuilder $processBuilder, ContextInterface $context)
+    {
+        $processBuilder->createArgumentsForCommand('ecs')->shouldNotBeCalled();
+        $processBuilder->buildProcess()->shouldNotBeCalled();
+        $context->getFiles()->willReturn(new FilesCollection());
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->getResultCode()->shouldBe(TaskResult::SKIPPED);
+    }
+
+    function it_runs_the_check(ProcessBuilder $processBuilder, Process $process, ContextInterface $context)
+    {
+        $arguments = new ProcessArgumentsCollection();
+        $processBuilder->createArgumentsForCommand('ecs')->willReturn($arguments);
+        $processBuilder->buildProcess($arguments)->willReturn($process);
+
+        $process->run()->shouldBeCalled();
+        $process->isSuccessful()->willReturn(true);
+
+        $context->getFiles()->willReturn(new FilesCollection([
+            new SplFileInfo('test.php', '.', 'test.php')
+        ]));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_throws_exception_if_the_process_fails(
+        ProcessBuilder $processBuilder,
+        Process $process,
+        ContextInterface $context,
+        ProcessFormatterInterface $formatter
+    ) {
+        $formatter->format($process)->willReturn('format string');
+
+        $arguments = new ProcessArgumentsCollection();
+        $processBuilder->createArgumentsForCommand('ecs')->willReturn($arguments);
+        $processBuilder->buildProcess($arguments)->willReturn($process);
+
+        $process->run()->shouldBeCalled();
+        $process->isSuccessful()->willReturn(false);
+
+        $context->getFiles()->willReturn(new FilesCollection([
+            new SplFileInfo('test.php', '.', 'test.php')
+        ]));
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+    }
+}

--- a/src/Task/Ecs.php
+++ b/src/Task/Ecs.php
@@ -31,6 +31,7 @@ class Ecs extends AbstractExternalTask
             'no-progress-bar' => true,
             'config' => null,
             'level' => null,
+            'triggered_by' => ['php'],
         ]);
 
         $resolver->addAllowedTypes('whitelist_patterns', ['array']);
@@ -39,6 +40,7 @@ class Ecs extends AbstractExternalTask
         $resolver->addAllowedTypes('no-progress-bar', ['bool']);
         $resolver->addAllowedTypes('config', ['null', 'string']);
         $resolver->addAllowedTypes('level', ['null', 'string']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
 
         return $resolver;
     }
@@ -50,12 +52,12 @@ class Ecs extends AbstractExternalTask
 
     public function run(ContextInterface $context): TaskResultInterface
     {
-        $files = $context->getFiles()->name('*.php');
+        $config = $this->getConfiguration();
+
+        $files = $context->getFiles()->extensions($config['triggered_by']);
         if (0 === \count($files)) {
             return TaskResult::createSkipped($this, $context);
         }
-
-        $config = $this->getConfiguration();
 
         $arguments = $this->processBuilder->createArgumentsForCommand('ecs');
         $arguments->add('check');

--- a/src/Task/Ecs.php
+++ b/src/Task/Ecs.php
@@ -26,7 +26,6 @@ class Ecs extends AbstractExternalTask
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
             'whitelist_patterns' => [],
-            'fix' => false,
             'clear-cache' => false,
             'no-progress-bar' => true,
             'config' => null,
@@ -35,7 +34,6 @@ class Ecs extends AbstractExternalTask
         ]);
 
         $resolver->addAllowedTypes('whitelist_patterns', ['array']);
-        $resolver->addAllowedTypes('fix', ['bool']);
         $resolver->addAllowedTypes('clear-cache', ['bool']);
         $resolver->addAllowedTypes('no-progress-bar', ['bool']);
         $resolver->addAllowedTypes('config', ['null', 'string']);
@@ -68,7 +66,6 @@ class Ecs extends AbstractExternalTask
 
         $arguments->addOptionalArgument('--config=%s', $config['config']);
         $arguments->addOptionalArgument('--level=%s', $config['level']);
-        $arguments->addOptionalArgument('--fix', $config['fix']);
         $arguments->addOptionalArgument('--clear-cache', $config['clear-cache']);
         $arguments->addOptionalArgument('--no-progress-bar', $config['no-progress-bar']);
         $arguments->addOptionalArgument('--ansi', true);

--- a/src/Task/Ecs.php
+++ b/src/Task/Ecs.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Task;
+
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Ecs task.
+ */
+class Ecs extends AbstractExternalTask
+{
+    public function getName(): string
+    {
+        return 'ecs';
+    }
+
+    public function getConfigurableOptions(): OptionsResolver
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'whitelist_patterns' => [],
+            'fix' => false,
+            'clear-cache' => false,
+            'no-progress-bar' => true,
+            'config' => null,
+            'level' => null,
+        ]);
+
+        $resolver->addAllowedTypes('whitelist_patterns', ['array']);
+        $resolver->addAllowedTypes('fix', ['bool']);
+        $resolver->addAllowedTypes('clear-cache', ['bool']);
+        $resolver->addAllowedTypes('no-progress-bar', ['bool']);
+        $resolver->addAllowedTypes('config', ['null', 'string']);
+        $resolver->addAllowedTypes('level', ['null', 'string']);
+
+        return $resolver;
+    }
+
+    public function canRunInContext(ContextInterface $context): bool
+    {
+        return $context instanceof GitPreCommitContext || $context instanceof RunContext;
+    }
+
+    public function run(ContextInterface $context): TaskResultInterface
+    {
+        $files = $context->getFiles()->name('*.php');
+        if (0 === \count($files)) {
+            return TaskResult::createSkipped($this, $context);
+        }
+
+        $config = $this->getConfiguration();
+
+        $arguments = $this->processBuilder->createArgumentsForCommand('ecs');
+        $arguments->add('check');
+
+        foreach ($config['whitelist_patterns'] as $whitelistPattern) {
+            $arguments->add($whitelistPattern);
+        }
+
+        $arguments->addOptionalArgument('--config=%s', $config['config']);
+        $arguments->addOptionalArgument('--level=%s', $config['level']);
+        $arguments->addOptionalArgument('--fix', $config['fix']);
+        $arguments->addOptionalArgument('--clear-cache', $config['clear-cache']);
+        $arguments->addOptionalArgument('--no-progress-bar', $config['no-progress-bar']);
+        $arguments->addOptionalArgument('--ansi', true);
+        $arguments->addOptionalArgument('--no-interaction', true);
+
+        $process = $this->processBuilder->buildProcess($arguments);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes

Add EasyCodingStandard task for use for exemple :
- https://github.com/Symplify/EasyCodingStandard
- https://github.com/SyliusLabs/CodingStandard
- ...

# New Task Checklist:

- [x] Is the README.md file updated?
- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpspec tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?
