### PR TITLE
Provide a stdin way of configuring files that need to be validated by GrumPHP

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -28,8 +28,19 @@ php ./vendor/bin/grumphp git:pre-commit
 php ./vendor/bin/grumphp git:commit-msg
 ```
 
-Both commands support raw git diffs as STDIN input. 
+Both commands support raw git diffs and file lists as STDIN input. 
 This way it is possible to pass changes triggered by `git commit -a` from the GIT hook to the GrumPHP commands.
+If no stdin is provided, it will load the currently staged git diff.
+
+Example stdin usages:
+
+```sh
+git diff | php ./vendor/bin/grumphp git:pre-commit
+git diff --staged | php ./vendor/bin/grumphp git:pre-commit
+git ls-files src | php ./vendor/bin/grumphp git:pre-commit
+```
+
+:exclamation: *If you use the stdin, we won't be able to answer questions interactively.*
 
 ## Run
 
@@ -51,3 +62,18 @@ php ./vendor/bin/grumphp run --tasks=task1,task2
 
 The `--tasks` value has to be a comma-separated string of task names that match the keys in the `tasks` section 
 of the `grumphp.yml` file. See [#580](https://github.com/phpro/grumphp/issues/580) for a more exhaustive explanation.
+
+The run command support raw git diffs and file lists as STDIN input. 
+This way it is possible to select which files you want grumphp to check.
+If no stdin is provided, it will load all files known to git.
+
+Example stdin usages:
+
+```sh
+git diff | php ./vendor/bin/grumphp run
+git diff --staged | php ./vendor/bin/grumphp run
+git ls-files src | php ./vendor/bin/grumphp run
+```
+
+:exclamation: *If you use the stdin, we won't be able to answer questions interactively.*
+ 

--- a/resources/config/console.yml
+++ b/resources/config/console.yml
@@ -25,14 +25,16 @@ services:
     GrumPHP\Console\Command\RunCommand:
         arguments:
             - '@GrumPHP\Collection\TestSuiteCollection'
-            - '@locator.registered_files'
+            - '@GrumPHP\Locator\StdInFiles'
+            - '@GrumPHP\Locator\RegisteredFiles'
             - '@GrumPHP\Runner\TaskRunner'
         tags:
             - { name: 'console.command' }
     GrumPHP\Console\Command\Git\CommitMsgCommand:
         arguments:
             - '@GrumPHP\Collection\TestSuiteCollection'
-            - '@locator.changed_files'
+            - '@GrumPHP\Locator\StdInFiles'
+            - '@GrumPHP\Locator\ChangedFiles'
             - '@GrumPHP\Runner\TaskRunner'
             - '@grumphp.util.filesystem'
             - '@GrumPHP\Util\Paths'
@@ -55,7 +57,8 @@ services:
     GrumPHP\Console\Command\Git\PreCommitCommand:
         arguments:
             - '@GrumPHP\Collection\TestSuiteCollection'
-            - '@locator.changed_files'
+            - '@GrumPHP\Locator\StdInFiles'
+            - '@GrumPHP\Locator\ChangedFiles'
             - '@GrumPHP\Runner\TaskRunner'
         tags:
             - { name: 'console.command' }

--- a/resources/config/locators.yml
+++ b/resources/config/locators.yml
@@ -4,30 +4,34 @@ services:
             - '@GrumPHP\Configuration\Model\AsciiConfig'
             - '@filesystem'
             - '@GrumPHP\Util\Paths'
-        public: true
 
-    locator.external_command:
-        class: GrumPHP\Locator\ExternalCommand
+    GrumPHP\Locator\ExternalCommand:
+        class:
         factory: ['GrumPHP\Locator\ExternalCommand', 'loadWithPaths']
         arguments:
             - '@GrumPHP\Util\Paths'
             - '@executable_finder'
-        public: true
 
-    locator.changed_files:
-        class: GrumPHP\Locator\ChangedFiles
+    GrumPHP\Locator\ChangedFiles:
         arguments:
             - '@GrumPHP\Git\GitRepository'
             - '@filesystem'
             - '@GrumPHP\Util\Paths'
-        public: true
 
-    locator.registered_files:
-        class: GrumPHP\Locator\RegisteredFiles
+    GrumPHP\Locator\ListedFiles:
+        arguments:
+            - '@GrumPHP\Util\Paths'
+
+    GrumPHP\Locator\RegisteredFiles:
         arguments:
             - '@GrumPHP\Git\GitRepository'
             - '@GrumPHP\Util\Paths'
-        public: true
+            - '@GrumPHP\Locator\ListedFiles'
+
+    GrumPHP\Locator\StdInFiles:
+        arguments:
+            - '@GrumPHP\Locator\ChangedFiles'
+            - '@GrumPHP\Locator\ListedFiles'
 
     GrumPHP\Locator\GitWorkingDirLocator:
         arguments:

--- a/resources/config/services.yml
+++ b/resources/config/services.yml
@@ -25,7 +25,7 @@ services:
     process_builder:
       class: GrumPHP\Process\ProcessBuilder
       arguments:
-        - '@locator.external_command'
+        - '@GrumPHP\Locator\ExternalCommand'
         - '@grumphp.io'
         - '@GrumPHP\Configuration\Model\ProcessConfig'
       public: true

--- a/spec/IO/ConsoleIOSpec.php
+++ b/spec/IO/ConsoleIOSpec.php
@@ -81,6 +81,12 @@ class ConsoleIOSpec extends ObjectBehavior
         $this->writeError(['test']);
     }
 
+    function it_doesnt_read_empty_input()
+    {
+        $handle = $this->mockHandle('');
+        $this->readCommandInput($handle)->shouldBe('');
+    }
+
     function it_reads_command_input()
     {
         $handle = $this->mockHandle('input');
@@ -139,7 +145,7 @@ EOD;
 
     private function mockHandle($content)
     {
-        $handle = fopen('php://memory', 'a');
+        $handle = tmpfile();
         fwrite($handle, $content);
         rewind($handle);
 

--- a/spec/Locator/ListedFilesSpec.php
+++ b/spec/Locator/ListedFilesSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\GrumPHP\Locator;
+
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Locator\ListedFiles;
+use GrumPHP\Util\Paths;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ListedFilesSpec extends ObjectBehavior
+{
+    function let(Paths $paths)
+    {
+        $this->beConstructedWith($paths);
+        $paths->makePathRelativeToProjectDir(Argument::type('string'))->will(
+            function (array $arguments): string {
+                return $arguments[0];
+            }
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ListedFiles::class);
+    }
+
+    function it_will_list_all_listed_files()
+    {
+        $files = ['file1.txt', 'file2.txt'];
+        $result = $this->locate(implode(PHP_EOL, $files));
+        $result->shouldBeAnInstanceOf(FilesCollection::class);
+        $result[0]->getPathname()->shouldBe('file1.txt');
+        $result[1]->getPathname()->shouldBe('file2.txt');
+        $result->getIterator()->count()->shouldBe(2);
+    }
+}

--- a/spec/Locator/RegisteredFilesSpec.php
+++ b/spec/Locator/RegisteredFilesSpec.php
@@ -4,21 +4,16 @@ namespace spec\GrumPHP\Locator;
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Git\GitRepository;
+use GrumPHP\Locator\ListedFiles;
 use GrumPHP\Locator\RegisteredFiles;
 use GrumPHP\Util\Paths;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class RegisteredFilesSpec extends ObjectBehavior
 {
-    function let(GitRepository $repository, Paths $paths)
+    function let(GitRepository $repository, Paths $paths, ListedFiles $listedFiles)
     {
-        $this->beConstructedWith($repository, $paths);
-        $paths->makePathRelativeToProjectDir(Argument::type('string'))->will(
-            function (array $arguments): string {
-                return $arguments[0];
-            }
-        );
+        $this->beConstructedWith($repository, $paths, $listedFiles);
     }
 
     function it_is_initializable()
@@ -26,16 +21,14 @@ class RegisteredFilesSpec extends ObjectBehavior
         $this->shouldHaveType(RegisteredFiles::class);
     }
 
-    function it_will_list_all_diffed_files(GitRepository $repository, Paths $paths)
+    function it_will_list_all_diffed_files(GitRepository $repository, Paths $paths, ListedFiles $listedFiles)
     {
         $paths->getProjectDir()->willReturn($projectDir = '/path/to/project');
         $files = ['file1.txt', 'file2.txt'];
-        $repository->run('ls-files', [$projectDir])->willReturn(implode(PHP_EOL, $files));
+        $repository->run('ls-files', [$projectDir])->willReturn($fileList = implode(PHP_EOL, $files));
+        $listedFiles->locate($fileList)->willReturn($expected = new FilesCollection());
 
         $result = $this->locate();
-        $result->shouldBeAnInstanceOf(FilesCollection::class);
-        $result[0]->getPathname()->shouldBe('file1.txt');
-        $result[1]->getPathname()->shouldBe('file2.txt');
-        $result->getIterator()->count()->shouldBe(2);
+        $result->shouldBe($expected);
     }
 }

--- a/spec/Locator/StdInFilesSpec.php
+++ b/spec/Locator/StdInFilesSpec.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace spec\GrumPHP\Locator;
+
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Locator\ChangedFiles;
+use GrumPHP\Locator\ListedFiles;
+use PhpSpec\ObjectBehavior;
+use GrumPHP\Locator\StdInFiles;
+
+class StdInFilesSpec extends ObjectBehavior
+{
+    public function let(
+        ChangedFiles $changedFilesLocator,
+        ListedFiles $listedFiles
+    ): void {
+        $this->beConstructedWith($changedFilesLocator, $listedFiles);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(StdInFiles::class);
+    }
+
+    public function it_can_parse_git_diffs(ChangedFiles $changedFilesLocator): void
+    {
+        $diff = <<<EOD
+diff --git a/src/test.php b/src/test.php
+index 372bf10b74013301cfb4bf0e8007d208bb813363..d95f50da4a02d3d203bda1f3cb94e29d4f0ef481 100644
+--- a/src/test.php
++++ b/src/test.php
+@@ -2,3 +2,4 @@
+
+
+ 'something';
++'ok';
+
+EOD;
+        $changedFilesLocator->locateFromRawDiffInput($diff)->willReturn($expected = new FilesCollection());
+
+        $this->locate($diff)->shouldBe($expected);
+    }
+
+    public function it_can_parse_file_lists(ListedFiles $listedFiles): void
+    {
+        $fileList = implode(PHP_EOL, ['file1.txt', 'file2.txt']);
+        $listedFiles->locate($fileList)->willReturn($expected = new FilesCollection());
+
+        $this->locate($fileList)->shouldBe($expected);
+    }
+}

--- a/src/Console/Command/Git/CommitMsgCommand.php
+++ b/src/Console/Command/Git/CommitMsgCommand.php
@@ -6,9 +6,9 @@ namespace GrumPHP\Console\Command\Git;
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\TestSuiteCollection;
-use GrumPHP\Console\Helper\TaskRunnerHelper;
 use GrumPHP\IO\ConsoleIO;
 use GrumPHP\Locator\ChangedFiles;
+use GrumPHP\Locator\StdInFiles;
 use GrumPHP\Runner\TaskRunner;
 use GrumPHP\Runner\TaskRunnerContext;
 use GrumPHP\Task\Context\GitCommitMsgContext;
@@ -36,6 +36,11 @@ class CommitMsgCommand extends Command
     private $testSuites;
 
     /**
+     * @var StdInFiles
+     */
+    private $stdInFilesLocator;
+
+    /**
      * @var ChangedFiles
      */
     private $changedFilesLocator;
@@ -57,6 +62,7 @@ class CommitMsgCommand extends Command
 
     public function __construct(
         TestSuiteCollection $testSuites,
+        StdInFiles $stdInFilesLocator,
         ChangedFiles $changedFilesLocator,
         TaskRunner $taskRunner,
         Filesystem $filesystem,
@@ -69,6 +75,7 @@ class CommitMsgCommand extends Command
         $this->taskRunner = $taskRunner;
         $this->filesystem = $filesystem;
         $this->paths = $paths;
+        $this->stdInFilesLocator = $stdInFilesLocator;
     }
 
     public static function getDefaultName(): string
@@ -120,7 +127,7 @@ class CommitMsgCommand extends Command
     protected function getCommittedFiles(ConsoleIO $io): FilesCollection
     {
         if ($stdin = $io->readCommandInput(STDIN)) {
-            return $this->changedFilesLocator->locateFromRawDiffInput($stdin);
+            return $this->stdInFilesLocator->locate($stdin);
         }
 
         return $this->changedFilesLocator->locateFromGitRepository();

--- a/src/Console/Command/Git/PreCommitCommand.php
+++ b/src/Console/Command/Git/PreCommitCommand.php
@@ -6,9 +6,9 @@ namespace GrumPHP\Console\Command\Git;
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\TestSuiteCollection;
-use GrumPHP\Console\Helper\TaskRunnerHelper;
 use GrumPHP\IO\ConsoleIO;
 use GrumPHP\Locator\ChangedFiles;
+use GrumPHP\Locator\StdInFiles;
 use GrumPHP\Runner\TaskRunner;
 use GrumPHP\Runner\TaskRunnerContext;
 use GrumPHP\Task\Context\GitPreCommitContext;
@@ -32,6 +32,11 @@ class PreCommitCommand extends Command
     private $testSuites;
 
     /**
+     * @var StdInFiles
+     */
+    private $stdInFilesLocator;
+
+    /**
      * @var ChangedFiles
      */
     private $changedFilesLocator;
@@ -43,12 +48,14 @@ class PreCommitCommand extends Command
 
     public function __construct(
         TestSuiteCollection $testSuites,
+        StdInFiles $stdInFilesLocator,
         ChangedFiles $changedFilesLocator,
         TaskRunner $taskRunner
     ) {
         parent::__construct();
 
         $this->testSuites = $testSuites;
+        $this->stdInFilesLocator = $stdInFilesLocator;
         $this->changedFilesLocator = $changedFilesLocator;
         $this->taskRunner = $taskRunner;
     }
@@ -91,7 +98,7 @@ class PreCommitCommand extends Command
     protected function getCommittedFiles(ConsoleIO $io): FilesCollection
     {
         if ($stdin = $io->readCommandInput(STDIN)) {
-            return $this->changedFilesLocator->locateFromRawDiffInput($stdin);
+            return $this->stdInFilesLocator->locate($stdin);
         }
 
         return $this->changedFilesLocator->locateFromGitRepository();

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -110,7 +110,7 @@ class RunCommand extends Command
     private function detectFiles(ConsoleIO $io): FilesCollection
     {
         if ($stdin = $io->readCommandInput(STDIN)) {
-            $this->stdInFileLocator->locate($stdin);
+            return $this->stdInFileLocator->locate($stdin);
         }
 
         return $this->registeredFilesLocator->locate();

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace GrumPHP\Console\Command;
 
+use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\TestSuiteCollection;
+use GrumPHP\IO\ConsoleIO;
 use GrumPHP\Locator\RegisteredFiles;
+use GrumPHP\Locator\StdInFiles;
 use GrumPHP\Runner\TaskRunner;
 use GrumPHP\Runner\TaskRunnerContext;
 use GrumPHP\Task\Context\RunContext;
@@ -32,19 +35,25 @@ class RunCommand extends Command
     private $registeredFilesLocator;
 
     /**
+     * @var StdInFiles
+     */
+    private $stdInFileLocator;
+
+    /**
      * @var TaskRunner
      */
     private $taskRunner;
 
-
     public function __construct(
         TestSuiteCollection $testSuites,
+        StdInFiles $stdInFileLocator,
         RegisteredFiles $registeredFilesLocator,
         TaskRunner $taskRunner
     ) {
         parent::__construct();
 
         $this->testSuites = $testSuites;
+        $this->stdInFileLocator = $stdInFileLocator;
         $this->registeredFilesLocator = $registeredFilesLocator;
         $this->taskRunner = $taskRunner;
     }
@@ -74,13 +83,15 @@ class RunCommand extends Command
 
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        $io = new ConsoleIO($input, $output);
+
         /** @var string $taskNames */
         $taskNames = $input->getOption('tasks') ?? '';
 
         /** @var string $testsSuite */
         $testsSuite = $input->getOption('testsuite') ?? '';
 
-        $files = $this->registeredFilesLocator->locate();
+        $files = $this->detectFiles($io);
         $tasks = Str::explodeWithCleanup(',', $taskNames);
 
         $context = new TaskRunnerContext(
@@ -94,5 +105,14 @@ class RunCommand extends Command
         $results = $this->taskRunner->run($context);
 
         return $results->isFailed() ? self::EXIT_CODE_NOK : self::EXIT_CODE_OK;
+    }
+
+    private function detectFiles(ConsoleIO $io): FilesCollection
+    {
+        if ($stdin = $io->readCommandInput(STDIN)) {
+            $this->stdInFileLocator->locate($stdin);
+        }
+
+        return $this->registeredFilesLocator->locate();
     }
 }

--- a/src/IO/ConsoleIO.php
+++ b/src/IO/ConsoleIO.php
@@ -91,9 +91,11 @@ class ConsoleIO implements IOInterface, \Serializable
             return $this->stdin;
         }
 
+        $read = [$handle];
+        $write = $except = null;
         $input = '';
-        while (!feof($handle)) {
-            $input .= fread($handle, 1024);
+        if (\stream_select($read, $write, $except, 0)) {
+            $input = \stream_get_contents($handle) ?: '';
         }
 
         // When the input only consist of white space characters, we assume that there is no input.

--- a/src/IO/ConsoleIO.php
+++ b/src/IO/ConsoleIO.php
@@ -91,13 +91,11 @@ class ConsoleIO implements IOInterface, \Serializable
             return $this->stdin;
         }
 
-        $read = [$handle];
-        $write = $except = null;
         $input = '';
 
-        // By using stream-select, the stdin will not be read if there is no content on the stream.
-        // This will still make it available for interactive questions from the cli.
-        if (\stream_select($read, $write, $except, 0)) {
+        // Validate if the resource is being piped to.
+        // If it is not a tty, it can be read in a non blocking way.
+        if (!\stream_isatty($handle)) {
             // Once the stream is read, it is marked as EOF.
             // From that point on, you sadly cannot use interactive cli questions anymore.
             $input = \stream_get_contents($handle) ?: '';

--- a/src/IO/ConsoleIO.php
+++ b/src/IO/ConsoleIO.php
@@ -94,7 +94,12 @@ class ConsoleIO implements IOInterface, \Serializable
         $read = [$handle];
         $write = $except = null;
         $input = '';
+
+        // By using stream-select, the stdin will not be read if there is no content on the stream.
+        // This will still make it available for interactive questions from the cli.
         if (\stream_select($read, $write, $except, 0)) {
+            // Once the stream is read, it is marked as EOF.
+            // From that point on, you sadly cannot use interactive cli questions anymore.
             $input = \stream_get_contents($handle) ?: '';
         }
 

--- a/src/Locator/ListedFiles.php
+++ b/src/Locator/ListedFiles.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Locator;
+
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Util\Paths;
+use Symfony\Component\Finder\SplFileInfo;
+
+class ListedFiles
+{
+    /**
+     * @var Paths
+     */
+    private $paths;
+
+    public function __construct(Paths $paths)
+    {
+        $this->paths = $paths;
+    }
+
+    public function locate(string $fileList): FilesCollection
+    {
+        $filePaths = preg_split("/\r\n|\n|\r/", $fileList);
+
+        $files = [];
+        foreach (array_filter($filePaths) as $file) {
+            $relativeFile = $this->paths->makePathRelativeToProjectDir($file);
+            $files[] = new SplFileInfo($relativeFile, dirname($relativeFile), $relativeFile);
+        }
+
+        return new FilesCollection($files);
+    }
+}

--- a/src/Locator/RegisteredFiles.php
+++ b/src/Locator/RegisteredFiles.php
@@ -7,7 +7,6 @@ namespace GrumPHP\Locator;
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Git\GitRepository;
 use GrumPHP\Util\Paths;
-use Symfony\Component\Finder\SplFileInfo;
 
 class RegisteredFiles
 {
@@ -21,24 +20,23 @@ class RegisteredFiles
      */
     private $paths;
 
-    public function __construct(GitRepository $repository, Paths $paths)
+    /**
+     * @var ListedFiles
+     */
+    private $listedFiles;
+
+    public function __construct(GitRepository $repository, Paths $paths, ListedFiles $listedFiles)
     {
         $this->repository = $repository;
         $this->paths = $paths;
+        $this->listedFiles = $listedFiles;
     }
 
     public function locate(): FilesCollection
     {
         // Make sure to only return the files that are registered to GIT inside current project directory:
         $allFiles = trim((string) $this->repository->run('ls-files', [$this->paths->getProjectDir()]));
-        $filePaths = preg_split("/\r\n|\n|\r/", $allFiles);
 
-        $files = [];
-        foreach (array_filter($filePaths) as $file) {
-            $relativeFile = $this->paths->makePathRelativeToProjectDir($file);
-            $files[] = new SplFileInfo($relativeFile, dirname($relativeFile), $relativeFile);
-        }
-
-        return new FilesCollection($files);
+        return $this->listedFiles->locate($allFiles);
     }
 }

--- a/src/Locator/StdInFiles.php
+++ b/src/Locator/StdInFiles.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Locator;
+
+use GrumPHP\Collection\FilesCollection;
+
+class StdInFiles
+{
+    /**
+     * @var ChangedFiles
+     */
+    private $changedFilesLocator;
+
+    /**
+     * @var ListedFiles
+     */
+    private $listedFiles;
+
+    public function __construct(
+        ChangedFiles $changedFilesLocator,
+        ListedFiles $listedFiles
+    ) {
+        $this->changedFilesLocator = $changedFilesLocator;
+        $this->listedFiles = $listedFiles;
+    }
+
+    public function locate(string $stdIn): FilesCollection
+    {
+        if (preg_match('/^diff --git/', $stdIn)) {
+            return $this->changedFilesLocator->locateFromRawDiffInput($stdIn);
+        }
+
+        return $this->listedFiles->locate($stdIn);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #394

This PR allows adding files to GrumPHP through stdin.
Example:


```sh
git diff | php ./vendor/bin/grumphp run
git diff --staged | php ./vendor/bin/grumphp run
git ls-files src | php ./vendor/bin/grumphp run
cat some-file-with-one-path-per-line.txt | php ./vendor/bin/grumphp run
```

This works for the commands: `run`, `git:pre-commit`, `git:commit-msg`

