### PR TITLE
Create smart backups of existing git hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ You will see following message in the composer logs:
 GrumPHP will never push you into using a specific task. You can choose the tasks that fit your needs, and activate or
 deactivate any task in no time! See the `suggest` section in [composer.json](https://github.com/phpro/grumphp/blob/master/composer.json#L37).
 
-Note: GrumPHP will overwrite existing hooks unless you run `composer install` with `--no-plugins` or `--no-scripts`. Be sure to backup your hooks before you try to install GrumPHP.
+Note: GrumPHP will overwrite existing hooks unless you run `composer install` with `--no-plugins` or `--no-scripts`.
+We do create a backup of your git hook, but it's best to make sure you also have a backup of your custom hooks before you try to install GrumPHP.
 
 Having trouble installing GrumPHP? Find out how to:
 

--- a/src/Console/Command/Git/InitCommand.php
+++ b/src/Console/Command/Git/InitCommand.php
@@ -116,6 +116,7 @@ class InitCommand extends Command
             }
 
             $content = $this->parseHookBody($hook, $hookTemplate);
+            $this->filesystem->backupFile($gitHook, md5($content));
             $this->filesystem->dumpFile($gitHook, $content);
             $this->filesystem->chmod($gitHook, 0775);
         }

--- a/src/Util/Filesystem.php
+++ b/src/Util/Filesystem.php
@@ -136,4 +136,27 @@ class Filesystem extends SymfonyFilesystem
 
         return $path;
     }
+
+    /**
+     * This method can be used to create a backup of current file.
+     * It used md5 to hash the content.
+     * So multiple backups of a file can exist (depending on the content)
+     */
+    public function backupFile(string $fileName, ?string $hashOfNewContent = null): void
+    {
+        if (!$this->isFile($fileName)) {
+            return;
+        }
+
+        if (!$hash = md5_file($fileName)) {
+            return;
+        }
+
+        // Skip backup if the new file has the same content as the old one.
+        if ($hashOfNewContent && $hashOfNewContent === $hash) {
+            return;
+        }
+
+        $this->copy($fileName, sprintf('%s.%s.backup', $fileName, $hash));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #416


This PR introduces a way of backup up existing git hooks.
It only backs them up if the old content does not match the new content.

This can be handy for testing a couple of different versions without atually removing them.
It also helps to recover a custom hook on first install as described in issue #416.
