### PR TITLE
Change easycodingstandard package name in suggest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "squizlabs/php_codesniffer": "Lets GrumPHP sniff on your code.",
         "sstalle/php7cc": "Lets GrumPHP check PHP 5.3 - 5.6 code compatibility with PHP 7.",
         "symfony/phpunit-bridge": "Lets GrumPHP run your unit tests with the phpunit-bridge of Symfony.",
-        "symplify/easycodingstandard": "Lets GrumPHP check coding standard.",
+        "symplify/easy-coding-standard": "Lets GrumPHP check coding standard.",
         "vimeo/psalm": "Lets GrumPHP discover errors in your code without running it."
     },
     "config": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Documented?   | yes
| Fixed tickets | 

Current package name is not up-to-date for symplify/easy-coding-standard within the suggest section of the composer.json. It is correct in the documentation though: https://github.com/phpro/grumphp/blob/master/doc/tasks/ecs.md#ecs---easycodingstandard