### PR TITLE
Add a way to call the standalone composer-normalize command

### DIFF
--- a/doc/tasks/composer_normalize.md
+++ b/doc/tasks/composer_normalize.md
@@ -44,6 +44,12 @@ Indent style (one of "space", "tab"); must be used with the `indent_size` option
 
 If `false`, do not update lock file if it exists.
 
+**use_standalone**
+
+*Default: false*
+
+If `true`, use the standalone `composer-normalize` command instead of the Composer plugin.
+
 **verbose**
 
 *Default: false*

--- a/src/Task/ComposerNormalize.php
+++ b/src/Task/ComposerNormalize.php
@@ -23,6 +23,7 @@ class ComposerNormalize extends AbstractExternalTask
             'indent_size' => null,
             'indent_style' => null,
             'no_update_lock' => true,
+            'use_standalone' => false,
             'verbose' => false,
         ]);
 
@@ -48,6 +49,11 @@ class ComposerNormalize extends AbstractExternalTask
 
         $arguments = $this->processBuilder->createArgumentsForCommand('composer');
         $arguments->add('normalize');
+
+        if ($config['use_standalone']) {
+            $arguments = $this->processBuilder->createArgumentsForCommand('composer-normalize');
+        }
+
         $arguments->add('--dry-run');
 
         if ($config['indent_size'] !== null && $config['indent_style'] !== null) {

--- a/src/Task/ComposerNormalize.php
+++ b/src/Task/ComposerNormalize.php
@@ -47,13 +47,9 @@ class ComposerNormalize extends AbstractExternalTask
             return TaskResult::createSkipped($this, $context);
         }
 
-        $arguments = $this->processBuilder->createArgumentsForCommand('composer');
-        $arguments->add('normalize');
-
-        if ($config['use_standalone']) {
-            $arguments = $this->processBuilder->createArgumentsForCommand('composer-normalize');
-        }
-
+        $executable = $config['use_standalone'] ? 'composer-normalize' : 'composer';
+        $arguments = $this->processBuilder->createArgumentsForCommand($executable);
+        $arguments->addOptionalArgument('normalize', !$config['use_standalone']);
         $arguments->add('--dry-run');
 
         if ($config['indent_size'] !== null && $config['indent_style'] !== null) {

--- a/test/Unit/Task/ComposerNormalizeTest.php
+++ b/test/Unit/Task/ComposerNormalizeTest.php
@@ -25,6 +25,7 @@ class ComposerNormalizeTest extends AbstractExternalTaskTestCase
         yield 'defaults' => [
             [],
             [
+                'use_standalone' => false,
                 'indent_size' => null,
                 'indent_style' => null,
                 'no_update_lock' => true,

--- a/test/Unit/Task/ComposerNormalizeTest.php
+++ b/test/Unit/Task/ComposerNormalizeTest.php
@@ -165,5 +165,16 @@ class ComposerNormalizeTest extends AbstractExternalTaskTestCase
                 '-q'
             ]
         ];
+        yield 'use_standalone' => [
+            [
+                'use_standalone' => true,
+            ],
+            $this->mockContext(RunContext::class, ['composer.json', 'hello2.php']),
+            'composer-normalize',
+            [
+                '--dry-run',
+                '--no-update-lock',
+            ]
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

composer-normalize is also available as a stand-alone PHAR (https://github.com/ergebnis/composer-normalize#phar).
This PR adds a new option to call this stand-alone command instead of `composer normalize`.
