### PR TITLE
Suggest command to fix composer_normalize errors

### DIFF
--- a/resources/config/formatter.yml
+++ b/resources/config/formatter.yml
@@ -5,6 +5,8 @@ services:
         class: GrumPHP\Formatter\PhpCsFixerFormatter
     formatter.phpcs:
         class: GrumPHP\Formatter\PhpcsFormatter
+    formatter.composer_normalize:
+        class: GrumPHP\Formatter\ComposerNormalizeFormatter
     formatter.git_blacklist:
         class: GrumPHP\Formatter\GitBlacklistFormatter
         arguments:

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -51,7 +51,7 @@ services:
     GrumPHP\Task\ComposerNormalize:
         arguments:
             - '@process_builder'
-            - '@formatter.raw_process'
+            - '@formatter.composer_normalize'
         tags:
             - {name: grumphp.task, task: composer_normalize}
 

--- a/src/Formatter/ComposerNormalizeFormatter.php
+++ b/src/Formatter/ComposerNormalizeFormatter.php
@@ -6,7 +6,6 @@ namespace GrumPHP\Formatter;
 
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Process\ProcessBuilder;
-use Symfony\Component\Process\Process;
 
 class ComposerNormalizeFormatter extends RawProcessFormatter
 {

--- a/src/Formatter/ComposerNormalizeFormatter.php
+++ b/src/Formatter/ComposerNormalizeFormatter.php
@@ -10,20 +10,18 @@ use GrumPHP\Process\ProcessBuilder;
 class ComposerNormalizeFormatter extends RawProcessFormatter
 {
 
-    /**
-     * @param \GrumPHP\Collection\ProcessArgumentsCollection $defaultArguments
-     * @param \GrumPHP\Process\ProcessBuilder $processBuilder
-     *
-     * @return string
-     */
+  /**
+   * @param string $fixerCommand
+   *
+   * @return string
+   */
     public function formatErrorMessage(
-        ProcessArgumentsCollection $defaultArguments,
-        ProcessBuilder $processBuilder
+        string $fixerCommand
     ): string {
         return sprintf(
             '%sYou can fix some errors by running following command:%s',
             PHP_EOL.PHP_EOL,
-            PHP_EOL.$processBuilder->buildProcess($defaultArguments)->getCommandLine()
+            PHP_EOL.$fixerCommand
         );
     }
 }

--- a/src/Formatter/ComposerNormalizeFormatter.php
+++ b/src/Formatter/ComposerNormalizeFormatter.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Formatter;
+
+use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
+
+class ComposerNormalizeFormatter extends RawProcessFormatter
+{
+
+    /**
+     * @param \GrumPHP\Collection\ProcessArgumentsCollection $defaultArguments
+     * @param \GrumPHP\Process\ProcessBuilder $processBuilder
+     *
+     * @return string
+     */
+    public function formatErrorMessage(
+        ProcessArgumentsCollection $defaultArguments,
+        ProcessBuilder $processBuilder
+    ): string {
+        return sprintf(
+            '%sYou can fix some errors by running following command:%s',
+            PHP_EOL.PHP_EOL,
+            PHP_EOL.$processBuilder->buildProcess($defaultArguments)->getCommandLine()
+        );
+    }
+}

--- a/src/Task/ComposerNormalize.php
+++ b/src/Task/ComposerNormalize.php
@@ -48,43 +48,27 @@ class ComposerNormalize extends AbstractExternalTask
         }
 
         $arguments = $this->processBuilder->createArgumentsForCommand('composer');
-        $arguments = $this->addArgumentsFromConfig($arguments, $config);
+        $arguments->add('normalize');
         $arguments->add('--dry-run');
