### PR TITLE
Implement refactored formatter options for Deptrac >= v0.9.0

### DIFF
--- a/doc/tasks/deptrac.md
+++ b/doc/tasks/deptrac.md
@@ -19,6 +19,7 @@ grumphp:
             graphviz_dump_dot: ~
             graphviz_dump_html: ~
             junit_dump_xml: ~
+            xml_dump: ~
 ```
 
 **depfile**
@@ -62,3 +63,9 @@ Set path to a dumped html file.
 *Default: null*
 
 Set path to a dumped JUnit xml file.
+
+**xml_dump**
+
+*Default: null*
+
+Set path to a dumped xml file.

--- a/doc/tasks/deptrac.md
+++ b/doc/tasks/deptrac.md
@@ -18,6 +18,7 @@ grumphp:
             graphviz_dump_image: ~
             graphviz_dump_dot: ~
             graphviz_dump_html: ~
+            junit_dump_xml: ~
 ```
 
 **depfile**
@@ -55,3 +56,9 @@ Set path to a dumped dot file.
 *Default: null*
 
 Set path to a dumped html file.
+
+**junit_dump_xml**
+
+*Default: null*
+
+Set path to a dumped JUnit xml file.

--- a/doc/tasks/deptrac.md
+++ b/doc/tasks/deptrac.md
@@ -13,11 +13,11 @@ grumphp:
     tasks:
         deptrac:
             depfile: ~
-            formatter_graphviz: ~
-            formatter_graphviz_display: ~
-            formatter_graphviz_dump_image: ~
-            formatter_graphviz_dump_dot: ~
-            formatter_graphviz_dump_html: ~
+            formatter: ~
+            graphviz_display: ~
+            graphviz_dump_image: ~
+            graphviz_dump_dot: ~
+            graphviz_dump_html: ~
 ```
 
 **depfile**
@@ -26,31 +26,31 @@ grumphp:
 
 Set path to deptrac configuration file. Example: `/var/www/src/depfile.yml`
 
-**formatter_graphviz**
+**formatter**
 
-*Default: false*
+*Default: []*
 
-Set to `true` to enable the graphviz formatter.
+Enable (multiple) formatters with this option, e.g. `console`, `github-actions`, `graphviz`, `table`, `junit`, `xml`, `baseline`.
 
-**formatter_graphviz_display**
+**graphviz_display**
 
 *Default: true*
 
 Open the generated graphviz image. Set to `true` to activate.
 
-**formatter_graphviz_dump_image**
+**graphviz_dump_image**
 
 *Default: null*
 
 Set path to a dumped png file.
 
-**formatter_graphviz_dump_dot**
+**graphviz_dump_dot**
 
 *Default: null*
 
 Set path to a dumped dot file.
 
-**formatter_graphviz_dump_html**
+**graphviz_dump_html**
 
 *Default: null*
 

--- a/doc/tasks/deptrac.md
+++ b/doc/tasks/deptrac.md
@@ -20,6 +20,7 @@ grumphp:
             graphviz_dump_html: ~
             junit_dump_xml: ~
             xml_dump: ~
+            baseline_dump: ~
 ```
 
 **depfile**
@@ -69,3 +70,9 @@ Set path to a dumped JUnit xml file.
 *Default: null*
 
 Set path to a dumped xml file.
+
+**baseline_dump**
+
+*Default: null*
+
+Set path to a dumped baseline file.

--- a/src/Task/Deptrac.php
+++ b/src/Task/Deptrac.php
@@ -21,19 +21,19 @@ class Deptrac extends AbstractExternalTask
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
             'depfile' => null,
-            'formatter_graphviz' => false,
-            'formatter_graphviz_display' => true,
-            'formatter_graphviz_dump_image' => null,
-            'formatter_graphviz_dump_dot' => null,
-            'formatter_graphviz_dump_html' => null,
+            'formatter' => [],
+            'graphviz_display' => true,
+            'graphviz_dump_image' => null,
+            'graphviz_dump_dot' => null,
+            'graphviz_dump_html' => null,
         ]);
 
         $resolver->addAllowedTypes('depfile', ['null', 'string']);
