### PR TITLE
paratest: Add support for '--coverage-clover' and '--coverage-php'

### DIFF
--- a/doc/tasks/paratest.md
+++ b/doc/tasks/paratest.md
@@ -25,8 +25,10 @@ grumphp:
             configuration: null
             runner: null
             debugger: null
-            coverage-xml: null
+            coverage-clover: null
             coverage-html: null
+            coverage-php: null
+            coverage-xml: null
             log-junit: null
             testsuite: null
             verbose: false
@@ -81,7 +83,7 @@ The PHPUnit configuration file to use.
 
 Runner, WrapperRunner or SqliteRunner. (Default: Runner)
 
-**coverage-xml**
+**coverage-clover**
 
 *Default: null*
 
@@ -92,6 +94,18 @@ Generate code coverage report in Clover XML format.
 *Default: null*
 
 Generate code coverage report in HTML format.
+
+**coverage-php**
+
+*Default: null*
+
+Serialize PHP_CodeCoverage object to file.
+
+**coverage-xml**
+
+*Default: null*
+
+Generate code coverage report in PHPUnit XML format.
 
 **log-junit**
 

--- a/src/Task/Paratest.php
+++ b/src/Task/Paratest.php
@@ -25,8 +25,10 @@ class Paratest extends AbstractExternalTask
                 'always_execute' => false,
                 'group'          => [],
                 'runner'         => null,
-                'coverage-xml'   => null,
+                'coverage-clover'  => null,
                 'coverage-html'  => null,
+                'coverage-php'  => null,
+                'coverage-xml'   => null,
                 'log-junit'      => null,
                 'testsuite'      => null,
                 'config'         => null,
@@ -40,8 +42,10 @@ class Paratest extends AbstractExternalTask
         $resolver->addAllowedTypes('configuration', ['null', 'string']);
         $resolver->addAllowedTypes('always_execute', ['bool']);
         $resolver->addAllowedTypes('runner', ['null', 'string']);
-        $resolver->addAllowedTypes('coverage-xml', ['null', 'string']);
+        $resolver->addAllowedTypes('coverage-clover', ['null', 'string']);
         $resolver->addAllowedTypes('coverage-html', ['null', 'string']);
+        $resolver->addAllowedTypes('coverage-php', ['null', 'string']);
+        $resolver->addAllowedTypes('coverage-xml', ['null', 'string']);
         $resolver->addAllowedTypes('log-junit', ['null', 'string']);
         $resolver->addAllowedTypes('testsuite', ['null', 'string']);
         $resolver->addAllowedTypes('verbose', ['bool']);
@@ -69,8 +73,10 @@ class Paratest extends AbstractExternalTask
         $arguments->addOptionalArgument('-c=%s', $config['configuration']);
         $arguments->addOptionalArgument('--phpunit=%s', $config['phpunit']);
         $arguments->addOptionalArgument('--runner=%s', $config['runner']);
-        $arguments->addOptionalArgument('--coverage-xml=%s', $config['coverage-xml']);
+        $arguments->addOptionalArgument('--coverage-clover=%s', $config['coverage-clover']);
         $arguments->addOptionalArgument('--coverage-html=%s', $config['coverage-html']);
+        $arguments->addOptionalArgument('--coverage-php=%s', $config['coverage-php']);
+        $arguments->addOptionalArgument('--coverage-xml=%s', $config['coverage-xml']);
         $arguments->addOptionalArgument('--log-junit=%s', $config['log-junit']);
         $arguments->addOptionalArgument('--testsuite=%s', $config['testsuite']);
         $arguments->addOptionalArgument('--verbose=1', $config['verbose']);

--- a/test/Unit/Task/ParatestTest.php
+++ b/test/Unit/Task/ParatestTest.php
@@ -33,8 +33,10 @@ class ParatestTest extends AbstractExternalTaskTestCase
                 'configuration' => null,
                 'always_execute' => false,
                 'runner' => null,
-                'coverage-xml' => null,
+                'coverage-clover' => null,
                 'coverage-html' => null,
+                'coverage-php' => null,
+                'coverage-xml' => null,
                 'log-junit' => null,
                 'testsuite' => null,
                 'verbose' => false,
@@ -146,14 +148,14 @@ class ParatestTest extends AbstractExternalTaskTestCase
                 '--runner=WrapperRunner',
             ]
         ];
-        yield 'coverage-xml' => [
+        yield 'coverage-clover' => [
             [
-                'coverage-xml' => 'coverage.xml',
+                'coverage-clover' => 'clover.xml',
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'paratest',
             [
-                '--coverage-xml=coverage.xml',
+                '--coverage-clover=clover.xml',
             ]
         ];
         yield 'coverage-html' => [
@@ -164,6 +166,26 @@ class ParatestTest extends AbstractExternalTaskTestCase
             'paratest',
             [
                 '--coverage-html=coverage.html',
+            ]
+        ];
+        yield 'coverage-php' => [
+            [
+                'coverage-php' => 'coverage.php',
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'paratest',
+            [
+                '--coverage-php=coverage.php',
+            ]
+        ];
+        yield 'coverage-xml' => [
+            [
+                'coverage-xml' => 'coverage.xml',
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'paratest',
+            [
+                '--coverage-xml=coverage.xml',
             ]
         ];
         yield 'testsuite' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | 

Now for paratest task grumphp support only `--coverage-html` and `--coverage-xml` agrument. I added support also for `--coverage-clover` and `--coverage-php`.
Currently paratest don't support generating clover coverage base on phpunit logging configuration, so without that change we can't use paratet to generate correct raport to `clover_coverage` task.