### PR TITLE
Fixes return type of `ConfigureCommand::pathValidator`

### DIFF
--- a/src/Console/Command/ConfigureCommand.php
+++ b/src/Console/Command/ConfigureCommand.php
@@ -213,7 +213,7 @@ class ConfigureCommand extends Command
         return rtrim($this->paths()->getRelativePath($topLevel), '/');
     }
 
-    public function pathValidator($path): bool
+    public function pathValidator($path): string
     {
         if (!$this->filesystem->exists($path)) {
             throw new RuntimeException(sprintf('The path %s could not be found!', $path));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | None

`$path` should be a string and not a boolean. Not sure how this isn't breaking for anyone else.