### PR TITLE
adjust the gitignore so the bin directory gets included in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-bin
-!bin/grumphp
 vendor
 composer.lock
 grumphp.yml
 .phpunit.result.cache
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes (?)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | none

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
Because of the .gitignore in this project, we cannot commit the executable for grumphp to our repository. We would like to do that, but afaik there is no way to overrule that without changing the .gitignore file itself. This PR does exactly that.

Note that not committing our vendor directory is currently not an option.
