### PR TITLE
[Docs][PHPlint] Change parallel-lint package

### DIFF
--- a/doc/tasks/phplint.md
+++ b/doc/tasks/phplint.md
@@ -5,7 +5,7 @@ The PHPLint task will check your source files for syntax errors.
 ***Composer***
 
 ```
-composer require --dev jakub-onderka/php-parallel-lint
+composer require --dev php-parallel-lint/php-parallel-lint
 ```
 
 ***Config***


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | N/A

The proposed package for php-parallel-lint [is abandoned](https://github.com/JakubOnderka/PHP-Parallel-Lint#php-parallel-lint). The library I changed is the proposed alternative fork.

I tested by requiring it locally, and the task work :+1: 

