### PR TITLE
Fixed a bug when phplint is active and only non-php files are commited

### DIFF
--- a/src/Task/PhpLint.php
+++ b/src/Task/PhpLint.php
@@ -53,6 +53,10 @@ class PhpLint extends AbstractExternalTask
             ->notPaths($config['ignore_patterns'])
             ->extensions($config['triggered_by']);
 
+        if ($files->isEmpty()) {
+            return TaskResult::createSkipped($this, $context);
+        }
+
         $arguments = $this->processBuilder->createArgumentsForCommand('parallel-lint');
         $arguments->add('--no-colors');
         $arguments->addOptionalArgumentWithSeparatedValue('-j', $config['jobs']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | no

There was a bug when you try to commit (pre-hook) some non-php files.
You receive the PHP Parallel Lint usage error every time. With this it
will be marked as "passed" when no files are available to pass trough
the linter.