### PR TITLE
Fixed exception message in constructor

### DIFF
--- a/src/Task/AbstractLinterTask.php
+++ b/src/Task/AbstractLinterTask.php
@@ -64,7 +64,10 @@ abstract class AbstractLinterTask implements TaskInterface
     {
         if (!$this->linter->isInstalled()) {
             throw new RuntimeException(
-                sprintf('The %s can\'t run on your system. Please install all dependencies.', $this->getName())
+                sprintf(
+                    'The %s can\'t run on your system. Please install all dependencies.',
+                    $this->getConfig()->getName()
+                )
             );
         }
     }

--- a/src/Task/AbstractParserTask.php
+++ b/src/Task/AbstractParserTask.php
@@ -31,7 +31,10 @@ abstract class AbstractParserTask implements TaskInterface
 
         if (!$parser->isInstalled()) {
             throw new RuntimeException(
-                sprintf('The %s can\'t run on your system. Please install all dependencies.', $this->getName())
+                sprintf(
+                    'The %s can\'t run on your system. Please install all dependencies.',
+                    $this->getConfig()->getName()
+                )
             );
         }
     }
@@ -54,12 +57,6 @@ abstract class AbstractParserTask implements TaskInterface
     {
         return $this->configuration;
     }
-    
-    public function getName() : string
-    {
-        return get_class($this);
-    }
-
 
     public function withConfig(TaskConfigInterface $config): TaskInterface
     {

--- a/src/Task/AbstractParserTask.php
+++ b/src/Task/AbstractParserTask.php
@@ -54,6 +54,11 @@ abstract class AbstractParserTask implements TaskInterface
     {
         return $this->configuration;
     }
+    
+    public function getName() : string
+    {
+        return get_class($this);
+    }
 
 
     public function withConfig(TaskConfigInterface $config): TaskInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
If you add phpparser to your tasks but forget to require php-parser in composer the exception thrown in the constructer hits an undefined getName() method. This could be added in the interface or in this abstract class, I chose the later.

**constructor code**
```

    public function __construct(ParserInterface $parser)
    {
        $this->configuration = new EmptyTaskConfig();
        $this->parser = $parser;

        if (!$parser->isInstalled()) {
            throw new RuntimeException(
                sprintf('The %s can\'t run on your system. Please install all dependencies.', $this->getName())
            );
        }
    }
````