### PR TITLE
PHPStan task : search automatically phpstan.neon

### DIFF
--- a/doc/tasks/phpstan.md
+++ b/doc/tasks/phpstan.md
@@ -35,6 +35,7 @@ With this parameter you can specify the path your project's additional autoload 
 *Default: null*
 
 With this parameter you can specify the path your project's configuration file.
+By leaving null, GrumPHP will look if you have a phpstan.neon or phpstan.neon.dist config file ([default values](https://phpstan.org/config-reference#config-file)).
 
 **level**
 

--- a/src/Task/PhpStan.php
+++ b/src/Task/PhpStan.php
@@ -73,6 +73,14 @@ class PhpStan extends AbstractExternalTask
             ->notPaths($config['ignore_patterns'])
             ->extensions($config['triggered_by']);
 
+        if (!($config['configuration'])) {
+            if (file_exists('phpstan.neon')) {
+                $config['configuration'] = 'phpstan.neon';
+            } elseif(file_exists('phpstan.neon.dist')) {
+                $config['configuration'] = 'phpstan.neon.dist';
+            }
+        }
+
         if (!empty($config['force_patterns'])) {
             $forcedFiles = $context->getFiles()->paths($config['force_patterns']);
             $files = $files->ensureFiles($forcedFiles);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets |

It is now no longer necessary to specify its phpstan configuration file if it has the default name.