### PR TITLE
[phpmd] Allow setting output format to ansi

### DIFF
--- a/doc/tasks/phpmd.md
+++ b/doc/tasks/phpmd.md
@@ -19,6 +19,7 @@ parameters:
         phpmd:
             whitelist_patterns: []
             exclude: []
+            report_format: text
             ruleset: ['cleancode', 'codesize', 'naming']
             triggered_by: ['php']
 ```
@@ -40,6 +41,13 @@ whitelist_patterns:
 *Default: []*
 
 This is a list of patterns that will be ignored by phpmd. With this option you can skip directories like tests. Leave this option blank to run phpmd for every php file.
+
+**report_format**
+
+*Default: text*
+
+This sets the output [renderer](https://phpmd.org/documentation/#renderers) of phpmd.
+Available formats: ansi, text.
 
 **ruleset**
 

--- a/src/Task/PhpMd.php
+++ b/src/Task/PhpMd.php
@@ -22,12 +22,15 @@ class PhpMd extends AbstractExternalTask
         $resolver->setDefaults([
             'whitelist_patterns' => [],
             'exclude' => [],
+            'report_format' => 'text',
             'ruleset' => ['cleancode', 'codesize', 'naming'],
             'triggered_by' => ['php'],
         ]);
 
         $resolver->addAllowedTypes('whitelist_patterns', ['array']);
         $resolver->addAllowedTypes('exclude', ['array']);
+        $resolver->addAllowedTypes('report_format', ['string']);
+        $resolver->addAllowedValues('report_format', ['text', 'ansi']);
         $resolver->addAllowedTypes('ruleset', ['array']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
@@ -64,7 +67,7 @@ class PhpMd extends AbstractExternalTask
 
         $arguments = $this->processBuilder->createArgumentsForCommand('phpmd');
         $arguments->addCommaSeparatedFiles($files);
-        $arguments->add('text');
+        $arguments->add($config['report_format']);
         $arguments->addOptionalCommaSeparatedArgument('%s', $config['ruleset']);
         $arguments->addOptionalArgument('--exclude', !empty($config['exclude']));
         $arguments->addOptionalCommaSeparatedArgument('%s', $config['exclude']);

--- a/test/Unit/Task/PhpMdTest.php
+++ b/test/Unit/Task/PhpMdTest.php
@@ -27,6 +27,7 @@ class PhpMdTest extends AbstractExternalTaskTestCase
             [
                 'whitelist_patterns' => [],
                 'exclude' => [],
+                'report_format' => 'text',
                 'ruleset' => ['cleancode', 'codesize', 'naming'],
                 'triggered_by' => ['php'],
             ]
@@ -141,6 +142,19 @@ class PhpMdTest extends AbstractExternalTaskTestCase
                 'hello.php,hello2.php',
                 'text',
                 'cleancode',
+            ]
+        ];
+
+        yield 'report_formats' => [
+            [
+                'report_format' => 'ansi',
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'phpmd',
+            [
+                'hello.php,hello2.php',
+                'ansi',
+                'cleancode,codesize,naming',
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
Since [2.8](https://phpmd.org/#phpmd-2-8-0-2019-12-18-) phpmd has a new, subjectively nicer, report format that is ansi

**ansi**
<img width="675" alt="Screen Shot 2020-05-08 at 1 07 25 PM" src="https://user-images.githubusercontent.com/39970/81440228-eaacc080-912c-11ea-975f-3172f87b1d74.png">
**text (current)**
![image](https://user-images.githubusercontent.com/39970/81440337-1f207c80-912d-11ea-9c4a-9eef6d7ceee3.png)

I did not set the default to ansi for this PR, as the renderer is not available in older versions of phpmd

