### PR TITLE
Improve exectuable locator

### DIFF
--- a/doc/installation/exotic.md
+++ b/doc/installation/exotic.md
@@ -63,6 +63,7 @@ GRUMPHP_GIT_WORKING_DIR=....
 GRUMPHP_GIT_REPOSITORY_DIR=...
 GRUMPHP_COMPOSER_DIR=...
 GRUMPHP_BIN_DIR=...
+PATH=/additional/bin/dirs:$PATH
 ```
 
 **GRUMPHP_PROJECT_DIR**
@@ -95,7 +96,13 @@ The directory in which your `composer.json` file is available.
 
 *Default: null*
 
-The directory in which your executables are located.
+The directory in which the executables installed by composer are located.
+
+**PATH**
+
+*Default: system specific*
+
+If you want to support multiple bin directories, you can prepend them to your path variable.
 
 
 ## Running GrumPHP with a custom config file

--- a/resources/config/services.yml
+++ b/resources/config/services.yml
@@ -26,8 +26,14 @@ services:
     filesystem:
         alias: grumphp.util.filesystem
 
+    GrumPHP\Configuration\Configurator\ExecutableFinderConfigurator:
+        arguments:
+            - '@GrumPHP\Util\Paths'
     executable_finder:
         class: Symfony\Component\Process\ExecutableFinder
+        configurator: ['@GrumPHP\Configuration\Configurator\ExecutableFinderConfigurator', 'configure']
+        calls:
+            - { method: 'setSuffixes', arguments: [['.phar', '.exe', '.bat', '.cmd', '.com']] }
 
     process_builder:
       class: GrumPHP\Process\ProcessBuilder

--- a/resources/config/util.yml
+++ b/resources/config/util.yml
@@ -1,7 +1,4 @@
 services:
-    grumphp.util.composer:
-        class: GrumPHP\Util\Composer
-
     grumphp.util.filesystem:
         class: GrumPHP\Util\Filesystem
         public: true

--- a/src/Configuration/Configurator/ExecutableFinderConfigurator.php
+++ b/src/Configuration/Configurator/ExecutableFinderConfigurator.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Configuration\Configurator;
+
+use GrumPHP\Util\Paths;
+use Symfony\Component\Process\ExecutableFinder;
+
+class ExecutableFinderConfigurator
+{
+    /**
+     * @var Paths
+     */
+    private $paths;
+
+    public function __construct(Paths $paths)
+    {
+        $this->paths = $paths;
+    }
+
+    public function configure(ExecutableFinder $executableFinder): ExecutableFinder
+    {
+        $this->prefixBinDir();
+
+        return $executableFinder;
+    }
+
+    /**
+     * Make sure the bin dir is prepended to your current PATH env var.
+     * This way, it first tries to detect dependencies in the folder they will most likely be.
+     *
+     * Code copied from composer:
+     * @see https://github.com/composer/composer/blob/1.1/src/Composer/EventDispatcher/EventDispatcher.php#L147-L160
+     */
+    private function prefixBinDir(): void
+    {
+        $pathStr = 'PATH';
+        if (!isset($_SERVER[$pathStr]) && isset($_SERVER['Path'])) {
+            $pathStr = 'Path';
+        }
+
+        if (!is_dir($binDir = $this->paths->getBinDir())) {
+            return;
+        }
+
+        // add the bin dir to the PATH to make local binaries of deps usable in scripts
+        $hasBindDirInPath = preg_match(
+            '{(^|'.PATH_SEPARATOR.')'.preg_quote($binDir).'($|'.PATH_SEPARATOR.')}',
+            $_SERVER[$pathStr]
+        );
+
+        if (!$hasBindDirInPath && isset($_SERVER[$pathStr])) {
+            $_SERVER[$pathStr] = $binDir.PATH_SEPARATOR.getenv($pathStr);
+            putenv($pathStr.'='.$_SERVER[$pathStr]);
+        }
+    }
+}

--- a/src/Configuration/ContainerFactory.php
+++ b/src/Configuration/ContainerFactory.php
@@ -20,9 +20,6 @@ class ContainerFactory
         $cliConfigFile = $input->getParameterOption(['--config', '-c'], null);
         $guessedPaths = self::guessPaths($cliConfigFile);
 
-        // Make sure to register bin dir in PATHS
-        $guessedPaths->getComposerFile()->ensureProjectBinDirInSystemPath();
-
         // Build the service container:
         $container = ContainerBuilder::buildFromConfiguration($guessedPaths->getConfigFile());
         $container->set('console.input', $input);

--- a/src/Util/ComposerFile.php
+++ b/src/Util/ComposerFile.php
@@ -22,39 +22,6 @@ class ComposerFile
         $this->configuration = $configuration;
     }
 
-    /**
-     * Composer contains some logic to prepend the current bin dir to the system PATH.
-     * To make sure this application works the same in CLI and Composer mode,
-     * we'll have to ensure that the bin path is always prefixed.
-     *
-     * @see https://github.com/composer/composer/blob/1.1/src/Composer/EventDispatcher/EventDispatcher.php#L147-L160
-     */
-    public function ensureProjectBinDirInSystemPath(): bool
-    {
-        $pathStr = 'PATH';
-        if (!isset($_SERVER[$pathStr]) && isset($_SERVER['Path'])) {
-            $pathStr = 'Path';
-        }
-
-        if (!is_dir($this->getBinDir())) {
-            return false;
-        }
-
-        // add the bin dir to the PATH to make local binaries of deps usable in scripts
-        $binDir = realpath($this->getBinDir());
-        $hasBindDirInPath = preg_match(
-            '{(^|'.PATH_SEPARATOR.')'.preg_quote($binDir).'($|'.PATH_SEPARATOR.')}',
-            $_SERVER[$pathStr]
-        );
-
-        if (!$hasBindDirInPath && isset($_SERVER[$pathStr])) {
-            $_SERVER[$pathStr] = $binDir.PATH_SEPARATOR.getenv($pathStr);
-            putenv($pathStr.'='.$_SERVER[$pathStr]);
-        }
-
-        return true;
-    }
-
     public function getBinDir(): string
     {
         $binDir = $this->configuration['config']['bin-dir'] ?? null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #671, #677

This PR:

- Moves bin-dir prepending to PATH outside the ComposerFile logic and runs it when loading the Symfony exectuable finder. This fixes a possible issue when a bin dir is defined with env variables that is different from the one in composer.
- Adds documentation on how to support multiple bin dirs.
- Adds `.phar` as a valid suffix so that those executables can also be detected.
