### PR TITLE
fix(PhpcsFormatter): remove last PHP_EOL before parsing json

### DIFF
--- a/src/Formatter/PhpcsFormatter.php
+++ b/src/Formatter/PhpcsFormatter.php
@@ -19,12 +19,12 @@ class PhpcsFormatter implements ProcessFormatterInterface
 
     public function format(Process $process): string
     {
-        $output = $process->getOutput();
+        $output = trim($process->getOutput());
         if (!$output) {
             return $process->getErrorOutput();
         }
 
-        $pos = strrpos(trim($output), "\n");
+        $pos = strrpos($output, "\n");
         if (false === $pos) {
             return $output;
         }

--- a/src/Formatter/PhpcsFormatter.php
+++ b/src/Formatter/PhpcsFormatter.php
@@ -24,7 +24,7 @@ class PhpcsFormatter implements ProcessFormatterInterface
             return $process->getErrorOutput();
         }
 
-        $pos = strrpos($output, "\n");
+        $pos = strrpos(trim($output), "\n");
         if (false === $pos) {
             return $output;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #662 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

5 months ago a commit changes how PHPCS ends the json report by adding  a new line at the end. You can see here: https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Reports/Json.php#L101

This messes up the PhpcsFormatter because the last "\n" that finds is the new PHP_EOL that is added to de report. 

With this fix it won't print the json report and will prompt for autofixing like before.

<!-- Are you creating a new task? Make sure to complete this checklist: -->

No