-        $resolver->addAllowedTypes('formatter_graphviz', ['bool']);
-        $resolver->addAllowedTypes('formatter_graphviz_display', ['bool']);
-        $resolver->addAllowedTypes('formatter_graphviz_dump_image', ['null', 'string']);
-        $resolver->addAllowedTypes('formatter_graphviz_dump_dot', ['null', 'string']);
-        $resolver->addAllowedTypes('formatter_graphviz_dump_html', ['null', 'string']);
+        $resolver->addAllowedTypes('formatter', ['string[]']);
+        $resolver->addAllowedTypes('graphviz_display', ['bool']);
+        $resolver->addAllowedTypes('graphviz_dump_image', ['null', 'string']);
+        $resolver->addAllowedTypes('graphviz_dump_dot', ['null', 'string']);
+        $resolver->addAllowedTypes('graphviz_dump_html', ['null', 'string']);
 
         return $resolver;
     }
@@ -54,11 +54,11 @@ class Deptrac extends AbstractExternalTask
 
         $arguments = $this->processBuilder->createArgumentsForCommand('deptrac');
         $arguments->add('analyze');
-        $arguments->add('--formatter-graphviz='.(int) $config['formatter_graphviz']);
-        $arguments->add('--formatter-graphviz-display='.(int) $config['formatter_graphviz_display']);
-        $arguments->addOptionalArgument('--formatter-graphviz-dump-image=%s', $config['formatter_graphviz_dump_image']);
-        $arguments->addOptionalArgument('--formatter-graphviz-dump-dot=%s', $config['formatter_graphviz_dump_dot']);
-        $arguments->addOptionalArgument('--formatter-graphviz-dump-html=%s', $config['formatter_graphviz_dump_html']);
+        $arguments->addArgumentArray('--formatter=%s', $config['formatter']);
+        $arguments->add('--graphviz-display='.(int) $config['graphviz_display']);
+        $arguments->addOptionalArgument('--graphviz-dump-image=%s', $config['graphviz_dump_image']);
+        $arguments->addOptionalArgument('--graphviz-dump-dot=%s', $config['graphviz_dump_dot']);
+        $arguments->addOptionalArgument('--graphviz-dump-html=%s', $config['graphviz_dump_html']);
         $arguments->addOptionalArgument('%s', $config['depfile']);
 
         $process = $this->processBuilder->buildProcess($arguments);

--- a/src/Task/Deptrac.php
+++ b/src/Task/Deptrac.php
@@ -26,6 +26,7 @@ class Deptrac extends AbstractExternalTask
             'graphviz_dump_image' => null,
             'graphviz_dump_dot' => null,
             'graphviz_dump_html' => null,
+            'junit_dump_xml' => null,
         ]);
 
         $resolver->addAllowedTypes('depfile', ['null', 'string']);
@@ -34,6 +35,7 @@ class Deptrac extends AbstractExternalTask
         $resolver->addAllowedTypes('graphviz_dump_image', ['null', 'string']);
         $resolver->addAllowedTypes('graphviz_dump_dot', ['null', 'string']);
         $resolver->addAllowedTypes('graphviz_dump_html', ['null', 'string']);
+        $resolver->addAllowedTypes('junit_dump_xml', ['null', 'string']);
 
         return $resolver;
     }
@@ -59,6 +61,7 @@ class Deptrac extends AbstractExternalTask
         $arguments->addOptionalArgument('--graphviz-dump-image=%s', $config['graphviz_dump_image']);
         $arguments->addOptionalArgument('--graphviz-dump-dot=%s', $config['graphviz_dump_dot']);
         $arguments->addOptionalArgument('--graphviz-dump-html=%s', $config['graphviz_dump_html']);
+        $arguments->addOptionalArgument('--junit-dump-xml=%s', $config['junit_dump_xml']);
         $arguments->addOptionalArgument('%s', $config['depfile']);
 
         $process = $this->processBuilder->buildProcess($arguments);

--- a/src/Task/Deptrac.php
+++ b/src/Task/Deptrac.php
@@ -28,6 +28,7 @@ class Deptrac extends AbstractExternalTask
             'graphviz_dump_html' => null,
             'junit_dump_xml' => null,
             'xml_dump' => null,
+            'baseline_dump' => null,
         ]);
 
         $resolver->addAllowedTypes('depfile', ['null', 'string']);
@@ -38,6 +39,7 @@ class Deptrac extends AbstractExternalTask
         $resolver->addAllowedTypes('graphviz_dump_html', ['null', 'string']);
         $resolver->addAllowedTypes('junit_dump_xml', ['null', 'string']);
         $resolver->addAllowedTypes('xml_dump', ['null', 'string']);
+        $resolver->addAllowedTypes('baseline_dump', ['null', 'string']);
 
         return $resolver;
     }
@@ -65,6 +67,7 @@ class Deptrac extends AbstractExternalTask
         $arguments->addOptionalArgument('--graphviz-dump-html=%s', $config['graphviz_dump_html']);
         $arguments->addOptionalArgument('--junit-dump-xml=%s', $config['junit_dump_xml']);
         $arguments->addOptionalArgument('--xml-dump=%s', $config['xml_dump']);
