### PR TITLE
Allow merging tasks

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -37,6 +37,7 @@ class Configuration implements ConfigurationInterface
         $tasks = $rootNode->children()->arrayNode('tasks');
         $tasks->normalizeKeys(false);
         $tasks->variablePrototype();
+        $tasks->useAttributeAsKey('name');
 
         // Testsuites
         $testSuites = $rootNode->children()->arrayNode('testsuites');

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -37,7 +37,7 @@ class Configuration implements ConfigurationInterface
         $tasks = $rootNode->children()->arrayNode('tasks');
         $tasks->normalizeKeys(false);
         $tasks->variablePrototype();
-        $tasks->useAttributeAsKey('name');
+        $tasks->useAttributeAsKey('grumphpTaskName');
 
         // Testsuites
         $testSuites = $rootNode->children()->arrayNode('testsuites');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

We have two separate YAML files like this:
```yaml
---
grumphp:
  tasks:
    composer: ~
```
```yaml
---
imports:
  - resource: grumphp2.yml
grumphp:
  tasks:
    composer_normalize: ~
```

This does not work because the import does not merge the task array correctly.
If I dump it, the merged array looks like this:
```yaml
tasks:
  composer: ~
  1: ~
```

And it will crash with this error:
```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to GrumPHP\Exception\TaskConfigResolverException::unknownTask() must be of the type string, int given, called in /home/pierre/workspace/drupal_d9/vendor/phpro/grumphp/src/Configuration/Compiler/TaskCompilerPass.php on line 42 and defined in /home/pierre/workspace/drupal_d9/vendor/phpro/grumphp/src/Exception/TaskConfigResolverException.php:11
Stack trace:
#0 /home/pierre/workspace/drupal_d9/vendor/phpro/grumphp/src/Configuration/Compiler/TaskCompilerPass.php(42): GrumPHP\Exception\TaskConfigResolverException::unknownTask()
#1 /home/pierre/workspace/drupal_d9/vendor/symfony/dependency-injection/Compiler/Compiler.php(94): GrumPHP\Configuration\Compiler\TaskCompilerPass->process()
#2 /home/pierre/workspace/drupal_d9/vendor/symfony/dependency-injection/ContainerBuilder.php(762): Symfony\Component\DependencyInjection\Compiler\Compiler->compile()
#3 /home/pierre/workspace/drupal_d9/vendor/phpro/grumphp/src/Configuration/ContainerBuilder.php(59): Symfony\Component\DependencyInjec in /home/pierre/workspace/drupal_d9/vendor/phpro/grumphp/src/Exception/TaskConfigResolverException.php on line 11
```

This PR makes sure the keys are kept when merging the arrays.