### PR TITLE
ecs: rename whitelist_patterns to paths and add files_on_pre_commit

### DIFF
--- a/doc/tasks/ecs.md
+++ b/doc/tasks/ecs.md
@@ -19,7 +19,7 @@ grumphp:
         ecs:
             config: ~
             level: ~
-            whitelist_patterns: []
+            paths: []
             triggered_by: ['php']
             clear-cache: false
             no-progress-bar: true
@@ -40,11 +40,13 @@ If you want to use a different config file than the default easy-coding-standard
 If you want to use a different level than the default one, specify it with this option.
 
 
-**whitelist_patterns**
+**paths**
 
 *Default: []*
 
-If you want to run on particular directories only, specify it with this option.
+Specify which folders you want to run ecs on.
+If you don't set any paths, ECS falls back to [the paths configuration inside your config file](https://github.com/symplify/easy-coding-standard#set-paths).
+Be aware: If both the CLI and the config file don't contain any paths, the task will always return true.
 
 **triggered_by**
 

--- a/doc/tasks/ecs.md
+++ b/doc/tasks/ecs.md
@@ -20,6 +20,7 @@ grumphp:
             config: ~
             level: ~
             paths: []
+            files_on_pre_commit: false
             triggered_by: ['php']
             clear-cache: false
             no-progress-bar: true
@@ -47,6 +48,13 @@ If you want to use a different level than the default one, specify it with this 
 Specify which folders you want to run ecs on.
 If you don't set any paths, ECS falls back to [the paths configuration inside your config file](https://github.com/symplify/easy-coding-standard#set-paths).
 Be aware: If both the CLI and the config file don't contain any paths, the task will always return true.
+
+**files_on_pre_commit**
+
+*Default: false*
+
+This option makes it possible to use the changed files as paths during pre-commits.
+It will use the paths option to make sure only committed files that match the path are validated.
 
 **triggered_by**
 

--- a/src/Task/Ecs.php
+++ b/src/Task/Ecs.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace GrumPHP\Task;
 
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
 use GrumPHP\Task\Context\ContextInterface;
@@ -26,6 +28,7 @@ class Ecs extends AbstractExternalTask
             'config' => null,
             'level' => null,
             'triggered_by' => ['php'],
+            'files_on_pre_commit' => false,
         ]);
 
         $resolver->addAllowedTypes('paths', ['array']);
@@ -34,6 +37,7 @@ class Ecs extends AbstractExternalTask
         $resolver->addAllowedTypes('config', ['null', 'string']);
         $resolver->addAllowedTypes('level', ['null', 'string']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
+        $resolver->addAllowedTypes('files_on_pre_commit', ['bool']);
 
         return $resolver;
     }
@@ -47,7 +51,10 @@ class Ecs extends AbstractExternalTask
     {
         $config = $this->getConfig()->getOptions();
 
-        $files = $context->getFiles()->extensions($config['triggered_by']);
+        $files = $context->getFiles()
+            ->extensions($config['triggered_by'])
+            ->paths($config['paths']);
+
         if (0 === \count($files)) {
             return TaskResult::createSkipped($this, $context);
         }
@@ -61,7 +68,7 @@ class Ecs extends AbstractExternalTask
         $arguments->addOptionalArgument('--no-progress-bar', $config['no-progress-bar']);
         $arguments->addOptionalArgument('--ansi', true);
         $arguments->addOptionalArgument('--no-interaction', true);
-        $arguments->addArgumentArray('%s', $config['paths']);
+        $this->addPaths($arguments, $context, $files, $config);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();
@@ -71,5 +78,24 @@ class Ecs extends AbstractExternalTask
         }
 
         return TaskResult::createPassed($this, $context);
+    }
+
+    /**
+     * This method adds the newly committed files in pre commit context if you enabled the files_on_pre_commit flag.
+     * In other cases, it falls back to the configured paths.
+     * If no paths have been set, the paths from inside your ECS configuration file will be used.
+     */
+    private function addPaths(
+        ProcessArgumentsCollection $arguments,
+        ContextInterface $context,
+        FilesCollection $files,
+        array $config
+    ): void {
+        if ($context instanceof GitPreCommitContext && $config['files_on_pre_commit']) {
+            $arguments->addFiles($files);
+            return;
+        }
+
+        $arguments->addArgumentArray('%s', $config['paths']);
     }
 }

--- a/src/Task/Ecs.php
+++ b/src/Task/Ecs.php
@@ -20,7 +20,7 @@ class Ecs extends AbstractExternalTask
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
-            'whitelist_patterns' => [],
+            'paths' => [],
             'clear-cache' => false,
             'no-progress-bar' => true,
             'config' => null,
