### PR TITLE
Add silent argument to npm task

### DIFF
--- a/doc/tasks/npm_script.md
+++ b/doc/tasks/npm_script.md
@@ -12,6 +12,7 @@ parameters:
             triggered_by: [js, jsx, coffee, ts, less, sass, scss]
             working_directory: "./"
             is_run_task: false
+            silent: false
 ```
 
 **script**
@@ -46,3 +47,9 @@ This option specifies in which directory the NPM script should be run.
 *Default: false*
 
 This option will append 'run' to the npm command to make it possible to run custom npm scripts.
+
+**silent**
+
+*Default: false*
+
+This option will append '--silent' to the npm script to supress `npm ERR!` messages from showing.

--- a/spec/Task/NpmScriptSpec.php
+++ b/spec/Task/NpmScriptSpec.php
@@ -14,7 +14,6 @@ use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use GrumPHP\Task\NpmScript;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
@@ -45,6 +44,7 @@ class NpmScriptSpec extends ObjectBehavior
         $options->getDefinedOptions()->shouldContain('triggered_by');
         $options->getDefinedOptions()->shouldContain('working_directory');
         $options->getDefinedOptions()->shouldContain('is_run_task');
+        $options->getDefinedOptions()->shouldContain('silent');
     }
 
     function it_should_run_in_git_pre_commit_context(GitPreCommitContext $context)

--- a/src/Task/NpmScript.php
+++ b/src/Task/NpmScript.php
@@ -29,12 +29,14 @@ class NpmScript extends AbstractExternalTask
             'triggered_by' => ['js', 'jsx', 'coffee', 'ts', 'less', 'sass', 'scss'],
             'working_directory' => './',
             'is_run_task' => false,
+            'silent' => false,
         ]);
 
         $resolver->addAllowedTypes('script', ['string']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
         $resolver->addAllowedTypes('working_directory', ['string']);
         $resolver->addAllowedTypes('is_run_task', ['bool']);
+        $resolver->addAllowedTypes('silent', ['bool']);
 
         return $resolver;
     }
@@ -61,6 +63,7 @@ class NpmScript extends AbstractExternalTask
         $arguments = $this->processBuilder->createArgumentsForCommand('npm');
         $arguments->addOptionalArgument('run', $config['is_run_task']);
         $arguments->addRequiredArgument('%s', $config['script']);
+        $arguments->addOptionalArgument('--silent', $config['silent']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->setWorkingDirectory(realpath($config['working_directory']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
This PR adds a `silent` argument to the npm task which appends `--silent` to the script that will be ran. This suppresses `npm ERR!` messages from showing.

<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [ ] Is the README.md file updated?
- [ ] Are the dependencies added to the composer.json suggestions?
- [ ] Is the doc/tasks.md file updated?
- [ ] Are the task parameters documented?
- [ ] Is the task registered in the tasks.yml file?
- [ ] Does the task contains phpspec tests?
- [ ] Is the configuration having logical allowed types?
- [ ] Does the task run in the correct context?
- [ ] Is the `run()` method readable?
- [ ] Is the `run()` method using the configuration correctly?
- [ ] Are all CI services returning green?