### PR TITLE
Check config before skipping

### DIFF
--- a/src/Task/PhpStan.php
+++ b/src/Task/PhpStan.php
@@ -78,7 +78,7 @@ class PhpStan extends AbstractExternalTask
             $files = $files->ensureFiles($forcedFiles);
         }
 
-        if (0 === \count($files)) {
+        if (0 === \count($files) && $config['use_grumphp_paths']) {
             return TaskResult::createSkipped($this, $context);
         }
 

--- a/test/Unit/Task/PhpStanTest.php
+++ b/test/Unit/Task/PhpStanTest.php
@@ -108,6 +108,13 @@ class PhpStanTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['test/file.php']),
             function () {}
         ];
+        yield 'no-files-with-use-grumphp-paths' => [
+            [
+                'use_grumphp_paths' => true,
+            ],
+            $this->mockContext(RunContext::class),
+            function () {}
+        ];
     }
 
     public function provideExternalTaskRuns(): iterable
@@ -193,7 +200,7 @@ class PhpStanTest extends AbstractExternalTaskTestCase
             [
                 'use_grumphp_paths' => false,
             ],
-            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            $this->mockContext(RunContext::class, []),
             'phpstan',
             [
                 'analyse',


### PR DESCRIPTION
This adds a check on the 'use_grumphp_paths' config before skipping so this task runs even though there are no changed files when `use_grumphp_paths` is set to false.

| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Documented?   | no
| Fixed tickets | -

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->


<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpunit tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?
