### PR TITLE
Improve no-ansi reporting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "doctrine/collections": "^1.6.7",
         "gitonomy/gitlib": "^1.0.3",
         "monolog/monolog": "~1.16 || ^2.0",
+        "ondram/ci-detector": "^3.5",
         "opis/closure": "^3.5",
         "psr/container": "^1.0",
         "seld/jsonlint": "~1.1",

--- a/resources/config/runner.yml
+++ b/resources/config/runner.yml
@@ -110,4 +110,12 @@ services:
         arguments:
             - '@grumphp.io'
             - '@GrumPHP\Runner\MemoizedTaskResultMap'
+            - '@GrumPHP\Runner\Ci\CiDetector'
 
+    #
+    # CI Detection
+    #
+    GrumPHP\Runner\Ci\CiDetector:
+        arguments:
+            - '@OndraM\CiDetector\CiDetector'
+    OndraM\CiDetector\CiDetector: ~

--- a/src/Runner/Ci/CiDetector.php
+++ b/src/Runner/Ci/CiDetector.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Runner\Ci;
+
+use OndraM\CiDetector\CiDetector as RealCiDetector;
+
+class CiDetector
+{
+    /**
+     * @var RealCiDetector
+     */
+    private $ciDetector;
+
+    /**
+     * @var ?bool
+     */
+    private $ciDetected;
+
+    public function __construct(RealCiDetector $ciDetector)
+    {
+        $this->ciDetector = $ciDetector;
+    }
+
+    public function isCiDetected(): bool
+    {
+        if (null === $this->ciDetected) {
+            $this->ciDetected = $this->ciDetector->isCiDetected();
+        }
+
+        return $this->ciDetected;
+    }
+}

--- a/src/Runner/Reporting/TaskResultsReporter.php
+++ b/src/Runner/Reporting/TaskResultsReporter.php
@@ -78,9 +78,10 @@ class TaskResultsReporter
             $i++;
         }
 
-        // Add a newline if overwrite is not possible in order to split both sections
+        // Always add content if we decided that an overwrite is not possible!
         if (!$this->isOverwritePossible()) {
-            $this->IO->write(['']);
+            $this->outputSection->writeln(array_merge($message, ['']));
+            return;
         }
 
         $this->outputSection->overwrite(implode(PHP_EOL, $message));

--- a/src/Runner/Reporting/TaskResultsReporter.php
+++ b/src/Runner/Reporting/TaskResultsReporter.php
@@ -78,6 +78,11 @@ class TaskResultsReporter
             $i++;
         }
 
+        // Add a newline if overwrite is not possible in order to split both sections
+        if (!$this->isOverwritePossible()) {
+            $this->IO->write(['']);
+        }
+
         $this->outputSection->overwrite(implode(PHP_EOL, $message));
     }
 
@@ -127,7 +132,7 @@ class TaskResultsReporter
      */
     private function shouldRenderReport(TaskRunnerContext $context): bool
     {
-        if ($this->IO->isDecorated() && !$this->ciDetector->isCiDetected()) {
+        if ($this->isOverwritePossible()) {
             return true;
         }
 
@@ -140,5 +145,10 @@ class TaskResultsReporter
         );
 
         return $reportedCount === 0 || $reportedCount === count($context->getTasks());
+    }
+
+    private function isOverwritePossible(): bool
+    {
+        return $this->IO->isDecorated() && !$this->ciDetector->isCiDetected();
     }
 }

--- a/test/Unit/Runner/Ci/CiDetectorTest.php
+++ b/test/Unit/Runner/Ci/CiDetectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHPTest\Unit\Runner\Ci;
+
+use GrumPHP\Runner\Ci\CiDetector;
+use OndraM\CiDetector\CiDetector as RealCiDetector;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class CiDetectorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /** @test */
+    public function it_can_detect_it_runs_in_well_known_ci_environments(): void
+    {
+        /** @var ObjectProphecy & RealCiDetector $ciDetector */
+        $ciDetector = $this->prophesize(RealCiDetector::class);
+        $detector = new CiDetector($ciDetector->reveal());
+
+        $ciDetector->isCiDetected()->willReturn(true);
+
+        self::assertTrue($detector->isCiDetected());
+        self::assertTrue($detector->isCiDetected());
+        self::assertTrue($detector->isCiDetected());
+
+        $ciDetector->isCiDetected()->shouldHaveBeenCalledOnce();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #817


This PR creates a less verbose output on non-ansi systems like Github actions, Travis, ...
You can switch the behaviour by adding `--ansi` or `--no-ansi` flag.