### PR TITLE
fixes Phpcs task ignoring 'triggered_by' option when crafting the act…

### DIFF
--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -120,6 +120,7 @@ class Phpcs extends AbstractExternalTask
         $arguments->addOptionalCommaSeparatedArgument('--sniffs=%s', $config['sniffs']);
         $arguments->addOptionalCommaSeparatedArgument('--ignore=%s', $config['ignore_patterns']);
         $arguments->addOptionalCommaSeparatedArgument('--exclude=%s', $config['exclude']);
+        $arguments->addOptionalCommaSeparatedArgument('--extensions=%s', $config['triggered_by']);
 
         return $arguments;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

the `phpcs` task allows to pass a list of file extension to consider (`triggered_by`);
although this parameter is considered in the `vendor/phpro/grumphp/src/Task/Phpcs.php` task class to build the file list (to check if *actually* have some file to process, and exit otherwise) the parameter is **not** eventually used in the method building the actual phpcs command (would translate into the `--extensions=` parameter). 

this patch simply remedies that with an extra line in `vendor/phpro/grumphp/src/Task/Phpcs.php@addArgumentsFromConfig`

```
$arguments->addOptionalCommaSeparatedArgument('--extensions=%s', $config['triggered_by']);
```