### PR TITLE
Composer v2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ php:
 
 env:
   matrix:
-    -
-    - DEPENDENCIES=--prefer-lowest
+    - COMPOSER_VERSION=1
+    - COMPOSER_VERSION=2
+    - COMPOSER_VERSION=1 DEPENDENCIES=--prefer-lowest
 
 cache:
   directories:
@@ -22,8 +23,11 @@ matrix:
 
 before_install:
   - phpenv config-rm xdebug.ini
-  - alias composer=composer\ --no-interaction && composer selfupdate
-  - composer global require hirak/prestissimo
+  - alias composer=composer\ --no-interaction && composer selfupdate --$COMPOSER_VERSION
+  - |
+      if [ $COMPOSER_VERSION -eq 1 ]; then
+        composer global require hirak/prestissimo
+      fi;
 
 install:
   - travis_retry composer update --no-progress --profile --no-scripts --no-suggest $DEPENDENCIES

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
     - dependencies: highest
       php_version: 7.3
     - dependencies: highest
-      php_version: 7.4
+      php_version: 7.4.3  # OpenSSL issue will be resolved in 7.4.6
 
   project_directory: c:\projects\grumphp
   composer_directory: c:\tools\composer

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "composer-plugin-api": "~1.0",
+        "composer-plugin-api": "~1.0 || ~2.0",
         "doctrine/collections": "~1.2",
         "gitonomy/gitlib": "^1.0.3",
         "monolog/monolog": "~1.16 || ^2.0",
@@ -32,10 +32,9 @@
         "symfony/yaml": "~3.4 || ~4.0 || ~5.0"
     },
     "require-dev": {
-        "brianium/paratest": "~3.1",
-        "composer/composer": "~1.9",
+        "brianium/paratest": "~3.1 || dev-master",
+        "composer/composer": "~1.9 || ^2.0@dev",
         "ergebnis/composer-normalize": "~2.1",
-        "friendsofphp/php-cs-fixer": "~2.16",
         "jakub-onderka/php-parallel-lint": "~1.0",
         "nikic/php-parser": "~3.1",
         "phpspec/phpspec": "~6.1",

--- a/src/Composer/GrumPHPPlugin.php
+++ b/src/Composer/GrumPHPPlugin.php
@@ -66,6 +66,20 @@ class GrumPHPPlugin implements PluginInterface, EventSubscriberInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
      * Attach package installation events:.
      *
      * {@inheritdoc}

--- a/test/Unit/Task/AntTest.php
+++ b/test/Unit/Task/AntTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Ant;
 use GrumPHP\Task\Context\GitPreCommitContext;

--- a/test/Unit/Task/AtoumTest.php
+++ b/test/Unit/Task/AtoumTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/BehatTest.php
+++ b/test/Unit/Task/BehatTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/BrunchTest.php
+++ b/test/Unit/Task/BrunchTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/CodeceptionTest.php
+++ b/test/Unit/Task/CodeceptionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/ComposerNormalizeTest.php
+++ b/test/Unit/Task/ComposerNormalizeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/ComposerRequireCheckerTest.php
+++ b/test/Unit/Task/ComposerRequireCheckerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/ComposerScriptTest.php
+++ b/test/Unit/Task/ComposerScriptTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/ComposerTest.php
+++ b/test/Unit/Task/ComposerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/DeptracTest.php
+++ b/test/Unit/Task/DeptracTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/DoctrineOrmTest.php
+++ b/test/Unit/Task/DoctrineOrmTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/EcsTest.php
+++ b/test/Unit/Task/EcsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/GherkinTest.php
+++ b/test/Unit/Task/GherkinTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/Git/BlacklistTest.php
+++ b/test/Unit/Task/Git/BlacklistTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task\Git;
+namespace GrumPHPTest\Unit\Task\Git;
 
 use GrumPHP\IO\IOInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;

--- a/test/Unit/Task/Git/CommitMessageTest.php
+++ b/test/Unit/Task/Git/CommitMessageTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task\Git;
+namespace GrumPHPTest\Unit\Task\Git;
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Task\Context\ContextInterface;

--- a/test/Unit/Task/GruntTest.php
+++ b/test/Unit/Task/GruntTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/GulpTest.php
+++ b/test/Unit/Task/GulpTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/InfectionTest.php
+++ b/test/Unit/Task/InfectionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/KahlanTest.php
+++ b/test/Unit/Task/KahlanTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/MakeTest.php
+++ b/test/Unit/Task/MakeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/NpmScriptTest.php
+++ b/test/Unit/Task/NpmScriptTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/ParatestTest.php
+++ b/test/Unit/Task/ParatestTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/PhanTest.php
+++ b/test/Unit/Task/PhanTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/PhingTest.php
+++ b/test/Unit/Task/PhingTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/Php7ccTest.php
+++ b/test/Unit/Task/Php7ccTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\GitPreCommitContext;

--- a/test/Unit/Task/PhpCsFixerV2Test.php
+++ b/test/Unit/Task/PhpCsFixerV2Test.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Formatter\PhpCsFixerFormatter;
 use GrumPHP\Task\Context\GitPreCommitContext;

--- a/test/Unit/Task/PhpLintTest.php
+++ b/test/Unit/Task/PhpLintTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/PhpMdTest.php
+++ b/test/Unit/Task/PhpMdTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/PhpMndTest.php
+++ b/test/Unit/Task/PhpMndTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/PhpStanTest.php
+++ b/test/Unit/Task/PhpStanTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/PhpcsTest.php
+++ b/test/Unit/Task/PhpcsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Exception\RuntimeException;

--- a/test/Unit/Task/PhpspecTest.php
+++ b/test/Unit/Task/PhpspecTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/PhpunitBridgeTest.php
+++ b/test/Unit/Task/PhpunitBridgeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/PhpunitTest.php
+++ b/test/Unit/Task/PhpunitTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/ProgpilotTest.php
+++ b/test/Unit/Task/ProgpilotTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/PsalmTest.php
+++ b/test/Unit/Task/PsalmTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/RoboTest.php
+++ b/test/Unit/Task/RoboTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/SecurityCheckerTest.php
+++ b/test/Unit/Task/SecurityCheckerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/ShellTest.php
+++ b/test/Unit/Task/ShellTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;

--- a/test/Unit/Task/TwigCsTest.php
+++ b/test/Unit/Task/TwigCsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GrumPHPTest\Uni\Task;
+namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #756 

This pull request adds support for Composer v2. I've also added the version of composer to the test matrix, so both versions are tested.

- Wrong namespaces don't get autoloaded anymore in Composer v2, so I fixed that as well.
- Paratest has not created a version supporting composer v2 yet, this is why I included the dev requirement
- friendsofphp/php-cs-fixer has an open PR for composer v2 (https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4935), but doesn't even seem to be needed anymore in the dev requirements, so I left it out. The alternative would be to include a phar version of php-cs-fixer for Travis.
- hirak/prestissimo should not be installed anymore for composer v2 (this is now built-in), see https://github.com/hirak/prestissimo/issues/218
- I don't think we need to use deactivate/uninstall (for now), because cleanup is already done by using events. Maybe things can be cleaned up / optimized after composer v1 has been dropped.

