### PR TITLE
Remove Old Compatibility Layer for Pre-5.x Symfony Process

### DIFF
--- a/src/Process/ProcessFactory.php
+++ b/src/Process/ProcessFactory.php
@@ -14,14 +14,6 @@ final class ProcessFactory
 {
     public static function fromArguments(ProcessArgumentsCollection $arguments): Process
     {
-        // @todo Remove backward compatibility layer as soon as Symfony Process accepts an array (3.3+).
-        //       From then on, you can simply pass `$arguments->getValues()` directly as the first constructor argument.
-        $commandlineArgs = array_map(function ($argument) {
-            return ProcessUtils::escapeArgument((string) $argument);
-        }, $arguments->getValues());
-
-        $commandline = implode(' ', $commandlineArgs);
-
-        return new Process($commandline);
+        return new Process($arguments->getValues());
     }
 }


### PR DESCRIPTION
Fixes #706.

However, I think it breaks use with Symfony Process 4.x and 3.x which according to the `composer.json` are still supported. I didn't see anything in Symfony Process that allows us to determine which version is currently running. Have you solved this issue before?

BTW, a comment in the Symfony Process constructor says arrays started being accepted as the first argument in Symfony 4.2.