### PR TITLE
Rework realpath logic to remove the possibility of a type error

### DIFF
--- a/src/Util/Filesystem.php
+++ b/src/Util/Filesystem.php
@@ -33,11 +33,12 @@ class Filesystem extends SymfonyFilesystem
 
     public function realpath(string $path): string
     {
-        if (!$this->exists($path)) {
+        $realPath = realpath($path);
+        if ($realPath === false) {
             throw new FileNotFoundException(sprintf('Path "%s" does not exist.', $path));
         }
 
-        return realpath($path);
+        return $realPath;
     }
 
     public function makePathAbsolute(string $path, string $basePath): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | N/a
| Fixed tickets | N/a

We check that the file exists, but if for whatever reason we cant
make a realpath out of it, or if we have another process that deletes
this in the mean time, then we could have a type error.

By retrieving the real path, and then checking the error condition
we  remove the ability for a type error to occur here.

We dont change the fact that the file in question can still be
deleted in the mean time, as thats not within the scope of this method.


