### PR TITLE
Made Ecs task fixable

### DIFF
--- a/test/Unit/Task/EcsTest.php
+++ b/test/Unit/Task/EcsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GrumPHPTest\Unit\Task;
 
+use GrumPHP\Runner\FixableTaskResult;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use GrumPHP\Task\Ecs;
@@ -63,7 +64,8 @@ class EcsTest extends AbstractExternalTaskTestCase
                 $this->mockProcessBuilder('ecs', $process = $this->mockProcess(1));
                 $this->formatter->format($process)->willReturn('nope');
             },
-            'nope'
+            'nope',
+            FixableTaskResult::class
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
The Ecs task now returns a `FixableTaskResult` allowing it to work with the `fixer` parameter.