### PR TITLE
Fix: do not display graphiz when argument is set false

### DIFF
--- a/doc/tasks/deptrac.md
+++ b/doc/tasks/deptrac.md
@@ -34,7 +34,7 @@ Set to `true` to enable the graphviz formatter.
 
 **formatter_graphviz_display**
 
-*Default: false*
+*Default: true*
 
 Open the generated graphviz image. Set to `true` to activate.
 

--- a/src/Task/Deptrac.php
+++ b/src/Task/Deptrac.php
@@ -27,7 +27,7 @@ class Deptrac extends AbstractExternalTask
         $resolver->setDefaults([
             'depfile' => null,
             'formatter_graphviz' => false,
-            'formatter_graphviz_display' => false,
+            'formatter_graphviz_display' => true,
             'formatter_graphviz_dump_image' => null,
             'formatter_graphviz_dump_dot' => null,
             'formatter_graphviz_dump_html' => null,

--- a/src/Task/Deptrac.php
+++ b/src/Task/Deptrac.php
@@ -60,7 +60,7 @@ class Deptrac extends AbstractExternalTask
         $arguments = $this->processBuilder->createArgumentsForCommand('deptrac');
         $arguments->add('analyze');
         $arguments->add('--formatter-graphviz='.(int) $config['formatter_graphviz']);
-        $arguments->addOptionalArgument('--formatter-graphviz-display=%s', $config['formatter_graphviz_display']);
+        $arguments->add('--formatter-graphviz-display='.(int) $config['formatter_graphviz_display']);
         $arguments->addOptionalArgument('--formatter-graphviz-dump-image=%s', $config['formatter_graphviz_dump_image']);
         $arguments->addOptionalArgument('--formatter-graphviz-dump-dot=%s', $config['formatter_graphviz_dump_dot']);
         $arguments->addOptionalArgument('--formatter-graphviz-dump-html=%s', $config['formatter_graphviz_dump_html']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | none

## Description

By default, `addOptionalArgument` in `ProcessArgumentsCollection` discards an argument when the value evaluates to false.
This results in the absence of the option in the final process command.

In many cases, the absence of an option means false, but in the case of Deptrac's `--formatter-graphviz-display` it means true.

The use of `addOptionalArgument` will never allow false, so unsetting this option in Deptrac is impossible. 
In `Deptrac.php` all options are always present, so adding it just by default with `add` will fix this.

**Edit:**
Because the default value for this option `--formatter-graphviz-display` is true at Deptrac itself, the default here should be true too, to align. This means a small BC because the default is different.

## Sources
Deptrac: option `formatter_graphviz_display` is set true by default:
- https://github.com/sensiolabs-de/deptrac#graphviz-formatter

GrumPHP: option `formatter_graphviz_display` is set false by default:
- https://github.com/phpro/grumphp/blob/master/doc/tasks/deptrac.md#deptrac