+        $arguments->addOptionalArgument('--baseline-dump=%s', $config['baseline_dump']);
         $arguments->addOptionalArgument('%s', $config['depfile']);
 
         $process = $this->processBuilder->buildProcess($arguments);

--- a/src/Task/Deptrac.php
+++ b/src/Task/Deptrac.php
@@ -27,6 +27,7 @@ class Deptrac extends AbstractExternalTask
             'graphviz_dump_dot' => null,
             'graphviz_dump_html' => null,
             'junit_dump_xml' => null,
+            'xml_dump' => null,
         ]);
 
         $resolver->addAllowedTypes('depfile', ['null', 'string']);
@@ -36,6 +37,7 @@ class Deptrac extends AbstractExternalTask
         $resolver->addAllowedTypes('graphviz_dump_dot', ['null', 'string']);
         $resolver->addAllowedTypes('graphviz_dump_html', ['null', 'string']);
         $resolver->addAllowedTypes('junit_dump_xml', ['null', 'string']);
+        $resolver->addAllowedTypes('xml_dump', ['null', 'string']);
 
         return $resolver;
     }
@@ -62,6 +64,7 @@ class Deptrac extends AbstractExternalTask
         $arguments->addOptionalArgument('--graphviz-dump-dot=%s', $config['graphviz_dump_dot']);
         $arguments->addOptionalArgument('--graphviz-dump-html=%s', $config['graphviz_dump_html']);
         $arguments->addOptionalArgument('--junit-dump-xml=%s', $config['junit_dump_xml']);
+        $arguments->addOptionalArgument('--xml-dump=%s', $config['xml_dump']);
         $arguments->addOptionalArgument('%s', $config['depfile']);
 
         $process = $this->processBuilder->buildProcess($arguments);

--- a/test/Unit/Task/DeptracTest.php
+++ b/test/Unit/Task/DeptracTest.php
@@ -26,11 +26,11 @@ class DeptracTest extends AbstractExternalTaskTestCase
             [],
             [
                 'depfile' => null,
-                'formatter_graphviz' => false,
-                'formatter_graphviz_display' => true,
-                'formatter_graphviz_dump_image' => null,
-                'formatter_graphviz_dump_dot' => null,
-                'formatter_graphviz_dump_html' => null,
+                'formatter' => [],
+                'graphviz_display' => true,
+                'graphviz_dump_image' => null,
+                'graphviz_dump_dot' => null,
+                'graphviz_dump_html' => null,
             ]
         ];
     }
