### PR TITLE
Use triggered_by option for extensions argument for phpcs. Fixes #715.

### DIFF
--- a/doc/tasks/phpcs.md
+++ b/doc/tasks/phpcs.md
@@ -122,7 +122,7 @@ This is a list of sniffs that need to be executed. Leave this option blank to ru
 
 *Default: [php]:
 
-This is a list of extensions to be sniffed. 
+This is a list of extensions to be sniffed. This list is also passed to phpcs using the `--extensions` parameter.
 
 **exclude**
 

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -110,6 +110,7 @@ class Phpcs extends AbstractExternalTask
         array $config
     ): ProcessArgumentsCollection {
         $arguments->addOptionalCommaSeparatedArgument('--standard=%s', (array) $config['standard']);
+        $arguments->addOptionalCommaSeparatedArgument('--extensions=%s', (array) $config['triggered_by']);
         $arguments->addOptionalArgument('--tab-width=%s', $config['tab_width']);
         $arguments->addOptionalArgument('--encoding=%s', $config['encoding']);
         $arguments->addOptionalArgument('--report=%s', $config['report']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes (missing phpcs functionality)
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #715

I have given a detailed description in #715.


<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [x] Is the README.md file updated?
- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpspec tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?
