### PR TITLE
Fixed label output

### DIFF
--- a/src/Configuration/Compiler/TaskCompilerPass.php
+++ b/src/Configuration/Compiler/TaskCompilerPass.php
@@ -45,7 +45,7 @@ class TaskCompilerPass implements CompilerPassInterface
             // Determine Keys:
             $currentTaskService = $availableTasks[$currentTaskName];
             ['id' => $taskId, 'class' => $taskClass,] = $currentTaskService;
-            $configuredTaskKey = $taskId.'.configured';
+            $configuredTaskKey = $taskName.'.configured';
 
             // Configure task:
             $taskBuilder = new Definition($taskClass, [

--- a/src/Configuration/Compiler/TaskCompilerPass.php
+++ b/src/Configuration/Compiler/TaskCompilerPass.php
@@ -45,7 +45,7 @@ class TaskCompilerPass implements CompilerPassInterface
             // Determine Keys:
             $currentTaskService = $availableTasks[$currentTaskName];
             ['id' => $taskId, 'class' => $taskClass,] = $currentTaskService;
-            $configuredTaskKey = $taskName.'.configured';
+            $configuredTaskKey = $taskId.'.'.$taskName.'.configured';
 
             // Configure task:
             $taskBuilder = new Definition($taskClass, [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no

With the taskId as key the label config gets overwriten by the last configuration

Test Setup:
```
    tasks:
        shell:
            scripts:
                - ['-c', 'echo', 'Running Task']
        shell_phpcs:
            metadata:
                label: 'Test'
                task: shell
            scripts:
            - ['-c', 'echo', 'test1']
        shell_phpmd:
            metadata:
                label: 'Hello'
                task: shell
            scripts:
                - ['-c', 'echo', 'test1']
```

Output with taskId: 

```
Running task 1/3: Hello... ✔
Running task 2/3: Hello... ✔
Running task 3/3: Hello... ✔
```
Output with taskName: 

```
Running task 1/3: shell... ✔
Running task 2/3: Test... ✔
Running task 3/3: Hello... ✔
```