### PR TITLE
Improved file passing tools

### DIFF
--- a/spec/Collection/FilesCollectionSpec.php
+++ b/spec/Collection/FilesCollectionSpec.php
@@ -250,4 +250,14 @@ class FilesCollectionSpec extends ObjectBehavior
         $result->contains($file1)->shouldBe(false);
         $result->contains($file2)->shouldBe(true);
     }
+
+    public function it_can_convert_to_file_list(): void
+    {
+        $file1 = new \SplFileInfo('path1/file1.php');
+        $file2 = new \SplFileInfo('path1/file2.php');
+        $file3 = new \SplFileInfo('path1/file3.php');
+        $this->beConstructedWith([$file1, $file2, $file3]);
+
+        $this->toFileList()->shouldBe($file1 . PHP_EOL . $file2 . PHP_EOL . $file3);
+    }
 }

--- a/spec/Exception/ProcessExceptionSpec.php
+++ b/spec/Exception/ProcessExceptionSpec.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace spec\GrumPHP\Exception;
+
+use GrumPHP\Exception\RuntimeException;
+use PhpSpec\ObjectBehavior;
+use GrumPHP\Exception\ProcessException;
+
+class ProcessExceptionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ProcessException::class);
+    }
+
+    function it_is_an_exception()
+    {
+        $this->shouldHaveType(RuntimeException::class);
+    }
+
+    public function it_can_be_created_when_tmp_file_cannot_be_created(): void
+    {
+        $this->beConstructedThrough('tmpFileCouldNotBeCreated', []);
+
+        $this->shouldHaveType(ProcessException::class);
+    }
+}

--- a/src/Collection/FilesCollection.php
+++ b/src/Collection/FilesCollection.php
@@ -251,4 +251,9 @@ class FilesCollection extends ArrayCollection implements \Serializable
     {
         return new \ArrayIterator($this->toArray());
     }
+
+    public function toFileList(): string
+    {
+        return \implode(PHP_EOL, $this->toArray());
+    }
 }

--- a/src/Exception/ProcessException.php
+++ b/src/Exception/ProcessException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Exception;
+
+class ProcessException extends RuntimeException
+{
+    public static function tmpFileCouldNotBeCreated(): self
+    {
+        return new self(
+            'The process requires a temporary file in order to run. We could not create one.'
+            . 'Please check your ini setting!'
+        );
+    }
+}

--- a/src/Process/InputWritingProcessRunner.php
+++ b/src/Process/InputWritingProcessRunner.php
@@ -7,13 +7,18 @@ namespace GrumPHP\Process;
 use Symfony\Component\Process\InputStream;
 use Symfony\Component\Process\Process;
 
+/**
+ * This runner can be used to run a process whilst writing data to STDIN
+ */
 class InputWritingProcessRunner
 {
     /**
+     * @param callable(): Process $processBuilder
      * @param callable(): \Generator<array-key, string, mixed, void> $writer
      */
-    public static function run(Process $process, callable $writer): int
+    public static function run(callable $processBuilder, callable $writer): Process
     {
+        $process = $processBuilder();
         $inputStream = new InputStream();
         $process->setInput($inputStream);
         $process->start();
@@ -22,7 +27,8 @@ class InputWritingProcessRunner
         }
 
         $inputStream->close();
+        $process->wait();
 
-        return $process->wait();
+        return $process;
     }
 }

--- a/src/Process/InputWritingProcessRunner.php
+++ b/src/Process/InputWritingProcessRunner.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Process;
+
+use Symfony\Component\Process\InputStream;
+use Symfony\Component\Process\Process;
+
+class InputWritingProcessRunner
+{
+    /**
+     * @param callable(): \Generator<array-key, string, mixed, void> $writer
+     */
+    public static function run(Process $process, callable $writer): int
+    {
+        $inputStream = new InputStream();
+        $process->setInput($inputStream);
+        $process->start();
+        foreach ($writer() as $input) {
+            $inputStream->write($input);
+        }
+
+        $inputStream->close();
+
+        return $process->wait();
+    }
+}

