### PR TITLE
Add missing composer information for Composer Normalize on Docs

### DIFF
--- a/doc/tasks/composer_normalize.md
+++ b/doc/tasks/composer_normalize.md
@@ -3,6 +3,14 @@
 If you are using `composer`, you have probably modified the file `composer.json` at least once to keep things nice
 and tidy.
 
+***Composer***
+
+```
+composer require --dev localheinz/composer-normalize
+```
+
+***Config***
+
 This task is a wrapper around a composer plugin for tidying up the file `composer.json`.
 
 The default configuration looks like:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes

Adding missing composer information for Composer Normalize on Docs


<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [ ] Is the README.md file updated?
- [ ] Are the dependencies added to the composer.json suggestions?
- [ ] Is the doc/tasks.md file updated?
- [ ] Are the task parameters documented?
- [ ] Is the task registered in the tasks.yml file?
- [ ] Does the task contains phpspec tests?
- [ ] Is the configuration having logical allowed types?
- [ ] Does the task run in the correct context?
- [ ] Is the `run()` method readable?
- [ ] Is the `run()` method using the configuration correctly?
- [ ] Are all CI services returning green?
