### PR TITLE
Pass $_ENV  variables to amp/parallel callback

### DIFF
--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -90,6 +90,17 @@ A list of the supported variables:
    
    These environment variables can be overwritten by the `environment` settings inside your `grumphp.yml`.
 
+The added environment variables will also be presented to the tasks that GrumPHP executes.
+Note that `symfony/process` only passes string values.
+If you want to use integers, you need do wrap the value in quotes:
+
+```yaml
+grumphp:
+    environment:
+      variables:
+        PHP_CS_FIXER_IGNORE_ENV: "1"
+```
+
 **stop_on_failure**
 
 *Default: false*


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #856


`amp/parallel-functions` is not copying the env variables from the parent into the child process automatically.
This fix enriches the `$_ENV` variables from the child process with the once set from the parent process.

The amp child process will pass the `$_ENV` during task execution to the task process in `symfony/process` (IF the value of the env variable is a string)