### PR TITLE
Phpstan: use_grumphp_paths option

### DIFF
--- a/doc/tasks/phpstan.md
+++ b/doc/tasks/phpstan.md
@@ -21,6 +21,7 @@ grumphp:
             ignore_patterns: []
             triggered_by: ['php']
             memory_limit: "-1"
+            use_grumphp_paths: true
 ```
 
 **autoload_file**
@@ -64,3 +65,12 @@ This is a list of extensions to be sniffed.
 *Default: null*
 
 With this parameter you can specify the memory limit.
+
+
+**use_grumphp_paths**
+
+*Default: true*
+
+Since there is no `--changed-files` flag [in PhpStan yet](https://github.com/phpstan/phpstan/issues/934#issuecomment-383002766),
+this flags allows you to change what files will be validated.
+You can choose to use the paths detected by GrumPHP, or you can choose to fall back on the PhpStan configuration.

--- a/src/Task/PhpStan.php
+++ b/src/Task/PhpStan.php
@@ -26,7 +26,8 @@ class PhpStan extends AbstractExternalTask
             'ignore_patterns' => [],
             'force_patterns' => [],
             'triggered_by' => ['php'],
-            'memory_limit' => null
+            'memory_limit' => null,
+            'use_grumphp_paths' => true,
         ]);
 
         $resolver->addAllowedTypes('autoload_file', ['null', 'string']);
@@ -47,6 +48,7 @@ class PhpStan extends AbstractExternalTask
         $resolver->addAllowedTypes('ignore_patterns', ['array']);
         $resolver->addAllowedTypes('force_patterns', ['array']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
+        $resolver->addAllowedTypes('use_grumphp_paths', ['bool']);
 
         return $resolver;
     }
@@ -90,7 +92,10 @@ class PhpStan extends AbstractExternalTask
         $arguments->add('--no-ansi');
         $arguments->add('--no-interaction');
         $arguments->add('--no-progress');
-        $arguments->addFiles($files);
+
+        if ($config['use_grumphp_paths']) {
+            $arguments->addFiles($files);
+        }
 
         $process = $this->processBuilder->buildProcess($arguments);
 

--- a/src/Test/Task/AbstractExternalTaskTestCase.php
+++ b/src/Test/Task/AbstractExternalTaskTestCase.php
@@ -80,7 +80,11 @@ abstract class AbstractExternalTaskTestCase extends AbstractTaskTestCase
      */
     private function resolveExpectedCliArgumentFromCallable(array $expectedArguments, array $actualArguments): array
     {
-        self::assertSameSize($expectedArguments, $actualArguments);
+        self::assertSameSize(
+            $expectedArguments,
+            $actualArguments,
+            'Received following arguments on CLI:'.implode(',', $actualArguments)
+        );
 
         return array_map(
             function ($expected, $actual) {

--- a/test/Unit/Task/PhpStanTest.php
+++ b/test/Unit/Task/PhpStanTest.php
@@ -31,8 +31,9 @@ class PhpStanTest extends AbstractExternalTaskTestCase
                 'ignore_patterns' => [],
                 'force_patterns' => [],
                 'triggered_by' => ['php'],
-                'memory_limit' => null
-            ]
+                'memory_limit' => null,
+                'use_grumphp_paths' => true,
+            ],
         ];
     }
 
@@ -192,12 +193,19 @@ class PhpStanTest extends AbstractExternalTaskTestCase
                 'hello2.php',
             ]
         ];
-
-        /*
-         *         $arguments->addOptionalArgument('--autoload-file=%s', $config['autoload_file']);
-        $arguments->addOptionalArgument('--configuration=%s', $config['configuration']);
-        $arguments->addOptionalArgument('--memory-limit=%s', $config['memory_limit']);
-        $arguments->addOptionalMixedArgument('--level=%s', $config['level']);
-         */
+        yield 'no_files' => [
+            [
+                'use_grumphp_paths' => false,
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'phpstan',
+            [
+                'analyse',
+                '--level=0',
+                '--no-ansi',
+                '--no-interaction',
+                '--no-progress',
+            ]
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #568, #512


This task adds a flag to the PhpStan task, so that you can choose whether you want GrumPHP to pass the list of changed files or not.

```yaml
grumphp:
    tasks:
        phpstan:
            use_grumphp_paths: true
```
