### PR TITLE
fix(CommitMessage): merge branch and tag syntax was failing with GitFlow

### DIFF
--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -355,7 +355,8 @@ class CommitMessage implements TaskInterface
         $typesPattern = '([a-zA-Z0-9]+)';
         $scopesPattern = '(:\s|(\(.+\)?:\s))';
         $subjectPattern = '([a-zA-Z0-9-_ #@\'\/\\"]+)';
-        $mergePattern = '(Merge branch \'.+\'\s.+|Merge remote-tracking branch \'.+\'|Merge pull request #\d+\s.+)';
+        $mergePattern =
+            '(Merge branch|tag \'.+\'(?:\s.+)?|Merge remote-tracking branch \'.+\'|Merge pull request #\d+\s.+)';
 
         if (count($types) > 0) {
             $types = implode('|', $types);

--- a/test/Unit/Task/Git/CommitMessageTest.php
+++ b/test/Unit/Task/Git/CommitMessageTest.php
@@ -656,6 +656,32 @@ class CommitMessageTest extends AbstractTaskTestCase
             function () {
             },
         ];
+        yield 'skip_type_scope_conventions_on_merge_branch_gitflow' => [
+            [
+                'enforce_capitalized_subject' => false,
+                'type_scope_conventions' => [
+                    'types' => [
+                        'fix'
+                    ],
+                ],
+            ],
+            $this->mockCommitMsgContext($this->buildMessage("Merge branch 'release/x.y.z'")),
+            function () {
+            },
+        ];
+        yield 'skip_type_scope_conventions_on_merge_tag_gitflow' => [
+            [
+                'enforce_capitalized_subject' => false,
+                'type_scope_conventions' => [
+                    'types' => [
+                        'fix'
+                    ],
+                ],
+            ],
+            $this->mockCommitMsgContext($this->buildMessage("Merge tag 'x.y.z' into")),
+            function () {
+            },
+        ];
         yield 'skip_type_scope_conventions_on_merge_remote' => [
             [
                 'enforce_capitalized_subject' => false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

GitFlow uses this syntax automatically when merging branches:
Merge release 'x.y.z'
Merge tag 'x.y.z' into develop

This PR fixes GrumPHP failing when merging a GitFlow branch with `git flow release finish`.