@@ -99,71 +99,74 @@ class DeptracTest extends AbstractExternalTaskTestCase
             'deptrac',
             [
                 'analyze',
-                '--formatter-graphviz=0',
-                '--formatter-graphviz-display=1',
+                '--graphviz-display=1',
             ]
         ];
         yield 'formatter-graphviz' => [
             [
-                'formatter_graphviz' => true,
+                'formatter' => ['graphviz'],
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'deptrac',
             [
                 'analyze',
-                '--formatter-graphviz=1',
-                '--formatter-graphviz-display=1',
+                '--formatter=graphviz',
+                '--graphviz-display=1',
             ]
         ];
         yield 'formatter-graphviz-no-display' => [
             [
-                'formatter_graphviz_display' => false,
+                'formatter' => ['graphviz'],
+                'graphviz_display' => false,
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'deptrac',
             [
                 'analyze',
-                '--formatter-graphviz=0',
-                '--formatter-graphviz-display=0',
+                '--formatter=graphviz',
+                '--graphviz-display=0',
             ]
         ];
         yield 'formatter-graphviz-dump-image' => [
             [
-                'formatter_graphviz_dump_image' => 'file.jpg',
+                'formatter' => ['graphviz'],
+                'graphviz_dump_image' => 'file.jpg',
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'deptrac',
             [
                 'analyze',
-                '--formatter-graphviz=0',
-                '--formatter-graphviz-display=1',
-                '--formatter-graphviz-dump-image=file.jpg',
+                '--formatter=graphviz',
+                '--graphviz-display=1',
+                '--graphviz-dump-image=file.jpg',
             ]
         ];
         yield 'formatter-graphviz-dump-dot' => [
             [
-                'formatter_graphviz_dump_dot' => 'file.dot',
+                'formatter' => ['graphviz'],
+                'graphviz_dump_dot' => 'file.dot',
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'deptrac',
             [
                 'analyze',
-                '--formatter-graphviz=0',
-                '--formatter-graphviz-display=1',
-                '--formatter-graphviz-dump-dot=file.dot',
+                '--formatter=graphviz',
+                '--graphviz-display=1',
+                '--graphviz-dump-dot=file.dot',
             ]
         ];
         yield 'formatter-graphviz-dump-html' => [
             [
-                'formatter_graphviz_dump_html' => 'file.html',
+                'formatter' => ['graphviz'],
+                'graphviz_dump_html' => 'file.html',
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'deptrac',
             [
                 'analyze',
-                '--formatter-graphviz=0',
-                '--formatter-graphviz-display=1',
-                '--formatter-graphviz-dump-html=file.html',
+                '--formatter=graphviz',
+                '--graphviz-display=1',
+                '--graphviz-dump-html=file.html',
             ]
         ];
         yield 'depfile' => [
@@ -174,8 +177,7 @@ class DeptracTest extends AbstractExternalTaskTestCase
             'deptrac',
             [
                 'analyze',
-                '--formatter-graphviz=0',
-                '--formatter-graphviz-display=1',
+                '--graphviz-display=1',
                 'depfile',
             ]
         ];

--- a/test/Unit/Task/DeptracTest.php
+++ b/test/Unit/Task/DeptracTest.php
@@ -31,6 +31,7 @@ class DeptracTest extends AbstractExternalTaskTestCase
                 'graphviz_dump_image' => null,
                 'graphviz_dump_dot' => null,
                 'graphviz_dump_html' => null,
+                'junit_dump_xml' => null,
             ]
         ];
     }
@@ -179,6 +180,20 @@ class DeptracTest extends AbstractExternalTaskTestCase
                 'analyze',
                 '--graphviz-display=1',
                 'depfile',
+            ]
+        ];
+        yield 'formatter-junit' => [
+            [
+                'formatter' => ['junit'],
+                'junit_dump_xml' => 'junit.xml',
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'deptrac',
+            [
+                'analyze',
+                '--formatter=junit',
+                '--graphviz-display=1',
+                '--junit-dump-xml=junit.xml',
             ]
         ];
     }

--- a/test/Unit/Task/DeptracTest.php
+++ b/test/Unit/Task/DeptracTest.php
@@ -32,6 +32,7 @@ class DeptracTest extends AbstractExternalTaskTestCase
                 'graphviz_dump_dot' => null,
                 'graphviz_dump_html' => null,
                 'junit_dump_xml' => null,
+                'xml_dump' => null,
             ]
         ];
     }
@@ -194,6 +195,20 @@ class DeptracTest extends AbstractExternalTaskTestCase
                 '--formatter=junit',
                 '--graphviz-display=1',
                 '--junit-dump-xml=junit.xml',
+            ]
+        ];
+        yield 'formatter-xml' => [
+            [
+                'formatter' => ['xml'],
+                'xml_dump' => 'file.xml',
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'deptrac',
+            [
+                'analyze',
+                '--formatter=xml',
+                '--graphviz-display=1',
+                '--xml-dump=file.xml',
             ]
         ];
     }

--- a/test/Unit/Task/DeptracTest.php
+++ b/test/Unit/Task/DeptracTest.php
@@ -33,6 +33,7 @@ class DeptracTest extends AbstractExternalTaskTestCase
                 'graphviz_dump_html' => null,
                 'junit_dump_xml' => null,
                 'xml_dump' => null,
+                'baseline_dump' => null,
             ]
         ];
     }
@@ -209,6 +210,20 @@ class DeptracTest extends AbstractExternalTaskTestCase
                 '--formatter=xml',
                 '--graphviz-display=1',
                 '--xml-dump=file.xml',
+            ]
+        ];
+        yield 'formatter-baseline' => [
+            [
+                'formatter' => ['baseline'],
+                'baseline_dump' => 'baseline.yml',
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'deptrac',
+            [
+                'analyze',
+                '--formatter=baseline',
+                '--graphviz-display=1',
+                '--baseline-dump=baseline.yml',
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Documented?   | yes
| Fixed tickets | none

# Description
Deptrac has updated formatter options in `v0.9.0`. They enabled new formatters (e.g. baseline, table) and refactored existing formatters (e.g. Graphviz). This means that the previous options are not working anymore. New options are introduced for existing formatters.

This PR adds all new formatters with its new options to the `DeptracTask`.

_See commit descriptions for further information._

## Resources
- https://github.com/sensiolabs-de/deptrac#formatters
- https://github.com/sensiolabs-de/deptrac/blob/master/CHANGELOG.md#090---2020-10-30