### PR TITLE
fix(commit-message): CheckTypeScope with a special prefix

### DIFF
--- a/spec/Task/Git/CommitMessageSpec.php
+++ b/spec/Task/Git/CommitMessageSpec.php
@@ -723,6 +723,35 @@ MSG;
         $result->isPassed()->shouldBe(true);
     }
 
+    function it_should_pass_when_type_scope_conventions_does_use_an_available_type_and_special_prefix(
+        GrumPHP $grumPHP,
+        GitCommitMsgContext $context
+    ) {
+        $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([
+            'allow_empty_message' => false,
+            'enforce_capitalized_subject' => false,
+            'enforce_no_subject_trailing_period' => false,
+            'enforce_single_lined_subject' => true,
+            'type_scope_conventions' => [
+                'types' => ['fix']
+            ],
+        ]);
+
+        $commitMessage = <<<'MSG'
+fixup! fix: this type is in the available types array
+
+The body ...
+
+And footer #12
+MSG;
+
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
     function it_should_fail_when_type_scope_conventions_does_not_use_an_available_scope(
         GrumPHP $grumPHP,
         GitCommitMsgContext $context

--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -328,6 +328,7 @@ class CommitMessage implements TaskInterface
             ? $config['type_scope_conventions']['scopes']
             : [];
 
+        $specialPrefix = '(?:(?:fixup|squash)! )?';
         $typesPattern = '([a-zA-Z0-9]+)';
         $scopesPattern = '(:\s|(\(.+\)?:\s))';
         $subjectPattern = '([a-zA-Z0-9-_ #@\'\/\\"]+)';
@@ -343,7 +344,7 @@ class CommitMessage implements TaskInterface
             $scopesPattern = '(:\s|(\(' . $scopes . '\)?:\s))';
         }
 
-        $rule = '/^' . $typesPattern . $scopesPattern . $subjectPattern . '|' . $mergePattern . '/';
+        $rule = '/^' . $specialPrefix . $typesPattern . $scopesPattern . $subjectPattern . '|' . $mergePattern . '/';
 
         try {
             $this->runMatcher($config, $subjectLine, $rule, 'Invalid Type/Scope Format');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | N/A

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

it's not possible to pass the task "commit-message" when we use :
`git commit --fixup ...`

This PR Fix that adding some rules on the Regex

<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [x] Does the task contains phpspec tests?