### PR TITLE
Use no-interaction in Git hook

### DIFF
--- a/resources/hooks/local/pre-commit
+++ b/resources/hooks/local/pre-commit
@@ -12,4 +12,4 @@ DIFF=$(git -c diff.mnemonicprefix=false --no-pager diff -r -p -m -M --full-index
 export GRUMPHP_GIT_WORKING_DIR=$(git rev-parse --show-toplevel)
 
 # Run GrumPHP
-(cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | $(EXEC_GRUMPHP_COMMAND) $(HOOK_COMMAND) '--skip-success-output')
+(cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | $(EXEC_GRUMPHP_COMMAND) $(HOOK_COMMAND) '--skip-success-output' '--no-interaction')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

When using `fix_by_default: true`, the fix is not applied automatically on commit.
That seems to be because `QuestionHelper::ask()` thinks the input is interactive. 

This PR calls the Git hook with `--no-interaction` so that the question helper knows the input is not interactive and correctly returns the default answer.