### PR TITLE
Consistently use yml instead of yaml extension in documentation

### DIFF
--- a/doc/installation/exotic.md
+++ b/doc/installation/exotic.md
@@ -116,7 +116,7 @@ If you want to support multiple bin directories, you can prepend them to your pa
 
 ### Environment variables
 
-It is also possible to set some of the environment variables above inside the `grumphp.yaml` file directly:
+It is also possible to set some of the environment variables above inside the `grumphp.yml` file directly:
 
 ```yaml
 grumphp:
@@ -130,9 +130,9 @@ grumphp:
       - 'tools' 
 ```
 
-The configuration from inside the `grumphp.yaml` file will be loaded if the guessing system was able to determine an initial version of the guessed paths.
+The configuration from inside the `grumphp.yml` file will be loaded if the guessing system was able to determine an initial version of the guessed paths.
 This is required because GrumPHP tries to guess its config file based on all the parameters above.
-Once the config is loaded, it does a second guess based on environment variables that were detected inside the `grumphp.yaml` file.
+Once the config is loaded, it does a second guess based on environment variables that were detected inside the `grumphp.yml` file.
 
 
 ## Running GrumPHP with a custom config file

--- a/doc/runner.md
+++ b/doc/runner.md
@@ -63,7 +63,7 @@ class PassThroughMiddleware implements RunnerMiddlewareInterface
 Configuration:
 
 ```yaml
-# grumphp.yaml
+# grumphp.yml
 
 services:
     PassThroughMiddleware:
@@ -103,7 +103,7 @@ class PassThroughTaskHandlerMiddleware implements TaskHandlerMiddlewareInterface
 Configuration:
 
 ```yaml
-# grumphp.yaml
+# grumphp.yml
 
 services:
     PassThroughTaskHandlerMiddleware:

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -169,7 +169,7 @@ This way you can configure the same task twice by using an alias with different 
 ## Creating a custom task
 
 Creating a custom task is a matter of implementing the provided `GrumPHP\Task\TaskInterface`.
-When your task is written, you have to register it to the service manager and add your task configuration to `grumphp.yaml`:
+When your task is written, you have to register it to the service manager and add your task configuration to `grumphp.yml`:
 
 ```php
 <?php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets |

Even though I can see that grumphp allows for both yml and yaml configuration files like it is supposed to:

https://github.com/phpro/grumphp/blob/0e6287a3ae70a8730d11a239449e991b3fc78f99/src/Locator/GuessedPathsLocator.php#L109-L112

I think semantically it's best to stay consistent through out the documentation to only reference one of the allowed extensions. A quick search showed that yml was the prefered extension:

- 11 results in 6 files for grumphp.yaml
- 148 results in 71 files for grumphp.yml

This pull request changes the extension in the documentation only. No code is touched. Maybe we could document that the GuessedPathsLocator allows for both yml and yaml extension on the grumphp configuration files. I just don't really know where to put that.