### PR TITLE
Fix invalid config generation

### DIFF
--- a/src/Console/Command/ConfigureCommand.php
+++ b/src/Console/Command/ConfigureCommand.php
@@ -138,7 +138,7 @@ class ConfigureCommand extends Command
 
         // Build configuration
         return [
-            'parameters' => [
+            'grumphp' => [
                 'tasks' => array_map(function ($task) {
                     return null;
                 }, array_flip($tasks)),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 0.19.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 


When `composer install` does not find a grumphp.yml file, the configuration wizard is started.
Right after that, the `grumphp git:init` command is triggerd.
Since the content of the GrumPHP file still contains 'parameters', you get this error:

```
PHP Fatal error:  Uncaught GrumPHP\Exception\DeprecatedException: Direct configuration of parameter tasks is not allowed anymore.
Please rename the `parameters` section in your grumphp.yaml file to `grumphp`.
More info: https://github.com/phpro/grumphp/releases/tag/v0.19.0
```