@@ -28,7 +28,7 @@ class Ecs extends AbstractExternalTask
             'triggered_by' => ['php'],
         ]);
 
-        $resolver->addAllowedTypes('whitelist_patterns', ['array']);
+        $resolver->addAllowedTypes('paths', ['array']);
         $resolver->addAllowedTypes('clear-cache', ['bool']);
         $resolver->addAllowedTypes('no-progress-bar', ['bool']);
         $resolver->addAllowedTypes('config', ['null', 'string']);
@@ -55,16 +55,13 @@ class Ecs extends AbstractExternalTask
         $arguments = $this->processBuilder->createArgumentsForCommand('ecs');
         $arguments->add('check');
 
-        foreach ($config['whitelist_patterns'] as $whitelistPattern) {
-            $arguments->add($whitelistPattern);
-        }
-
         $arguments->addOptionalArgument('--config=%s', $config['config']);
         $arguments->addOptionalArgument('--level=%s', $config['level']);
         $arguments->addOptionalArgument('--clear-cache', $config['clear-cache']);
         $arguments->addOptionalArgument('--no-progress-bar', $config['no-progress-bar']);
         $arguments->addOptionalArgument('--ansi', true);
         $arguments->addOptionalArgument('--no-interaction', true);
+        $arguments->addArgumentArray('%s', $config['paths']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();

--- a/test/Unit/Task/EcsTest.php
+++ b/test/Unit/Task/EcsTest.php
@@ -31,6 +31,7 @@ class EcsTest extends AbstractExternalTaskTestCase
                 'config' => null,
                 'level' => null,
                 'triggered_by' => ['php'],
+                'files_on_pre_commit' => false,
             ]
         ];
     }
@@ -89,6 +90,13 @@ class EcsTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['notaphpfile.txt']),
             function () {}
         ];
+        yield 'no-files-after-path' => [
+            [
+                'paths' => ['src']
+            ],
+            $this->mockContext(RunContext::class, ['test/notinsource.php']),
+            function () {}
+        ];
     }
 
     public function provideExternalTaskRuns(): iterable
@@ -109,7 +117,7 @@ class EcsTest extends AbstractExternalTaskTestCase
             [
                 'paths' => ['src/', 'test/'],
             ],
-            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            $this->mockContext(RunContext::class, ['src/hello.php', 'test/hello2.php']),
             'ecs',
             [
                 'check',
@@ -120,6 +128,39 @@ class EcsTest extends AbstractExternalTaskTestCase
                 'test/',
             ]
         ];
+
+        yield 'files_on_pre_commit_in_run_context' => [
+            [
+                'paths' => ['src/'],
+                'files_on_pre_commit' => true,
+            ],
+            $this->mockContext(RunContext::class, ['src/hello.php', 'test/hello2.php']),
+            'ecs',
+            [
+                'check',
+                '--no-progress-bar',
+                '--ansi',
+                '--no-interaction',
+                'src/',
+            ]
+        ];
+
+        yield 'files_on_pre_commit' => [
+            [
+                'paths' => ['src/'],
+                'files_on_pre_commit' => true,
+            ],
+            $this->mockContext(GitPreCommitContext::class, ['src/hello.php', 'test/hello2.php']),
+            'ecs',
+            [
+                'check',
+                '--no-progress-bar',
+                '--ansi',
+                '--no-interaction',
+                'src/hello.php',
+            ]
+        ];
+
         yield 'clear-cache' => [
             [
                 'clear-cache' => true,

--- a/test/Unit/Task/EcsTest.php
+++ b/test/Unit/Task/EcsTest.php
@@ -25,7 +25,7 @@ class EcsTest extends AbstractExternalTaskTestCase
         yield 'defaults' => [
             [],
             [
-                'whitelist_patterns' => [],
+                'paths' => [],
                 'clear-cache' => false,
                 'no-progress-bar' => true,
                 'config' => null,
@@ -105,19 +105,19 @@ class EcsTest extends AbstractExternalTaskTestCase
             ]
         ];
 
-        yield 'whitelist' => [
+        yield 'paths' => [
             [
-                'whitelist_patterns' => ['src/', 'test/'],
+                'paths' => ['src/', 'test/'],
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'ecs',
             [
                 'check',
-                'src/',
-                'test/',
                 '--no-progress-bar',
                 '--ansi',
                 '--no-interaction',
+                'src/',
+                'test/',
             ]
         ];
         yield 'clear-cache' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | #726
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #726, #652

This PR renames the `whitlist_patterns` option inside the ECS task to `paths`, making it less confusing.
It also updates the documentation to give you better information on how to configure the task.

Besides that, it also adds the `files_on_pre_commit` as suggested in PR #652 
