### PR TITLE
Fixed regex special characters not escaped in example code.

### DIFF
--- a/doc/tasks/git_blacklist.md
+++ b/doc/tasks/git_blacklist.md
@@ -9,8 +9,8 @@ grumphp:
     tasks:
         git_blacklist:
             keywords:
-                - "die("
-                - "var_dump("
+                - "die\\("
+                - "var_dump\\("
                 - "exit;"
             whitelist_patterns: []
             triggered_by: ['php']


### PR DESCRIPTION
Documentation fix for #833  