### PR TITLE
Add ESLint Task

### DIFF
--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -20,6 +20,7 @@ grumphp:
         deptrac: ~
         doctrine_orm: ~
         ecs: ~
+        eslint: ~
         file_size: ~
         gherkin: ~
         git_blacklist: ~
@@ -74,6 +75,7 @@ Every task has it's own default configuration. It is possible to overwrite the p
 - [Composer Script](tasks/composer_script.md)
 - [Doctrine ORM](tasks/doctrine_orm.md)
 - [Ecs EasyCodingStandard](tasks/ecs.md)
+- [ESLint](tasks/eslint.md)
 - [File size](tasks/file_size.md)
 - [Deptrac](tasks/deptrac.md)
 - [Gherkin](tasks/gherkin.md)

--- a/doc/tasks/eslint.md
+++ b/doc/tasks/eslint.md
@@ -34,7 +34,7 @@ grumphp:
                 - /^resources\/js\/(.*)/
             config: .eslintrc.json
             debug: false
-            format: stylish
+            format: ~
             max_warnings: ~
             no_eslintrc: false
             quiet: false
@@ -80,9 +80,9 @@ Turn on debug mode ([eslint.org](https://eslint.org/docs/user-guide/command-line
 
 **format**
 
-*Default: stylish*
+*Default: null*
 
-Output format, other handy ones on cli are `compact`, `codeframe` and `table` (see full list on [eslint.org](https://eslint.org/docs/user-guide/formatters/)).
+Output format, eslint will use `stylish` by default. Other handy ones on cli are `compact`, `codeframe` and `table` (see full list on [eslint.org](https://eslint.org/docs/user-guide/formatters/)).
 
 **max_warnings**
 

--- a/doc/tasks/eslint.md
+++ b/doc/tasks/eslint.md
@@ -37,6 +37,7 @@ grumphp:
             format: stylish
             max_warnings: ~
             no_eslintrc: false
+            quiet: false
 ```
 
 **bin**
@@ -94,6 +95,12 @@ Number of warnings (not errors) that are allowed before eslint exits with error 
 *Default: false*
 
 Set to true to ignore local .eslint config file ([eslint.org](https://eslint.org/docs/user-guide/command-line-interface#max-warnings)).
+
+**quiet**
+
+*Default: null*
+
+Report errors only (no warnings). [eslint.org](https://eslint.org/docs/user-guide/command-line-interface#quiet)
 
 **other settings**
 

--- a/doc/tasks/eslint.md
+++ b/doc/tasks/eslint.md
@@ -1,0 +1,100 @@
+# ESLint
+
+[ESLint](https://eslint.org/) is a static analysis tool for Javascript code. ESLint covers both code quality and coding style issues.
+
+## NPM
+If you'd like to install it globally:
+```bash
+npm -g eslint
+```
+
+If you'd like install it as a dev dependency of your project:
+```bash
+npm install eslint --save-dev
+```
+
+To generate a .eslintrc.* config file:
+```
+npx eslint --init
+```
+
+Done. See the ESLint [Getting Started](https://eslint.org/docs/user-guide/getting-started) guide for more info.
+
+## Config
+It lives under the `eslint` namespace and has the following configurable parameters:
+
+```yaml
+# grumphp.yml
+grumphp:
+    tasks:
+        eslint:
+            bin: node_modules/.bin/eslint
+            triggered_by: [js, jsx, ts, tsx, vue]
+            whitelist_patterns:
+                - /^resources\/js\/(.*)/
+            config: .eslintrc.json
+            debug: false
+            format: stylish
+            max_warnings: ~
+            no_eslintrc: false
+```
+
+**bin**
+
+*Default: null*
+
+The path to your eslint bin executable. Not necessary if eslint is in your $PATH. Can be used to specify path to project's eslint over globally installed eslint.
+
+
+**triggered_by**
+
+*Default: [js, jsx, ts, tsx, vue]*
+
+This is a list of extensions which will trigger the ESLint task.
+
+
+**whitelist_patterns**
+
+*Default: []*
+
+This is a list of regex patterns that will filter files to validate. With this option you can specify the folders containing javascript files and thus skip folders like /tests/ or the /vendor/ directory. This option is used in conjunction with the parameter `triggered_by`.
+For example: to whitelist files in `resources/js/` (Laravel's JS directory) and `assets/js/` (Symfony's JS directory) you can use:
+```yml
+whitelist_patterns:
+  - /^resources\/js\/(.*)/
+  - /^assets\/js\/(.*)/
+```
+
+**config**
+
+*Default: null*
+
+The path to your eslint's configuration file. Not necessary if using a standard eslintrc name, eg. .eslintrc.json, .eslint.js, or .eslint.yml
+
+**debug**
+
+*Default: false*
+
+Turn on debug mode ([eslint.org](https://eslint.org/docs/user-guide/command-line-interface#debug)).
+
+**format**
+
+*Default: stylish*
+
+Output format, other handy ones on cli are `compact`, `codeframe` and `table` (see full list on [eslint.org](https://eslint.org/docs/user-guide/formatters/)).
+
+**max_warnings**
+
+*Default: null*
+
+Number of warnings (not errors) that are allowed before eslint exits with error status ([eslint.org](https://eslint.org/docs/user-guide/command-line-interface#max-warnings)).
+
+**no_eslintrc**
+
+*Default: false*
+
+Set to true to ignore local .eslint config file ([eslint.org](https://eslint.org/docs/user-guide/command-line-interface#max-warnings)).
+
+**other settings**
+
+Any other eslint settings (such as rules, env, ignore patterns, etc) should be able to be set through an [eslint config file](https://eslint.org/docs/user-guide/configuring) (instructions to generate a config file at top of document).

--- a/resources/config/formatter.yml
+++ b/resources/config/formatter.yml
@@ -9,3 +9,5 @@ services:
         class: GrumPHP\Formatter\GitBlacklistFormatter
         arguments:
             - '@grumphp.io'
+    formatter.eslint:
+        class: GrumPHP\Formatter\ESLintFormatter

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -115,6 +115,13 @@ services:
         tags:
             - {name: grumphp.task, task: git_branch_name}
 
+    GrumPHP\Task\ESLint:
+        arguments:
+            - '@process_builder'
+            - '@formatter.raw_process'
+        tags:
+            - {name: grumphp.task, task: eslint}
+
     GrumPHP\Task\FileSize:
         tags:
             - {name: grumphp.task, task: file_size}

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -118,7 +118,7 @@ services:
     GrumPHP\Task\ESLint:
         arguments:
             - '@process_builder'
-            - '@formatter.raw_process'
+            - '@formatter.eslint'
         tags:
             - {name: grumphp.task, task: eslint}
 

--- a/spec/Formatter/ESLintFormatterSpec.php
+++ b/spec/Formatter/ESLintFormatterSpec.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace spec\GrumPHP\Formatter;
+
+use GrumPHP\Formatter\ESLintFormatter;
+use GrumPHP\Formatter\ProcessFormatterInterface;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Process\Process;
+use GrumPHP\Process\ProcessUtils;
+
+class ESLintFormatterSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ESLintFormatter::class);
+    }
+
+    function it_is_a_process_formatter()
+    {
+        $this->shouldHaveType(ProcessFormatterInterface::class);
+    }
+
+    function it_handles_command_exceptions(Process $process)
+    {
+        $process->getOutput()->willReturn('');
+        $process->getErrorOutput()->willReturn('stderr');
+        $this->format($process)->shouldReturn('stderr');
+    }
+
+    function it_formats_the_error_message()
+    {
+        $this->formatErrorMessage(['message1'], ['message2'])->shouldBeString();
+    }
+}

--- a/spec/Formatter/ESLintFormatterSpec.php
+++ b/spec/Formatter/ESLintFormatterSpec.php
@@ -29,6 +29,11 @@ class ESLintFormatterSpec extends ObjectBehavior
 
     function it_formats_the_error_message()
     {
-        $this->formatErrorMessage(['message1'], ['message2'])->shouldBeString();
+        $this->formatErrorMessage('message1', 'message2')
+            ->shouldBe(sprintf(
+                '%sYou can fix all errors by running the following commands:%s',
+                'message1' . PHP_EOL . PHP_EOL,
+                PHP_EOL . 'message2'
+            ));
     }
 }

--- a/src/Formatter/ESLintFormatter.php
+++ b/src/Formatter/ESLintFormatter.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Formatter;
+
+use Symfony\Component\Process\Process;
+
+class ESLintFormatter implements ProcessFormatterInterface
+{
+    public function format(Process $process): string
+    {
+        $stdout = $process->getOutput();
+        $stderr = $process->getErrorOutput();
+
+        return trim($stdout . PHP_EOL . $stderr);
+    }
+
+    public function formatErrorMessage(array $messages, array $suggestions): string
+    {
+        return sprintf(
+            '%sYou can fix all errors by running following commands:%s',
+            implode(PHP_EOL, $messages) . PHP_EOL . PHP_EOL,
+            PHP_EOL . implode(PHP_EOL, $suggestions)
+        );
+    }
+}

--- a/src/Formatter/ESLintFormatter.php
+++ b/src/Formatter/ESLintFormatter.php
@@ -16,12 +16,12 @@ class ESLintFormatter implements ProcessFormatterInterface
         return trim($stdout . PHP_EOL . $stderr);
     }
 
-    public function formatErrorMessage(array $messages, array $suggestions): string
+    public function formatErrorMessage(string $message, string $suggestion): string
     {
         return sprintf(
-            '%sYou can fix all errors by running following commands:%s',
-            implode(PHP_EOL, $messages) . PHP_EOL . PHP_EOL,
-            PHP_EOL . implode(PHP_EOL, $suggestions)
+            '%sYou can fix all errors by running the following commands:%s',
+            $message . PHP_EOL . PHP_EOL,
+            PHP_EOL . $suggestion
         );
     }
 }

--- a/src/Task/ESLint.php
+++ b/src/Task/ESLint.php
@@ -90,13 +90,13 @@ class ESLint extends AbstractExternalTask
         $process->run();
 
         if (!$process->isSuccessful()) {
-            $messages = [$this->formatter->format($process)];
+            $message = $this->formatter->format($process);
 
             $arguments->add('--fix');
             $process = $this->processBuilder->buildProcess($arguments);
             $fixerCommand = $process->getCommandLine();
 
-            $errorMessage = $this->formatter->formatErrorMessage($messages, [$fixerCommand]);
+            $errorMessage = $this->formatter->formatErrorMessage($message, $fixerCommand);
 
             return new FixableTaskResult(
                 TaskResult::createFailed($this, $context, $errorMessage),

--- a/src/Task/ESLint.php
+++ b/src/Task/ESLint.php
@@ -29,6 +29,7 @@ class ESLint extends AbstractExternalTask
             'format' => null,
             'max_warnings' => null,
             'no_eslintrc' => false,
+            'quiet' => false,
         ]);
 
         // Task config options
@@ -42,6 +43,7 @@ class ESLint extends AbstractExternalTask
         $resolver->addAllowedTypes('format', ['null', 'string']);
         $resolver->addAllowedTypes('max_warnings', ['null', 'integer']);
         $resolver->addAllowedTypes('no_eslintrc', ['bool']);
+        $resolver->addAllowedTypes('quiet', ['bool']);
 
         return $resolver;
     }
@@ -72,6 +74,7 @@ class ESLint extends AbstractExternalTask
         $arguments->addOptionalArgument('--debug', $config['debug']);
         $arguments->addOptionalArgument('--format=%s', $config['format']);
         $arguments->addOptionalArgument('--no-eslintrc', $config['no_eslintrc']);
+        $arguments->addOptionalArgument('--quiet', $config['quiet']);
         $arguments->addOptionalIntegerArgument('--max-warnings=%d', $config['max_warnings']);
         $arguments->addFiles($files);
 

--- a/src/Task/ESLint.php
+++ b/src/Task/ESLint.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Task;
+
+use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ESLint extends AbstractExternalTask
+{
+    public static function getConfigurableOptions(): OptionsResolver
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            // Task config options
+            'bin' => null,
+            'triggered_by' => ['js', 'jsx', 'ts', 'tsx', 'vue'],
+            'whitelist_patterns' => null,
+            
+            // ESLint native config options
+            'config' => null,
+            'debug' => false,
+            'format' => null,
+            'max_warnings' => null,
+            'no_eslintrc' => false,
+        ]);
+
+        // Task config options
+        $resolver->addAllowedTypes('bin', ['null', 'string']);
+        $resolver->addAllowedTypes('whitelist_patterns', ['null', 'array']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
+        
+        // ESLint native config options
+        $resolver->addAllowedTypes('config', ['null', 'string']);
+        $resolver->addAllowedTypes('debug', ['bool']);
+        $resolver->addAllowedTypes('format', ['null', 'string']);
+        $resolver->addAllowedTypes('max_warnings', ['null', 'integer']);
+        $resolver->addAllowedTypes('no_eslintrc', ['bool']);
+
+        return $resolver;
+    }
+
+    public function canRunInContext(ContextInterface $context): bool
+    {
+        return ($context instanceof GitPreCommitContext || $context instanceof RunContext);
+    }
+
+    public function run(ContextInterface $context): TaskResultInterface
+    {
+        $config = $this->getConfig()->getOptions();
+
+        $files = $context
+            ->getFiles()
+            ->paths($config['whitelist_patterns'] ?? [])
+            ->extensions($config['triggered_by']);
+
+        if (0 === \count($files)) {
+            return TaskResult::createSkipped($this, $context);
+        }
+
+        $arguments = isset($config['bin'])
+            ? ProcessArgumentsCollection::forExecutable($config['bin'])
+            : $this->processBuilder->createArgumentsForCommand('eslint');
+
+        $arguments->addOptionalArgument('--config=%s', $config['config']);
+        $arguments->addOptionalArgument('--debug', $config['debug']);
+        $arguments->addOptionalArgument('--format=%s', $config['format']);
+        $arguments->addOptionalArgument('--no-eslintrc', $config['no_eslintrc']);
+        $arguments->addOptionalIntegerArgument('--max-warnings=%d', $config['max_warnings']);
+        $arguments->addFiles($files);
+
+        $process = $this->processBuilder->buildProcess($arguments);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}

--- a/test/Unit/Task/ESLintTest.php
+++ b/test/Unit/Task/ESLintTest.php
@@ -143,13 +143,9 @@ class ESLintTest extends AbstractExternalTaskTestCase
                 'hello2.js',
             ]
         ];
-        yield 'config' => [
+        yield 'debug' => [
             [
                 'debug' => true,
-                'format' => 'table',
-                'no_eslintrc' => true,
-                'quiet' => true,
-                'max_warnings' => 10,
             ],
             $this->mockContext(RunContext::class, ['hello.js', 'hello2.js']),
             'eslint',
@@ -159,7 +155,7 @@ class ESLintTest extends AbstractExternalTaskTestCase
                 'hello2.js',
             ]
         ];
-        yield 'config' => [
+        yield 'format' => [
             [
                 'format' => 'table',
             ],
@@ -171,7 +167,7 @@ class ESLintTest extends AbstractExternalTaskTestCase
                 'hello2.js',
             ]
         ];
-        yield 'config' => [
+        yield 'no_eslintrc' => [
             [
                 'no_eslintrc' => true,
             ],
@@ -183,7 +179,7 @@ class ESLintTest extends AbstractExternalTaskTestCase
                 'hello2.js',
             ]
         ];
-        yield 'config' => [
+        yield 'quiet' => [
             [
                 'quiet' => true,
             ],
@@ -195,7 +191,7 @@ class ESLintTest extends AbstractExternalTaskTestCase
                 'hello2.js',
             ]
         ];
-        yield 'config' => [
+        yield 'max_warnings' => [
             [
                 'max_warnings' => 10,
             ],

--- a/test/Unit/Task/ESLintTest.php
+++ b/test/Unit/Task/ESLintTest.php
@@ -106,6 +106,18 @@ class ESLintTest extends AbstractExternalTaskTestCase
 
     public function provideExternalTaskRuns(): iterable
     {
+        yield 'bin' => [
+            [
+                'bin' => 'node_modules/.bin/eslint',
+            ],
+            $this->mockContext(RunContext::class, ['hello.js', 'hello2.js']),
+            'eslint',
+            [
+                'node_modules/.bin/eslint',
+                'hello.js',
+                'hello2.js',
+            ]
+        ];
         yield 'config' => [
             [
                 'config' => '.eslintrc.json',
@@ -114,6 +126,70 @@ class ESLintTest extends AbstractExternalTaskTestCase
             'eslint',
             [
                 '--config=.eslintrc.json',
+                'hello.js',
+                'hello2.js',
+            ]
+        ];
+        yield 'config' => [
+            [
+                'debug' => true,
+                'format' => 'table',
+                'no_eslintrc' => true,
+                'quiet' => true,
+                'max_warnings' => 10,
+            ],
+            $this->mockContext(RunContext::class, ['hello.js', 'hello2.js']),
+            'eslint',
+            [
+                '--debug',
+                'hello.js',
+                'hello2.js',
+            ]
+        ];
+        yield 'config' => [
+            [
+                'format' => 'table',
+            ],
+            $this->mockContext(RunContext::class, ['hello.js', 'hello2.js']),
+            'eslint',
+            [
+                '--format=table',
+                'hello.js',
+                'hello2.js',
+            ]
+        ];
+        yield 'config' => [
+            [
+                'no_eslintrc' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.js', 'hello2.js']),
+            'eslint',
+            [
+                '--no-eslintrc',
+                'hello.js',
+                'hello2.js',
+            ]
+        ];
+        yield 'config' => [
+            [
+                'quiet' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.js', 'hello2.js']),
+            'eslint',
+            [
+                '--quiet',
+                'hello.js',
+                'hello2.js',
+            ]
+        ];
+        yield 'config' => [
+            [
+                'max_warnings' => 10,
+            ],
+            $this->mockContext(RunContext::class, ['hello.js', 'hello2.js']),
+            'eslint',
+            [
+             '--max-warnings=10',
                 'hello.js',
                 'hello2.js',
             ]

--- a/test/Unit/Task/ESLintTest.php
+++ b/test/Unit/Task/ESLintTest.php
@@ -4,16 +4,26 @@ declare(strict_types=1);
 
 namespace GrumPHP\Test\Unit\Task;
 
+use GrumPHP\Formatter\ESLintFormatter;
+use GrumPHP\Runner\FixableTaskResult;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use GrumPHP\Task\ESLint;
 use GrumPHP\Task\TaskInterface;
 use GrumPHP\Test\Task\AbstractExternalTaskTestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Prophecy\Argument;
 
 class ESLintTest extends AbstractExternalTaskTestCase
 {
+    /**
+     * @var ESLintFormatter|ObjectProphecy
+     */
+    protected $formatter;
+
     protected function provideTask(): TaskInterface
     {
+        $this->formatter = $this->prophesize(ESLintFormatter::class);
         return new ESLint(
             $this->processBuilder->reveal(),
             $this->formatter->reveal()
@@ -66,9 +76,12 @@ class ESLintTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.js']),
             function () {
                 $this->mockProcessBuilder('eslint', $process = $this->mockProcess(1));
-                $this->formatter->format($process)->willReturn('nope');
+
+                $this->formatter->format($process)->willReturn($message = 'message');
+                $this->formatter->formatErrorMessage([$message], Argument::any())->willReturn('nope');
             },
-            'nope'
+            'nope',
+            FixableTaskResult::class
         ];
     }
 

--- a/test/Unit/Task/ESLintTest.php
+++ b/test/Unit/Task/ESLintTest.php
@@ -78,7 +78,7 @@ class ESLintTest extends AbstractExternalTaskTestCase
                 $this->mockProcessBuilder('eslint', $process = $this->mockProcess(1));
 
                 $this->formatter->format($process)->willReturn($message = 'message');
-                $this->formatter->formatErrorMessage([$message], Argument::any())->willReturn('nope');
+                $this->formatter->formatErrorMessage($message, Argument::any())->willReturn('nope');
             },
             'nope',
             FixableTaskResult::class

--- a/test/Unit/Task/ESLintTest.php
+++ b/test/Unit/Task/ESLintTest.php
@@ -36,6 +36,7 @@ class ESLintTest extends AbstractExternalTaskTestCase
                 'format' => null,
                 'max_warnings' => null,
                 'no_eslintrc' => false,
+                'quiet' => false,
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | no

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

Add [ESLint](https://eslint.org/) task for javascript code static analysis (code quality and coding style). 

As a good amount of php projects also have some javascript frontend, it's handy to lint your JS during pre-commit as well.

Example task run:
```
$ git commit
GrumPHP detected a pre-commit command.
GrumPHP is sniffing your code!

Running task 1/4: phpcs... 
Running task 2/4: phpunit... 
Running task 3/4: phpstan... 
Running task 4/4: eslint... ✘

eslint
======

/resources/js/app.js
  23:1   error    Expected indentation of 4 spaces but found 8  indent

✖ 1 problem (1 error, 0 warnings)
  1 error potentially fixable with the `--fix` option.

You can fix all errors by running following commands:
'eslint' 'resources/js/app.js'  '--fix'
To skip commit checks, add -n or --no-verify flag to commit command

 I can fix some stuff automatically, do you want me to? (yes/no) [no]:
 > 
```

<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [ ] Are the dependencies added to the composer.json suggestions? (n/a)
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpunit tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?
