### PR TITLE
Fix git hooks error if the path contains whitespace

### DIFF
--- a/resources/hooks/local/commit-msg
+++ b/resources/hooks/local/commit-msg
@@ -14,7 +14,7 @@ DIFF=$(git -c diff.mnemonicprefix=false -c diff.noprefix=false --no-pager diff -
 
 # Grumphp env vars
 $(ENV)
-export GRUMPHP_GIT_WORKING_DIR=$(git rev-parse --show-toplevel)
+export GRUMPHP_GIT_WORKING_DIR="$(git rev-parse --show-toplevel)"
 
 # Run GrumPHP
 (cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | $(EXEC_GRUMPHP_COMMAND) $(HOOK_COMMAND) "--git-user='$GIT_USER'" "--git-email='$GIT_EMAIL'" "$COMMIT_MSG_FILE")

--- a/resources/hooks/local/pre-commit
+++ b/resources/hooks/local/pre-commit
@@ -10,7 +10,7 @@ DIFF=$(git -c diff.mnemonicprefix=false -c diff.noprefix=false --no-pager diff -
 
 # Grumphp env vars
 $(ENV)
-export GRUMPHP_GIT_WORKING_DIR=$(git rev-parse --show-toplevel)
+export GRUMPHP_GIT_WORKING_DIR="$(git rev-parse --show-toplevel)"
 
 # Run GrumPHP
 (cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | $(EXEC_GRUMPHP_COMMAND) $(HOOK_COMMAND) '--skip-success-output')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #849

Fixes path whitespace issue in git hooks.