### PR TITLE
Adds PHP7 type hinting where missing

### DIFF
--- a/src/Collection/TaskResultCollection.php
+++ b/src/Collection/TaskResultCollection.php
@@ -28,14 +28,11 @@ class TaskResultCollection extends ArrayCollection
         return false;
     }
 
-    /**
-     * @return int
-     */
     public function getResultCode(): int
     {
         $resultCode = static::NO_TASKS;
         foreach ($this as $taskResult) {
-            $resultCode = max($resultCode, $taskResult->getResultCode());
+            $resultCode = (int) max($resultCode, $taskResult->getResultCode());
         }
 
         return $resultCode;

--- a/src/Collection/TaskResultCollection.php
+++ b/src/Collection/TaskResultCollection.php
@@ -29,9 +29,9 @@ class TaskResultCollection extends ArrayCollection
     }
 
     /**
-     * @return int|mixed
+     * @return int
      */
-    public function getResultCode()
+    public function getResultCode(): int
     {
         $resultCode = static::NO_TASKS;
         foreach ($this as $taskResult) {

--- a/src/Console/Command/ConfigureCommand.php
+++ b/src/Console/Command/ConfigureCommand.php
@@ -213,7 +213,7 @@ class ConfigureCommand extends Command
         return rtrim($this->paths()->getRelativePath($topLevel), '/');
     }
 
-    public function pathValidator($path): string
+    public function pathValidator(string $path): string
     {
         if (!$this->filesystem->exists($path)) {
             throw new RuntimeException(sprintf('The path %s could not be found!', $path));

--- a/src/Console/Command/Git/PreCommitCommand.php
+++ b/src/Console/Command/Git/PreCommitCommand.php
@@ -56,9 +56,6 @@ class PreCommitCommand extends Command
         );
     }
 
-    /**
-     * @return int
-     */
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new ConsoleIO($input, $output);

--- a/src/Console/Command/Git/PreCommitCommand.php
+++ b/src/Console/Command/Git/PreCommitCommand.php
@@ -57,7 +57,7 @@ class PreCommitCommand extends Command
     }
 
     /**
-     * @return int|void
+     * @return int
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -53,9 +53,6 @@ class RunCommand extends Command
         );
     }
 
-    /**
-     * @return int
-     */
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $files = $this->getRegisteredFiles();

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -54,7 +54,7 @@ class RunCommand extends Command
     }
 
     /**
-     * @return int|void
+     * @return int
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Util/Str.php
+++ b/src/Util/Str.php
@@ -11,7 +11,7 @@ class Str
      * @param array $needles
      * @return bool
      */
-    public static function containsOneOf($haystack, array $needles)
+    public static function containsOneOf(string $haystack, array $needles)
     {
         foreach ($needles as $needle) {
             if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {

--- a/src/Util/Str.php
+++ b/src/Util/Str.php
@@ -6,12 +6,8 @@ class Str
 {
     /**
      * String contains one of the provided needles
-     *
-     * @param string $haystack
-     * @param array $needles
-     * @return bool
      */
-    public static function containsOneOf(string $haystack, array $needles)
+    public static function containsOneOf(string $haystack, array $needles): bool
     {
         foreach ($needles as $needle) {
             if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {


### PR DESCRIPTION
String

| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | no

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
Added type hinting where missing. 
TaskResultCollection: only returns int
ConfigureCommand: return is string, which is the parameter, therefore parameter should be string.
PreCommitCommand: never returns void
RunCommand: never returns void
Str: doc says string, should be string
