### PR TITLE
Add more output when Blacklist fails with Git errors

### DIFF
--- a/src/Task/Git/Blacklist.php
+++ b/src/Task/Git/Blacklist.php
@@ -111,6 +111,12 @@ class Blacklist extends AbstractExternalTask
                 PHP_EOL,
                 $this->formatter->format($process)
             ));
+        } elseif ($process->getExitCode() !== 1) {
+            return TaskResult::createFailed(
+                $this,
+                $context,
+                'Something went wrong with Grep or Git. Error output: "' . trim($process->getErrorOutput()) . '"'
+            );
         }
 
         return TaskResult::createPassed($this, $context);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
Right now when the Blacklist task fails on Git errors, you don't see the output, but your taks passes. In my opinion the task should fail with some error output. This way you dont have false positives

<!-- Are you creating a new task? Make sure to complete this checklist: -->