### PR TITLE
Psalm phar support

### DIFF
--- a/doc/tasks/psalm.md
+++ b/doc/tasks/psalm.md
@@ -22,11 +22,12 @@ parameters:
             config: psalm.xml
             ignore_patterns: []
             no_cache: false
-            report: ~ 
+            report: ~
             output_format: null
             threads: 1
             triggered_by: ['php']
             show_info: false
+            phar: false
 ```
 
 
@@ -57,7 +58,7 @@ With this parameter you can run Psalm without using the cache file.
 
 *Default: null*
 
-With this path you can specify the path your psalm report file 
+With this path you can specify the path your psalm report file
 
 
 **output_format**
@@ -85,3 +86,10 @@ This is a list of extensions to be sniffed.
 *Default: false*
 
 Show non-exception parser findings
+
+**phar**
+
+*Default: false*
+
+Use "psalm.phar" instead of just "psalm" as the name of the Psalm command. Set to true
+if you wish to use the Phar package.

--- a/src/Task/Psalm.php
+++ b/src/Task/Psalm.php
@@ -25,6 +25,7 @@ class Psalm extends AbstractExternalTask
             'threads' => null,
             'triggered_by' => ['php'],
             'show_info' => false,
+            'phar' => false,
         ]);
 
         $resolver->addAllowedTypes('config', ['null', 'string']);
@@ -35,6 +36,7 @@ class Psalm extends AbstractExternalTask
         $resolver->addAllowedTypes('threads', ['null', 'int']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
         $resolver->addAllowedTypes('show_info', ['bool']);
+        $resolver->addAllowedTypes('phar', ['bool']);
 
         $resolver->setAllowedValues(
             'output_format',
@@ -62,7 +64,9 @@ class Psalm extends AbstractExternalTask
             return TaskResult::createSkipped($this, $context);
         }
 
-        $arguments = $this->processBuilder->createArgumentsForCommand('psalm');
+        $command = $config['phar'] ? 'psalm.phar' : 'psalm';
+
+        $arguments = $this->processBuilder->createArgumentsForCommand($command);
         $arguments->addOptionalArgument('--output-format=%s', $config['output_format']);
         $arguments->addOptionalArgument('--config=%s', $config['config']);
         $arguments->addOptionalArgument('--report=%s', $config['report']);

--- a/test/Unit/Task/PsalmTest.php
+++ b/test/Unit/Task/PsalmTest.php
@@ -33,6 +33,7 @@ class PsalmTest extends AbstractExternalTaskTestCase
                 'threads' => null,
                 'triggered_by' => ['php'],
                 'show_info' => false,
+                'phar' => false,
             ]
         ];
     }
@@ -183,6 +184,16 @@ class PsalmTest extends AbstractExternalTaskTestCase
                 '--show-info=false',
                 'hello.php',
                 'hello2.php',
+            ]
+        ];
+        yield 'use-phar' => [
+            [
+                'phar' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'psalm.phar',
+            [
+                '--show-info=false',
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | n/a

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
When using the phar package of Psalm as advertised in the task docs:
`composer require --dev psalm/phar`
...then the Psalm binary will be installed as "psalm.phar". Unfortunately, when executing the external command, the Psalm task would always use the binary name without the .phar extension, resulting in the error message `The executable for "psalm" could not be found.`on the console.

This PR introduces a new configuration option "phar" to the Psalm task that will use "psalm.phar" as the binary name when set to true.

Tests and docs have been updated to reflect the new option. There should be no side-effects.

I ticket "bug fix" instead of feature because the possibility of using the phar package was advertised in the task docs but does not work out-of-the-box when following the installation instructions.
