### PR TITLE
Add exclude parameter to twigcs task

### DIFF
--- a/doc/tasks/twigcs.md
+++ b/doc/tasks/twigcs.md
@@ -18,6 +18,7 @@ parameters:
     tasks:
         twigcs:
             path: '.'
+            exclude: []
             severity: 'warning'
             ruleset: 'FriendsOfTwig\Twigcs\Ruleset\Official'
             triggered_by: ['twig']
@@ -29,6 +30,12 @@ parameters:
 
 By default `.` (current folder) will be used.
 You can specify an alternate location by changing this option.
+
+**exclude**
+
+*Default: []*
+
+List of directories to exclude.
 
 **severity**
 

--- a/src/Task/TwigCs.php
+++ b/src/Task/TwigCs.php
@@ -23,12 +23,14 @@ class TwigCs extends AbstractExternalTask
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
             'path' => '.',
+            'exclude' => [],
             'severity' => 'warning',
             'ruleset' => 'FriendsOfTwig\Twigcs\Ruleset\Official',
             'triggered_by' => ['twig'],
         ]);
 
         $resolver->addAllowedTypes('path', ['string']);
+        $resolver->addAllowedTypes('exclude', ['string[]']);
         $resolver->addAllowedTypes('severity', ['string']);
         $resolver->addAllowedTypes('ruleset', ['string']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
@@ -53,6 +55,7 @@ class TwigCs extends AbstractExternalTask
         $arguments = $this->processBuilder->createArgumentsForCommand('twigcs');
         $arguments->add($config['path']);
 
+        $arguments->addArgumentArray('--exclude=%s', $config['exclude']);
         $arguments->addOptionalArgument('--severity=%s', $config['severity']);
         $arguments->addOptionalArgument('--ruleset=%s', $config['ruleset']);
         $arguments->addOptionalArgument('--ansi', true);


### PR DESCRIPTION
TwigCS 4.x will have a `--exclude` option. This PR adds it to the TwigCS-Task.
