### PR TITLE
Fix Paratest 6.1.1 syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/yaml": "~4.4 || ~5.0"
     },
     "require-dev": {
-        "brianium/paratest": "^6.0",
+        "brianium/paratest": "^6.1.1",
         "composer/composer": "^1.10.11 || ^2.0.1",
         "nikic/php-parser": "~4.0",
         "php-parallel-lint/php-parallel-lint": "^1.2",

--- a/src/Task/Paratest.php
+++ b/src/Task/Paratest.php
@@ -79,7 +79,7 @@ class Paratest extends AbstractExternalTask
         $arguments->addOptionalArgument('--coverage-xml=%s', $config['coverage-xml']);
         $arguments->addOptionalArgument('--log-junit=%s', $config['log-junit']);
         $arguments->addOptionalArgument('--testsuite=%s', $config['testsuite']);
-        $arguments->addOptionalArgument('--verbose=1', $config['verbose']);
+        $arguments->addOptionalArgument('--verbose', $config['verbose']);
         $arguments->addOptionalCommaSeparatedArgument('--group=%s', $config['group']);
 
         $process = $this->processBuilder->buildProcess($arguments);

--- a/test/Unit/Task/ParatestTest.php
+++ b/test/Unit/Task/ParatestTest.php
@@ -205,7 +205,7 @@ class ParatestTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'paratest',
             [
-                '--verbose=1',
+                '--verbose',
             ]
         ];
         yield 'group' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #853

This PR fixes the new paratest --verbose flag implementation (in 6.1.1).