### PR TITLE
Remove unknown options from phpcpd task documentation

### DIFF
--- a/doc/tasks/phpcpd.md
+++ b/doc/tasks/phpcpd.md
@@ -19,8 +19,6 @@ grumphp:
         phpcpd:
             directory: ['.']
             exclude: ['vendor']
-            names_exclude: []
-            regexps_exclude: []
             fuzzy: false
             min_lines: 5
             min_tokens: 70


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets |

When executing phpcpd through grumphp with the default settings copied from the documentation page to my grumphp.yml file it throws the following error:

```
In OptionsResolver.php line 871:
                                                                               
  The options "names_exclude", "regexps_exclude" do not exist. Defined option  
  s are: "directory", "exclude", "fuzzy", "min_lines", "min_tokens", "trigger  
  ed_by".  
```

This pull requests removes the unknown options from the documentation page.