+
+        if ($config['indent_size'] !== null && $config['indent_style'] !== null) {
+            $arguments->addOptionalArgument('--indent-style=%s', $config['indent_style']);
+            $arguments->addOptionalArgument('--indent-size=%s', $config['indent_size']);
+        }
+
+        $arguments->addOptionalArgument('--no-update-lock', $config['no_update_lock']);
+        $arguments->addOptionalArgument('-q', $config['verbose']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();
 
         if (!$process->isSuccessful()) {
             $output = $this->formatter->format($process);
-            $arguments = $this->processBuilder->createArgumentsForCommand('composer');
-            $arguments = $this->addArgumentsFromConfig($arguments, $config);
+            $arguments->removeElement('--dry-run');
             $output .= $this->formatter->formatErrorMessage($arguments, $this->processBuilder);
             return TaskResult::createFailed($this, $context, $output);
         }
 
         return TaskResult::createPassed($this, $context);
-    }
-
-    /**
-     * @param \GrumPHP\Collection\ProcessArgumentsCollection $arguments
-     * @param array $config
-     *
-     * @return \GrumPHP\Collection\ProcessArgumentsCollection
-     */
-    protected function addArgumentsFromConfig(
-        ProcessArgumentsCollection $arguments,
-        array $config
-    ): ProcessArgumentsCollection {
-        $arguments->add('normalize');
-
-        if ($config['indent_size'] !== null && $config['indent_style'] !== null) {
-          $arguments->addOptionalArgument('--indent-style=%s', $config['indent_style']);
-          $arguments->addOptionalArgument('--indent-size=%s', $config['indent_size']);
-        }
-
-        $arguments->addOptionalArgument('--no-update-lock', $config['no_update_lock']);
-        $arguments->addOptionalArgument('-q', $config['verbose']);
-
-        return $arguments;
     }
 }

--- a/test/Unit/Task/ComposerNormalizeTest.php
+++ b/test/Unit/Task/ComposerNormalizeTest.php
@@ -70,7 +70,7 @@ class ComposerNormalizeTest extends AbstractExternalTaskTestCase
             function () {
                 $this->mockProcessBuilder('composer', $process = $this->mockProcess(1));
                 $this->formatter->format($process)->willReturn('nope');
-                $this->formatter->formatErrorMessage(Argument::any(), Argument::any())->willReturn('nope');
+                $this->formatter->formatErrorMessage(Argument::any())->willReturn('nope');
             },
             'nope',
             FixableTaskResult::class

--- a/test/Unit/Task/ComposerNormalizeTest.php
+++ b/test/Unit/Task/ComposerNormalizeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GrumPHPTest\Unit\Task;
 
 use GrumPHP\Formatter\ComposerNormalizeFormatter;
+use GrumPHP\Runner\FixableTaskResult;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use GrumPHP\Task\ComposerNormalize;
@@ -71,7 +72,8 @@ class ComposerNormalizeTest extends AbstractExternalTaskTestCase
                 $this->formatter->format($process)->willReturn('nope');
                 $this->formatter->formatErrorMessage(Argument::any(), Argument::any())->willReturn('nope');
             },
-            'nope'
+            'nope',
+            FixableTaskResult::class
         ];
     }
 

--- a/test/Unit/Task/ComposerNormalizeTest.php
+++ b/test/Unit/Task/ComposerNormalizeTest.php
@@ -4,16 +4,26 @@ declare(strict_types=1);
 
 namespace GrumPHPTest\Unit\Task;
 
+use GrumPHP\Formatter\ComposerNormalizeFormatter;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use GrumPHP\Task\ComposerNormalize;
 use GrumPHP\Task\TaskInterface;
 use GrumPHP\Test\Task\AbstractExternalTaskTestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 
 class ComposerNormalizeTest extends AbstractExternalTaskTestCase
 {
+
+    /**
+     * @var ComposerNormalizeFormatter|ObjectProphecy
+     */
+    protected $formatter;
+
     protected function provideTask(): TaskInterface
     {
+        $this->formatter = $this->prophesize(ComposerNormalizeFormatter::class);
         return new ComposerNormalize(
             $this->processBuilder->reveal(),
             $this->formatter->reveal()
@@ -59,6 +69,7 @@ class ComposerNormalizeTest extends AbstractExternalTaskTestCase
             function () {
                 $this->mockProcessBuilder('composer', $process = $this->mockProcess(1));
                 $this->formatter->format($process)->willReturn('nope');
+                $this->formatter->formatErrorMessage(Argument::any(), Argument::any())->willReturn('nope');
             },
             'nope'
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

This PR makes the `composer_normalize` task output a suggested command to fix errors, inspired by what the `phpcs` task does.
