### PR TITLE
Swap implode function parameters to fix php 7.4 deprecation

### DIFF
--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -334,12 +334,12 @@ class CommitMessage implements TaskInterface
         $mergePattern = '(Merge branch \'.+\'\s.+|Merge remote-tracking branch \'.+\'|Merge pull request #\d+\s.+)';
 
         if (count($types) > 0) {
-            $types = implode($types, '|');
+            $types = implode('|', $types);
             $typesPattern = '(' . $types . ')';
         }
 
         if (count($scopes) > 0) {
-            $scopes = implode($scopes, '|');
+            $scopes = implode('|', $scopes);
             $scopesPattern = '(:\s|(\(' . $scopes . '\)?:\s))';
         }
 

--- a/src/Task/PhpLint.php
+++ b/src/Task/PhpLint.php
@@ -68,7 +68,7 @@ class PhpLint extends AbstractExternalTask
         $process = $this->processBuilder->buildProcess($arguments);
         $process->setInput($inputStream);
         $process->start();
-        $inputStream->write(\implode($files->toArray(), PHP_EOL));
+        $inputStream->write(\implode(PHP_EOL, $files->toArray()));
         $inputStream->close();
         $process->wait();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Documented?   | -
| Fixed tickets | -

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
PHP 7.4 emits a deprecation warning when calling implode in reverse order from the documented order of arguments eg. implode($pieces, $glue): 
https://wiki.php.net/rfc/deprecations_php_7_4#implode_parameter_order_mix

For historical reasons, the implode() function supports passing the $glue and $pieces parameters in either order, so this change will not create any BC break:
https://www.php.net/manual/en/function.implode.php