--- a/src/Process/TmpFileUsingProcessRunner.php
+++ b/src/Process/TmpFileUsingProcessRunner.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Process;
+
+use GrumPHP\Exception\ProcessException;
+use Symfony\Component\Process\Process;
+
+/**
+ * This runner can be used to run a process whilst creating a file with temporary data.
+ * Once the command has finished, the temporary file is removed.
+ */
+class TmpFileUsingProcessRunner
+{
+    /**
+     * @param callable(string): Process $processBuilder
+     * @param callable(): \Generator<array-key, string, mixed, void> $writer
+     */
+    public static function run(callable $processBuilder, callable $writer): Process
+    {
+        if (!$tmp = tmpfile()) {
+            throw ProcessException::tmpFileCouldNotBeCreated();
+        }
+
+        $path = stream_get_meta_data($tmp)['uri'] ?? null;
+        if (!$path) {
+            throw ProcessException::tmpFileCouldNotBeCreated();
+        }
+
+        foreach ($writer() as $entry) {
+            fwrite($tmp, (string) $entry);
+        }
+        fseek($tmp, 0);
+
+        try {
+            $process = $processBuilder($path);
+            $process->run();
+        } finally {
+            fclose($tmp);
+        }
+
+        return $process;
+    }
+}

--- a/src/Task/PhpLint.php
+++ b/src/Task/PhpLint.php
@@ -11,6 +11,7 @@ use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Process\Process;
 
 class PhpLint extends AbstractExternalTask
 {
@@ -59,11 +60,12 @@ class PhpLint extends AbstractExternalTask
         $arguments->addArgumentArrayWithSeparatedValue('--exclude', $config['exclude']);
         $arguments->add('--stdin');
 
-        $process = $this->processBuilder->buildProcess($arguments);
-        InputWritingProcessRunner::run(
-            $process,
+        $process = InputWritingProcessRunner::run(
+            function () use ($arguments): Process {
+                return $this->processBuilder->buildProcess($arguments);
+            },
             static function () use ($files) {
-                yield \implode(PHP_EOL, $files->toArray());
+                yield $files->toFileList();
             }
         );
 

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -69,17 +69,15 @@ class Phpcs extends AbstractExternalTask
     {
         /** @var array $config */
         $config = $this->getConfig()->getOptions();
-        /** @var array $whitelistPatterns */
-        $whitelistPatterns = $config['whitelist_patterns'];
-        /** @var array $extensions */
-        $extensions = $config['triggered_by'];
 
-        /** @var \GrumPHP\Collection\FilesCollection $files */
         $files = $context->getFiles();
-        if (\count($whitelistPatterns)) {
-            $files = $files->paths($whitelistPatterns);
+        if (\count($config['whitelist_patterns'])) {
+            $files = $files->paths($config['whitelist_patterns']);
         }
-        $files = $files->extensions($extensions);
+        if (\count($config['ignore_patterns'])) {
+            $files = $files->notPaths($config['ignore_patterns']);
+        }
+        $files = $files->extensions($config['triggered_by']);
 
         if (0 === \count($files)) {
             return TaskResult::createSkipped($this, $context);

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -70,14 +70,10 @@ class Phpcs extends AbstractExternalTask
         /** @var array $config */
         $config = $this->getConfig()->getOptions();
 
-        $files = $context->getFiles();
-        if (\count($config['whitelist_patterns'])) {
-            $files = $files->paths($config['whitelist_patterns']);
-        }
-        if (\count($config['ignore_patterns'])) {
-            $files = $files->notPaths($config['ignore_patterns']);
-        }
-        $files = $files->extensions($config['triggered_by']);
+        $files = $context->getFiles()
+            ->extensions($config['triggered_by'])
+            ->paths($config['whitelist_patterns'] ?? [])
+            ->notPaths($config['ignore_patterns'] ?? []);
 
         if (0 === \count($files)) {
             return TaskResult::createSkipped($this, $context);

--- a/src/Test/Task/AbstractExternalTaskTestCase.php
+++ b/src/Test/Task/AbstractExternalTaskTestCase.php
@@ -97,7 +97,7 @@ abstract class AbstractExternalTaskTestCase extends AbstractTaskTestCase
         $process = $this->prophesize(Process::class);
         $process->setInput(Argument::type(InputStream::class))->shouldBeCalled();
         $process->start()->shouldBeCalled();
-        $process->wait()->shouldBeCalled();
+        $process->wait()->willReturn($exitCode);
         $process->isSuccessful()->willReturn($exitCode === 0);
         $process->getOutput()->willReturn($output);
         $process->getErrorOutput()->willReturn($errors);

--- a/src/Test/Task/AbstractExternalTaskTestCase.php
+++ b/src/Test/Task/AbstractExternalTaskTestCase.php
@@ -97,7 +97,7 @@ abstract class AbstractExternalTaskTestCase extends AbstractTaskTestCase
         $process = $this->prophesize(Process::class);
         $process->setInput(Argument::type(InputStream::class))->shouldBeCalled();
         $process->start()->shouldBeCalled();
-        $process->wait()->willReturn($exitCode);
+        $process->wait()->shouldBeCalled()->willReturn($exitCode);
         $process->isSuccessful()->willReturn($exitCode === 0);
         $process->getOutput()->willReturn($output);
         $process->getErrorOutput()->willReturn($errors);

--- a/src/Test/Task/AbstractExternalTaskTestCase.php
+++ b/src/Test/Task/AbstractExternalTaskTestCase.php
@@ -54,16 +54,45 @@ abstract class AbstractExternalTaskTestCase extends AbstractTaskTestCase
             $arguments = new ProcessArgumentsCollection()
         );
 
+        // Added extra boilerplate since ->will() overwrites the bound $this context.
+        $cliArgumentResolver = function (array $cliArguments, array $processArguments): array {
+            return $this->resolveExpectedCliArgumentFromCallable($cliArguments, $processArguments);
+        };
+
         $process = $process ?? $this->mockProcess(0);
         $this->processBuilder->buildProcess(Argument::any())
             ->shouldBeCalled()
-            ->will(function ($parameters) use ($cliArguments, $process) {
-                Assert::assertSame($cliArguments, $parameters[0]->getValues());
+            ->will(function ($parameters) use ($cliArguments, $process, $cliArgumentResolver) {
+                $processArguments = $parameters[0]->getValues();
+                $resolvedCliArguments = $cliArgumentResolver($cliArguments, $processArguments);
+
+                Assert::assertSame($resolvedCliArguments, $processArguments);
                 return $process;
             });
 
         $result = $task->run($context);
         self::assertInstanceOf(TaskResultInterface::class, $result);
+    }
+
+    /**
+     * This function makes it possible to create a expected argument callback that takes the actual argument as input.
+     * This can be handy for validating a part of the argument.
+     */
+    private function resolveExpectedCliArgumentFromCallable(array $expectedArguments, array $actualArguments): array
+    {
+        self::assertSameSize($expectedArguments, $actualArguments);
+
+        return array_map(
+            function ($expected, $actual) {
+                if ($expected instanceof \Closure) {
+                    return $expected($actual);
+                }
+
+                return $expected;
+            },
+            $expectedArguments,
+            $actualArguments
+        );
     }
 
     protected function mockProcess(int $exitCode = 0, string $output = '', string $errors = ''): Process

--- a/test/Unit/Task/PhpcsTest.php
+++ b/test/Unit/Task/PhpcsTest.php
@@ -161,7 +161,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--extensions=php',
                 '--report=full',
                 '--report-json',
-                'hello.php',
+                '--file-list=/tmp/randomshit',
                 'hello2.php',
             ]
         ];

--- a/test/Unit/Task/PhpcsTest.php
+++ b/test/Unit/Task/PhpcsTest.php
@@ -161,8 +161,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--extensions=php',
                 '--report=full',
                 '--report-json',
-                '--file-list=/tmp/randomshit',
-                'hello2.php',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
         ];
         yield 'standard' => [
@@ -176,8 +175,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--extensions=php',
                 '--report=full',
                 '--report-json',
-                'hello.php',
-                'hello2.php',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
         ];
         yield 'extensions' => [
@@ -190,8 +188,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--extensions=php,phtml',
                 '--report=full',
                 '--report-json',
-                'hello.php',
-                'hello2.php',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
         ];
         yield 'tab-width' => [
@@ -205,8 +202,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--tab-width=4',
                 '--report=full',
                 '--report-json',
-                'hello.php',
-                'hello2.php',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
         ];
         yield 'encoding' => [
@@ -220,8 +216,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--encoding=UTF-8',
                 '--report=full',
                 '--report-json',
-                'hello.php',
-                'hello2.php',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
         ];
         yield 'report' => [
@@ -234,8 +229,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--extensions=php',
                 '--report=small',
                 '--report-json',
-                'hello.php',
-                'hello2.php',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
         ];
         yield 'report-width' => [
@@ -249,8 +243,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--report=full',
                 '--report-width=20',
                 '--report-json',
-                'hello.php',
-                'hello2.php',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
         ];
         yield 'severity' => [
@@ -264,8 +257,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--report=full',
                 '--severity=5',
                 '--report-json',
-                'hello.php',
-                'hello2.php',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
         ];
         yield 'error-severity' => [
@@ -279,8 +271,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--report=full',
                 '--error-severity=5',
                 '--report-json',
-                'hello.php',
-                'hello2.php',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
         ];
         yield 'warning-severity' => [
@@ -294,8 +285,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--report=full',
                 '--warning-severity=5',
                 '--report-json',
-                'hello.php',
-                'hello2.php',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
         ];
         yield 'sniffs' => [
@@ -309,8 +299,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--report=full',
                 '--sniffs=sniff1,sniff2',
                 '--report-json',
-                'hello.php',
-                'hello2.php',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
         ];
         yield 'ignore-patternes' => [
@@ -324,8 +313,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--report=full',
                 '--ignore=ignore1,ignore2',
                 '--report-json',
-                'hello.php',
-                'hello2.php',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
         ];
         yield 'exclude' => [
@@ -339,9 +327,21 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--report=full',
                 '--exclude=exclude1,exclude2',
                 '--report-json',
-                'hello.php',
-                'hello2.php',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
         ];
+    }
+
+    private function expectFileList(string $expectedContents): callable
+    {
+        return static function (string $argument) use ($expectedContents) {
+            self::assertStringStartsWith('--file-list=', $argument);
+            list($arg, $tmpFile) = explode('=', $argument, 2);
+
+            self::assertFileExists($tmpFile);
+            self::assertStringEqualsFile($tmpFile, 'hello.php'.PHP_EOL.'hello2.php');
+
+            return $argument;
+        };
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #523, #487, #275

New tools:

# InputWritingProcessRunner

Makes it possible to run a process whilst streaming to stdin:

```php
// used in PhpLint task

$process = InputWritingProcessRunner::run(
    function () use ($arguments): Process {
        return $this->processBuilder->buildProcess($arguments);
    },
    static function () use ($files) {
        yield $files->toFileList();
    }
);
```


# TmpFileUsingProcessRunner

Makes it possible to run a process whilst adding a temporary file with dynamic content to the cli command:

```php
// used in PhpCs task

$process = TmpFileUsingProcessRunner::run(
    function (string $tmpFile) use ($config): Process {
        $arguments = $this->processBuilder->createArgumentsForCommand('phpcs');
        $arguments = $this->addArgumentsFromConfig($arguments, $config);
        $arguments->add('--report-json');
        $arguments->add('--file-list='.$tmpFile);

        return $this->processBuilder->buildProcess($arguments);
    },
    static function () use ($files): \Generator {
        yield $files->toFileList();
    }
);
```


