### PR TITLE
Typo: Remove extra space in output text of FixerUpper

### DIFF
--- a/src/Fixer/FixerUpper.php
+++ b/src/Fixer/FixerUpper.php
@@ -83,7 +83,7 @@ class FixerUpper
 
         try {
             $shouldFix = $this->IO->style()->confirm(
-                'I can fix  some stuff automatically, do you want me to?',
+                'I can fix some stuff automatically, do you want me to?',
                 $this->config->fixByDefault()
             );
         } catch (RuntimeException $askException) {


### PR DESCRIPTION
Fix double space between "can" and "fix": "I can__fix some stuff"

| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | n/a
| Fixed tickets | n/a