### PR TITLE
Remove obsolete sprintf from ExecutableNotFoundException callback

### DIFF
--- a/src/Locator/ExternalCommand.php
+++ b/src/Locator/ExternalCommand.php
@@ -51,8 +51,6 @@ class ExternalCommand
             }
         }
 
-        throw ExecutableNotFoundException::forCommand(
-            sprintf('The executable for "%s" could not be found.', $command)
-        );
+        throw ExecutableNotFoundException::forCommand($command);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 

When Grumphp throws an ExecutableNotFoundException via the ExternalCommand class it executes sprintf twice because the Exception contains the sprintf as well.. This was probably introduced during refactoring of the Exception. This pull request just removes the obsolete sprintf.

https://github.com/phpro/grumphp/blob/0e6287a3ae70a8730d11a239449e991b3fc78f99/src/Exception/ExecutableNotFoundException.php#L12

**Example of output before:**
```
phpmd
=====

The executable for "The executable for "phpmd" could not be found." could not be found.
```

**Example of output after:**
```
phpmd
=====

The executable for "phpmd" could not be found.
```