### PR TITLE
Add $files to process $arguments (Easy Coding Standard Task)

### DIFF
--- a/src/Task/Ecs.php
+++ b/src/Task/Ecs.php
@@ -70,6 +70,7 @@ class Ecs extends AbstractExternalTask
         $arguments->addOptionalArgument('--no-progress-bar', $config['no-progress-bar']);
         $arguments->addOptionalArgument('--ansi', true);
         $arguments->addOptionalArgument('--no-interaction', true);
+        $arguments->addFiles($files);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();


### PR DESCRIPTION
$files will never be assigned to the process arguments. This has the affect that the check never fail.

| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
This pull request adds the `$files` variable to the process `$arguments`.
