### PR TITLE
Add $files to $arguments

### DIFF
--- a/src/Task/Ecs.php
+++ b/src/Task/Ecs.php
@@ -70,6 +70,7 @@ class Ecs extends AbstractExternalTask
         $arguments->addOptionalArgument('--no-progress-bar', $config['no-progress-bar']);
         $arguments->addOptionalArgument('--ansi', true);
         $arguments->addOptionalArgument('--no-interaction', true);
+        $arguments->addFiles($files);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();


### PR DESCRIPTION
This pull request affects the easy-coding-standard task.
$files will never assigned to the process arguments. This has the affect that the check never fail.
