### PR TITLE
Add a fail-safe fallback for fetching git config values

### DIFF
--- a/spec/Git/GitRepositorySpec.php
+++ b/spec/Git/GitRepositorySpec.php
@@ -4,12 +4,14 @@ namespace spec\GrumPHP\Git;
 
 use Gitonomy\Git\Diff\Diff;
 use Gitonomy\Git\Diff\File;
+use Gitonomy\Git\Exception\ProcessException;
 use Gitonomy\Git\Repository;
 use Gitonomy\Git\WorkingCopy;
 use GrumPHP\Locator\GitRepositoryLocator;
 use PhpSpec\ObjectBehavior;
 use GrumPHP\Git\GitRepository;
 use Prophecy\Argument;
+use Symfony\Component\Process\Process;
 
 class GitRepositorySpec extends ObjectBehavior
 {
@@ -37,6 +39,36 @@ class GitRepositorySpec extends ObjectBehavior
     {
         $repository->run('command', [])->willReturn('ok');
         $this->run('command', [])->shouldBe('ok');
+    }
+
+    public function it_can_deal_with_errornous_throwing_runs(Process $process): void
+    {
+        $this->tryToRunWithFallback(
+            function () use ($process) {
+                throw new ProcessException($process->getWrappedObject());
+            },
+            'fallback'
+        )->shouldBe('fallback');
+    }
+
+    public function it_can_deal_with_errornous_null_returing_runs(): void
+    {
+        $this->tryToRunWithFallback(
+            function () {
+                return null;
+            },
+            'fallback'
+        )->shouldBe('fallback');
+    }
+
+    public function it_can_deal_with_valid_run_results(): void
+    {
+        $this->tryToRunWithFallback(
+            function () {
+                return 'ok';
+            },
+            'fallback'
+        )->shouldBe('ok');
     }
 
     public function it_can_fetch_working_copy(Repository $repository, WorkingCopy $workingCopy): void

--- a/src/Git/GitRepository.php
+++ b/src/Git/GitRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GrumPHP\Git;
 
 use Gitonomy\Git\Diff\Diff;
+use Gitonomy\Git\Exception\ProcessException;
 use Gitonomy\Git\Repository;
 use Gitonomy\Git\WorkingCopy;
 use GrumPHP\Locator\GitRepositoryLocator;
@@ -45,6 +46,22 @@ class GitRepository
     public function run(string $command, array $args): ?string
     {
         return $this->getRepository()->run($command, $args);
+    }
+
+    /**
+     * The gitonomy run method handles errors differently based on debug (throw) or non-debug (return null) mode.
+     * This method makes it possible to run a git command but fallback to a default string if the command fails.
+     * It can be used to e.g. fetch git configurations.
+     */
+    public function tryToRunWithFallback(callable $run, string $fallback): string
+    {
+        try {
+            $result = $run();
+        } catch (ProcessException $exception) {
+            return $fallback;
+        }
+
+        return $result ?? $fallback;
     }
 
     public function createRawDiff(string $rawDiff): Diff

--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -307,7 +307,13 @@ class CommitMessage implements TaskInterface
 
     private function getCommitMessageLinesWithoutComments(string $commitMessage): array
     {
-        $commentChar = trim($this->repository->run('config', ['--get', 'core.commentChar']) ?: '#');
+        $commentChar = trim($this->repository->tryToRunWithFallback(
+            function (): ?string {
+                return $this->repository->run('config', ['--get', 'core.commentChar']);
+            },
+            '#'
+        ));
+
         $lines = preg_split('/\R/u', $commitMessage);
         $everythingBelowWillBeIgnored = false;
 

--- a/test/Unit/Task/Git/CommitMessageTest.php
+++ b/test/Unit/Task/Git/CommitMessageTest.php
@@ -13,6 +13,7 @@ use GrumPHP\Task\Context\RunContext;
 use GrumPHP\Task\Git\CommitMessage;
 use GrumPHP\Task\TaskInterface;
 use GrumPHP\Test\Task\AbstractTaskTestCase;
+use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 
 class CommitMessageTest extends AbstractTaskTestCase
@@ -26,6 +27,9 @@ class CommitMessageTest extends AbstractTaskTestCase
     {
         $this->repository = $this->prophesize(GitRepository::class);
         $this->repository->run('config', ['--get', 'core.commentChar'])->willReturn('#');
+        $this->repository->tryToRunWithFallback(Argument::cetera())->will(function (array $arguments) {
+            return $arguments[0]();
+        });
 
         return new CommitMessage(
             $this->repository->reveal()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #813

Fixes #813

This PR contains  a safer way of fetching git configuration values.
