### PR TITLE
Add a footnote on using finder config in intersection mode

### DIFF
--- a/doc/tasks/phpcsfixer2.md
+++ b/doc/tasks/phpcsfixer2.md
@@ -103,8 +103,11 @@ Cache is supported only for tool downloaded as phar file or installed via compos
 
 Intersection mode can only be used when you have a configuration file which contains a Finder.
 This mode works best since only files that are being commit and are in your configuration will be checked.
-When there is no Finder in your configuration, you'll have set this parameter to false. 
+When there is no Finder in your configuration, you'll have set this parameter to false.
 Otherwise php-cs-fixer will crash the execution.
+
+Note that activating this option with a consequent target directory will be slow on certain envs such as
+osx+docker.
 
 **verbose**
 
@@ -124,4 +127,3 @@ Show the full diff that will be applied.
 *Default: [php]*
 
 This option will specify which file extensions will trigger the phpcsfixer2 task.
-


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes

Add a footnote that warns about setting the `config_contains_finder` to `true` (or leaving the default which is `true`) when using php-cs-fixer2 task on a lot of files. 

See https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4745 : on a docker+osx environment, leaving the intersection with the list of files given by grumphp can go into a timeout, if configured (otherwise it runs for a long time, gave up after 2min).

We didn't have this problem because we were making our own php_cs config for grumphp, which had a finder... but with only the result of the `git diff --staged` command (and a few pipes and greps). Removing this check from the config showed me something was wrong.

We should even probably thing of setting this to `false` by default, but that would probably be a bc break (not sure how to handle a real intersection)