### PR TITLE
Add `match_word` option to git blacklist task

### DIFF
--- a/doc/tasks/git_blacklist.md
+++ b/doc/tasks/git_blacklist.md
@@ -15,6 +15,7 @@ grumphp:
             whitelist_patterns: []
             triggered_by: ['php']
             regexp_type: G
+            match_word: true
 ```
 
 **keywords**
@@ -49,3 +50,13 @@ You can overwrite this option to whatever filetype you want to validate!
 *Default: G*
 
 This option allows you to choose the type of regexp you want to use for patterns (can be G for POSIX basic, E for POSIX extended or P for Perl Compatible).
+
+**match_word**
+
+*Default: false*
+
+This option allows you to choose how the keywords is found.
+
+For instance let's say you have a keyword looking like `"dd("` by default this task would also find any
+text before or after the keyword meaning this: `function add($someTask)` would still be considered invalid.
+This configuration option allows you to get around that issue.

--- a/doc/tasks/git_blacklist.md
+++ b/doc/tasks/git_blacklist.md
@@ -15,7 +15,7 @@ grumphp:
             whitelist_patterns: []
             triggered_by: ['php']
             regexp_type: G
-            match_word: true
+            match_word: false
 ```
 
 **keywords**

--- a/src/Task/Git/Blacklist.php
+++ b/src/Task/Git/Blacklist.php
@@ -66,7 +66,6 @@ class Blacklist extends AbstractExternalTask
 
         $whitelistPatterns = $config['whitelist_patterns'];
         $extensions = $config['triggered_by'];
-        $matchWord = $config['match_word'];
 
         $files = $context->getFiles();
         if (0 !== \count($whitelistPatterns)) {
@@ -84,11 +83,7 @@ class Blacklist extends AbstractExternalTask
         $arguments->add('-n');
         $arguments->add('--break');
         $arguments->add('--heading');
-
-        if (true === $matchWord) {
-            $arguments->add('--word-regexp');
-        }
-
+        $arguments->addOptionalArgument('--word-regexp', $config['match_word']);
         $arguments->addOptionalArgument('--color', $this->IO->isDecorated());
         $arguments->addOptionalArgument('-%s', $config['regexp_type']);
         $arguments->addArgumentArrayWithSeparatedValue('-e', $config['keywords']);

--- a/src/Task/Git/Blacklist.php
+++ b/src/Task/Git/Blacklist.php
@@ -41,6 +41,7 @@ class Blacklist extends AbstractExternalTask
             'whitelist_patterns' => [],
             'triggered_by' => ['php'],
             'regexp_type' => 'G',
+            'match_word' => false
         ]);
 
         $resolver->addAllowedTypes('keywords', ['array']);
@@ -49,6 +50,7 @@ class Blacklist extends AbstractExternalTask
         $resolver->addAllowedTypes('regexp_type', ['string']);
 
         $resolver->setAllowedValues('regexp_type', ['G', 'E', 'P']);
+        $resolver->addAllowedTypes('match_word', ['bool']);
 
         return $resolver;
     }
@@ -64,6 +66,7 @@ class Blacklist extends AbstractExternalTask
 
         $whitelistPatterns = $config['whitelist_patterns'];
         $extensions = $config['triggered_by'];
+        $matchWord = $config['match_word'];
 
         $files = $context->getFiles();
         if (0 !== \count($whitelistPatterns)) {
@@ -81,6 +84,11 @@ class Blacklist extends AbstractExternalTask
         $arguments->add('-n');
         $arguments->add('--break');
         $arguments->add('--heading');
+
+        if (true === $matchWord) {
+            $arguments->add('--word-regexp');
+        }
+
         $arguments->addOptionalArgument('--color', $this->IO->isDecorated());
         $arguments->addOptionalArgument('-%s', $config['regexp_type']);
         $arguments->addArgumentArrayWithSeparatedValue('-e', $config['keywords']);

--- a/test/Unit/Task/Git/BlacklistTest.php
+++ b/test/Unit/Task/Git/BlacklistTest.php
@@ -40,6 +40,7 @@ class BlacklistTest extends AbstractExternalTaskTestCase
                 'whitelist_patterns' => [],
                 'triggered_by' => ['php'],
                 'regexp_type' => 'G',
+                'match_word' => false
             ]
         ];
     }
@@ -173,6 +174,30 @@ class BlacklistTest extends AbstractExternalTaskTestCase
                 '--heading',
                 '--color',
                 '-P',
+                '-e',
+                'keyword',
+                'hello.php',
+                'hello2.php',
+            ],
+            $this->mockProcess(1)
+        ];
+
+        yield 'match_word' => [
+            [
+                'keywords' => ['keyword'],
+                'match_word' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'git',
+            [
+                'grep',
+                '--cached',
+                '-n',
+                '--break',
+                '--heading',
+                '--word-regexp',
+                '--color',
+                '-G',
                 '-e',
                 'keyword',
                 'hello.php',


### PR DESCRIPTION
Added a match_word option to git blacklist.

Closes: #803

| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #803

So I figured my issue #803 out by myself, as it turns out `git grep` command has an option called word `--word-regexp` or `-w` for sorthand.

This has been taken from the [Git scm documentation](https://git-scm.com/docs/git-grep)

```
Match the pattern only at word boundary 

(either begin at the beginning of a line, or preceded by a non-word character; end at the end of a line or followed by a non-word character).
```

I have added the possiblity to opt-in to this functionallity by using the new `match_word` option on the task. However I am fully open to changing this option on the task to something else. Some alternative naming conventions considered `strict_keywords`, `match_keywords`, `match_using_boundary`

All tests passes however let me know if I need to address anything before this can be merged I am new to contributing here.
