### PR TITLE
Add descriptions to the git:* commands

### DIFF
--- a/src/Console/Command/Git/CommitMsgCommand.php
+++ b/src/Console/Command/Git/CommitMsgCommand.php
@@ -57,6 +57,7 @@ class CommitMsgCommand extends Command
     protected function configure()
     {
         $this->setName(self::COMMAND_NAME);
+        $this->setDescription('Executed by the commit-msg commit hook');
         $this->addOption('git-user', null, InputOption::VALUE_REQUIRED, 'The configured git user name.', '');
         $this->addOption('git-email', null, InputOption::VALUE_REQUIRED, 'The configured git email.', '');
         $this->addArgument('commit-msg-file', InputArgument::REQUIRED, 'The configured commit message file.');

--- a/src/Console/Command/Git/DeInitCommand.php
+++ b/src/Console/Command/Git/DeInitCommand.php
@@ -50,6 +50,7 @@ class DeInitCommand extends Command
     protected function configure()
     {
         $this->setName(self::COMMAND_NAME);
+        $this->setDescription('Removes the commit hooks');
     }
 
     /**

--- a/src/Console/Command/Git/InitCommand.php
+++ b/src/Console/Command/Git/InitCommand.php
@@ -66,6 +66,7 @@ class InitCommand extends Command
     protected function configure()
     {
         $this->setName(self::COMMAND_NAME);
+        $this->setDescription('Registers the Git hooks');
     }
 
     /**

--- a/src/Console/Command/Git/PreCommitCommand.php
+++ b/src/Console/Command/Git/PreCommitCommand.php
@@ -48,6 +48,7 @@ class PreCommitCommand extends Command
     protected function configure()
     {
         $this->setName(self::COMMAND_NAME);
+        $this->setDescription('Executed by the pre-commit hook');
         $this->addOption(
             'skip-success-output',
             null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | n/a
| Fixed tickets | -

This PR adds descriptions to the commands with the `git:` prefix like `git:init`. The descriptions should help users to understand what these commands do and to figure out how to initialize / re-initialize their GrumPHP installation.

