### PR TITLE
Only stop on failure for blocking failure results

### DIFF
--- a/src/Runner/Middleware/HandleRunnerMiddleware.php
+++ b/src/Runner/Middleware/HandleRunnerMiddleware.php
@@ -52,7 +52,7 @@ class HandleRunnerMiddleware implements RunnerMiddlewareInterface
                     [$errors, $results] = yield MultiPromise::cancelable(
                         $this->handleTasks($context),
                         function (TaskResultInterface $result) {
-                            return $this->config->stopOnFailure() && $result->hasFailed();
+                            return $this->config->stopOnFailure() && $result->isBlocking();
                         }
                     );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #860

Previous, task execution stopped when receiving non blocking failure results.
In this PR, `stop_on_failure` only stops if the failure result is actually blocking.
