### PR TITLE
fix: should not fail on long body when using git --verbose

### DIFF
--- a/spec/Task/Git/CommitMessageSpec.php
+++ b/spec/Task/Git/CommitMessageSpec.php
@@ -577,6 +577,59 @@ MSG;
         $result->getMessage()->shouldMatch('/keep.*subject <= 60.*\n.*line 3.*> 72.*/im');
     }
 
+    function it_should_pass_when_using_git_verbose_with_verbose_part_very_wide(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+A subject line that is just fine
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch fix-ignore-git-verbose
+# Changes to be committed:
+#	modified:   src/Task/Git/CommitMessage.php
+#
+# ------------------------ >8 ------------------------
+# Do not modify or remove the line above.
+# Everything below it will be ignored.
+diff --git a/src/Task/Git/CommitMessage.php b/src/Task/Git/CommitMessage.php
+Something very long. Something very long. Something very long. Something very long. Something very long. Something very long.
+MSG;
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(true);
+    }
+
+    function it_should_fail_when_using_git_verbose_on_wide_body_but_not_with_with_verbose_part_very_wide(GrumPHP $grumPHP, GitCommitMsgContext $context)
+    {
+        $commitMessage = <<<'MSG'
+A subject line that is just fine
+
+Something very long. Something very long. Something very long. Something very long. Something very long. Something very long.
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch fix-ignore-git-verbose
+# Changes to be committed:
+#	modified:   src/Task/Git/CommitMessage.php
+#
+# ------------------------ >8 ------------------------
+# Do not modify or remove the line above.
+# Everything below it will be ignored.
+diff --git a/src/Task/Git/CommitMessage.php b/src/Task/Git/CommitMessage.php
+Something very long. Something very long. Something very long. Something very long. Something very long. Something very long.
+MSG;
+        $context->getCommitMessage()->willReturn($commitMessage);
+
+        $result = $this->run($context);
+        $result->shouldBeAnInstanceOf(TaskResultInterface::class);
+        $result->isPassed()->shouldBe(false);
+        $result->getMessage()->shouldMatch('/line 3.*> 72.*/im');
+    }
+
     function it_should_fail_when_subject_contains_a_trailing_period(GrumPHP $grumPHP, GitCommitMsgContext $context)
     {
         $grumPHP->getTaskConfiguration('git_commit_message')->willReturn([

--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -294,9 +294,14 @@ class CommitMessage implements TaskInterface
     private function getCommitMessageLinesWithoutComments(string $commitMessage): array
     {
         $lines = preg_split('/\R/u', $commitMessage);
+        $everything_below_will_be_ignored = false;
 
-        return array_values(array_filter($lines, function ($line) {
-            return 0 !== strpos($line, '#');
+        return array_values(array_filter($lines, function ($line) use (&$everything_below_will_be_ignored) {
+            if (mb_stripos($line, '# Everything below it will be ignored.') !== false) {
+                $everything_below_will_be_ignored = true;
+                return false;
+            }
+            return 0 !== strpos($line, '#') && !$everything_below_will_be_ignored;
         }));
     }
 

--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -294,14 +294,14 @@ class CommitMessage implements TaskInterface
     private function getCommitMessageLinesWithoutComments(string $commitMessage): array
     {
         $lines = preg_split('/\R/u', $commitMessage);
-        $everything_below_will_be_ignored = false;
+        $everythingBelowWillBeIgnored = false;
 
-        return array_values(array_filter($lines, function ($line) use (&$everything_below_will_be_ignored) {
+        return array_values(array_filter($lines, function ($line) use (&$everythingBelowWillBeIgnored) {
             if (mb_stripos($line, '# Everything below it will be ignored.') !== false) {
-                $everything_below_will_be_ignored = true;
+                $everythingBelowWillBeIgnored = true;
                 return false;
             }
-            return 0 !== strpos($line, '#') && !$everything_below_will_be_ignored;
+            return 0 !== strpos($line, '#') && !$everythingBelowWillBeIgnored;
         }));
     }
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #656 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

This commit looks for a known marker in the git commit message when using `git --verbose` when the marker is seen it will ignore all lines after that (it will assume them to be comments).

The specs will test that long commit messages still fails above the marker.

<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [ ] Is the README.md file updated?
- [ ] Are the dependencies added to the composer.json suggestions?
- [ ] Is the doc/tasks.md file updated?
- [ ] Are the task parameters documented?
- [ ] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpspec tests?
- [ ] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?