### PR TITLE
Return commandline when project dir is same

### DIFF
--- a/src/Console/Command/Git/InitCommand.php
+++ b/src/Console/Command/Git/InitCommand.php
@@ -157,11 +157,16 @@ class InitCommand extends Command
         $process = $this->processBuilder->buildProcess($arguments);
 
         // Make the grumphp command relative to path where the config is stored (if it uses that executable)
-        return str_replace(
-            $this->filesystem->ensureUnixPath($this->paths->getProjectDir()),
-            '.',
-            $process->getCommandLine()
-        );
+        if (0 ===
+            strpos($process->getCommandLine(), $this->filesystem->ensureUnixPath($this->paths->getProjectDir()))) {
+            return str_replace(
+                $this->filesystem->ensureUnixPath($this->paths->getProjectDir()),
+                '.',
+                $process->getCommandLine()
+            );
+        }
+
+        return $process->getCommandLine();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
With this PR, the problem I reported in issue #671 is fixed. Our project dir in the vagrant box is `/vagrant` and after running the command `grumphp git:init`, the generated git hooks contains the path without `vagrant` so I became something like `/home./.composer/...`. Now. the path in the git hooks is correctly generated.

Also credits to @rvanginneken for searching for a solution

