### PR TITLE
Pass array of directories to phpcpd

### DIFF
--- a/doc/tasks/phpcpd.md
+++ b/doc/tasks/phpcpd.md
@@ -17,7 +17,7 @@ The task lives under the `phpcpd` namespace and has following configurable param
 parameters:
     tasks:
         phpcpd:
-            directory: '.'
+            directory: ['.']
             exclude: ['vendor']
             names_exclude: []
             regexps_exclude: []
@@ -29,9 +29,9 @@ parameters:
 
 **directory**
 
-*Default: .*
+*Default: [.]*
 
-With this parameter you can define which directory you want to run `phpcpd` in (must be relative to cwd).
+With this parameter you can define which directories you want to run `phpcpd` in (must be relative to cwd).
 
 **exclude**
 

--- a/src/Task/PhpCpd.php
+++ b/src/Task/PhpCpd.php
@@ -25,7 +25,7 @@ class PhpCpd extends AbstractExternalTask
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
-            'directory' => '.',
+            'directory' => ['.'],
             'exclude' => ['vendor'],
             'names_exclude' => [],
             'regexps_exclude' => [],
@@ -35,7 +35,7 @@ class PhpCpd extends AbstractExternalTask
             'triggered_by' => ['php'],
         ]);
 
-        $resolver->addAllowedTypes('directory', ['string']);
+        $resolver->addAllowedTypes('directory', ['array']);
         $resolver->addAllowedTypes('exclude', ['array']);
         $resolver->addAllowedTypes('names_exclude', ['array']);
         $resolver->addAllowedTypes('regexps_exclude', ['array']);
@@ -79,7 +79,7 @@ class PhpCpd extends AbstractExternalTask
         $arguments->addRequiredArgument('--min-tokens=%u', (string) $config['min_tokens']);
         $arguments->addOptionalCommaSeparatedArgument('--names=%s', $extensions);
         $arguments->addOptionalArgument('--fuzzy', $config['fuzzy']);
-        $arguments->add($config['directory']);
+        $arguments->addArgumentArray('%s', $config['directory']);
 
         $process = $this->processBuilder->buildProcess($arguments);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | `support-phpcs-multiple-dirs`
| Bug fix?      | yes/**no**
| New feature?  | **yes**/no
| BC breaks?    | yes/**no**
| Deprecations? | yes/**no**
| Documented?   | **yes**/no
| Fixed tickets | #696

Phpcpd allows users to pass multiple directories to the command. The tool will then check for duplicated code in those directories.

Grumphp doesn't take advantage of this - instead, users can only pass a single string for the directory.

This PR changes the string into an array, and updates the processing and docs accordingly.