### PR TITLE
Catch ExecutableNotFoundException

### DIFF
--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GrumPHP\Task;
 
 use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Exception\ExecutableNotFoundException;
 use GrumPHP\Fixer\Provider\FixableProcessResultProvider;
 use GrumPHP\Formatter\PhpcsFormatter;
 use GrumPHP\Process\TmpFileUsingProcessRunner;
@@ -98,7 +99,7 @@ class Phpcs extends AbstractExternalTask
 
             try {
                 $fixerProcess = $this->createFixerProcess($this->formatter->getSuggestedFiles());
-            } catch (CommandNotFoundException $e) {
+            } catch (CommandNotFoundException|ExecutableNotFoundException $e) {
                 return $failedResult->withAppendedMessage(
                     PHP_EOL.'Info: phpcbf could not be found. Please consider to install it for auto-fixing.'
                 );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
Right now, only `CommandNotFoundException` is caught but `ProcessBuilder::createArgumentsForCommand()` can throw `ExecutableNotFoundException`.

This means that if `phpcbf` is not available, it will fail with only:
> The executable for "phpcfbf" could not be found.

Instead of showing the errors + suggesting to install `phpcbf`.
