### PR TITLE
Twig min version

### DIFF
--- a/doc/tasks/twigcs.md
+++ b/doc/tasks/twigcs.md
@@ -5,7 +5,7 @@ Check Twig coding standard based on [FriendsOfTwig/TwigCs](https://github.com/Fr
 ***Composer***
 
 ```
-composer require --dev friendsoftwig/twigcs
+composer require --dev friendsoftwig/twigcs:^4.0
 ```
 
 ***Config***

--- a/doc/tasks/twigcs.md
+++ b/doc/tasks/twigcs.md
@@ -5,7 +5,7 @@ Check Twig coding standard based on [FriendsOfTwig/TwigCs](https://github.com/Fr
 ***Composer***
 
 ```
-composer require --dev friendsoftwig/twigcs:^4.0
+composer require --dev "friendsoftwig/twigcs:>=4"
 ```
 
 ***Config***


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Documented?   | yes/no
| Fixed tickets | 

With the default settings for the twigcs task in Grumphp we require the >=4.0 versions:

https://github.com/phpro/grumphp/blob/b8354000dc6e177ab1e77c06817876f11bb6c879/src/Task/TwigCs.php#L19-L25

Earlier version like ^3.0 have a different namespace:

https://github.com/friendsoftwig/twigcs/blob/7c4bc76dad8d851045b9eeab4979a240550f8300/src/Ruleset/Official.php#L3

For that I think it's best that we change the documentation line to require the >=4 version of this package.