### PR TITLE
Ignore files from zip export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+spec/ export-ignore
+test/ export-ignore


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch        | master 
| Bug fix?      | no
| New feature?  | Yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | None

This makes the composer installers smaller as the test are not shipped

