### PR TITLE
Added support for phar executables

### DIFF
--- a/doc/tasks/psalm.md
+++ b/doc/tasks/psalm.md
@@ -8,6 +8,11 @@ It lives under the `psalm` namespace and has following configurable parameters:
 composer require --dev vimeo/psalm
 ```
 
+If you'd like to use the Phar version
+```bash
+composer require --dev psalm/phar
+```
+
 ## Config
 ```yaml
 # grumphp.yml

--- a/spec/Locator/ExternalCommandSpec.php
+++ b/spec/Locator/ExternalCommandSpec.php
@@ -4,7 +4,6 @@ namespace spec\GrumPHP\Locator;
 
 use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Locator\ExternalCommand;
-use GrumPHP\Util\Filesystem;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Process\ExecutableFinder;
 
@@ -23,12 +22,26 @@ class ExternalCommandSpec extends ObjectBehavior
     function it_throws_exception_when_external_command_is_not_found(ExecutableFinder $executableFinder)
     {
         $executableFinder->find('test', null, ['bin'])->willReturn(false);
+        $executableFinder->find('test.phar', null, ['bin'])->willReturn(false);
         $this->shouldThrow(RuntimeException::class)->duringLocate('test');
     }
 
     function it_locates_external_commands(ExecutableFinder $executableFinder)
     {
         $executableFinder->find('test', null, ['bin'])->willReturn('bin/test');
+        $this->locate('test')->shouldEqual('bin/test');
+    }
+
+    function it_locates_external_commands_with_a_suffix(ExecutableFinder $executableFinder)
+    {
+        $executableFinder->find('test', null, ['bin'])->willReturn(false);
+        $executableFinder->find('test.phar', null, ['bin'])->willReturn('bin/test.phar');
+        $this->locate('test')->shouldEqual('bin/test.phar');
+    }
+
+    function it_locates_external_commands_without_suffix_first(ExecutableFinder $executableFinder) {
+        $executableFinder->find('test', null, ['bin'])->willReturn('bin/test');
+        $executableFinder->find('test.phar', null, ['bin'])->willReturn('bin/test.phar');
         $this->locate('test')->shouldEqual('bin/test');
     }
 }

--- a/src/Locator/ExternalCommand.php
+++ b/src/Locator/ExternalCommand.php
@@ -38,23 +38,18 @@ class ExternalCommand
 
     public function locate(string $command): string
     {
-        $executable = false;
         foreach ($this->suffixes as $suffix) {
             $cmdName = $command . $suffix;
             // Search executable:
             $executable = $this->executableFinder->find($cmdName, null, [$this->binDir]);
 
             if ($executable) {
-                break;
+                return $executable;
             }
         }
 
-        if (!$executable) {
-            throw new RuntimeException(
-                sprintf('The executable for "%s" could not be found.', $command)
-            );
-        }
-
-        return $executable;
+        throw new RuntimeException(
+            sprintf('The executable for "%s" could not be found.', $command)
+        );
     }
 }

--- a/src/Locator/ExternalCommand.php
+++ b/src/Locator/ExternalCommand.php
@@ -10,6 +10,8 @@ use Symfony\Component\Process\ExecutableFinder;
 
 class ExternalCommand
 {
+    private $suffixes = ['', '.phar'];
+
     /**
      * @var string
      */
@@ -36,8 +38,17 @@ class ExternalCommand
 
     public function locate(string $command): string
     {
-        // Search executable:
-        $executable = $this->executableFinder->find($command, null, [$this->binDir]);
+        $executable = false;
+        foreach ($this->suffixes as $suffix) {
+            $cmdName = $command . $suffix;
+            // Search executable:
+            $executable = $this->executableFinder->find($cmdName, null, [$this->binDir]);
+
+            if ($executable) {
+                break;
+            }
+        }
+
         if (!$executable) {
             throw new RuntimeException(
                 sprintf('The executable for "%s" could not be found.', $command)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
Not every project allows to install psalm as a dependency.
I could not run the psalm task as I had installed the phar version.
I added support for the phar version of psalm in this PR by adding a new config option.

