### PR TITLE
minor git_commit_message improvements

### DIFF
--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -106,6 +106,8 @@ services:
             - {name: grumphp.task, task: git_blacklist}
 
     GrumPHP\Task\Git\CommitMessage:
+        arguments:
+            - '@GrumPHP\Git\GitRepository'
         tags:
             - {name: grumphp.task, task: git_commit_message}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | #757, #729
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #757, #729

* Fixes #757 : a regex bug in the type conventions
* Fixes #729 : Respect core.commentChar config
