### PR TITLE
Removed unused parameters for grumphp.yml.dist

### DIFF
--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -1,6 +1,4 @@
 parameters:
-  bin_dir: "./vendor/bin"
-  git_dir: "."
   process_timeout: 300
   tasks:
     phpcs:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
I deleted the bin_dir and git_dir options from the grumphp.yml.dist as they are no longer used.

<!-- Are you creating a new task? Make sure to complete this checklist: -->
