### PR TITLE
Test should not fail because it didn't match everything in the whitelist

### DIFF
--- a/doc/tasks/git_branch_name.md
+++ b/doc/tasks/git_branch_name.md
@@ -1,7 +1,7 @@
 # Git branch name
 
 The Git branch name task ensures that the current branch name matches the specified patterns.
-For this task to succeed, **all** whitelist patterns and **none** of the blacklist patterns have to
+For this task to succeed, **any** whitelist patterns and **none** of the blacklist patterns have to
 match the commit message. For example: if you are working with JIRA, it is possible to add a
 pattern for the JIRA issue number.
  

--- a/doc/tasks/git_branch_name.md
+++ b/doc/tasks/git_branch_name.md
@@ -2,7 +2,7 @@
 
 The Git branch name task ensures that the current branch name matches the specified patterns.
 For this task to succeed, **any** whitelist patterns and **none** of the blacklist patterns have to
-match the commit message. For example: if you are working with JIRA, it is possible to add a
+match the branch name. For example: if you are working with JIRA, it is possible to add a
 pattern for the JIRA issue number.
  
 ```yaml

--- a/src/Task/Git/BranchName.php
+++ b/src/Task/Git/BranchName.php
@@ -105,7 +105,7 @@ class BranchName implements TaskInterface
             $additionalModifiersArray = array_filter(str_split($config['additional_modifiers']));
             array_map([$regex, 'addPatternModifier'], $additionalModifiersArray);
             
-            if (preg_match((string) $regex, $name) {
+            if (preg_match((string) $regex, $name)) {
                 if ($isBlacklisted) {
                     continue;   
                 }

--- a/src/Task/Git/BranchName.php
+++ b/src/Task/Git/BranchName.php
@@ -107,6 +107,8 @@ class BranchName implements TaskInterface
             
             if (preg_match((string) $regex, $name)) {
                 if ($isBlacklisted) {
+                    $errors[] = sprintf('Matched whitelist rule: %s (IGNORED due to presence in blacklist)', $rule);
+                    
                     continue;
                 }
                 

--- a/src/Task/Git/BranchName.php
+++ b/src/Task/Git/BranchName.php
@@ -107,7 +107,7 @@ class BranchName implements TaskInterface
             
             if (preg_match((string) $regex, $name)) {
                 if ($isBlacklisted) {
-                    continue;   
+                    continue;
                 }
                 
                 return TaskResult::createPassed($this, $context);

--- a/src/Task/Git/BranchName.php
+++ b/src/Task/Git/BranchName.php
@@ -74,6 +74,7 @@ class BranchName implements TaskInterface
     public function run(ContextInterface $context): TaskResultInterface
     {
         $config = $this->getConfig()->getOptions();
+        $isBlacklisted = false;
         $errors = [];
 
         try {
@@ -95,6 +96,7 @@ class BranchName implements TaskInterface
 
             if (preg_match((string)$regex, $name)) {
                 $errors[] = sprintf('Matched blacklist rule: %s', $rule);
+                $isBlacklisted = true;
             }
         }
         foreach ($config['whitelist'] as $rule) {
@@ -102,10 +104,16 @@ class BranchName implements TaskInterface
 
             $additionalModifiersArray = array_filter(str_split($config['additional_modifiers']));
             array_map([$regex, 'addPatternModifier'], $additionalModifiersArray);
-
-            if (!preg_match((string) $regex, $name)) {
-                $errors[] = sprintf('Whitelist rule not matched: %s', $rule);
+            
+            if (preg_match((string) $regex, $name) {
+                if ($isBlacklisted) {
+                    continue;   
+                }
+                
+                return TaskResult::createPassed($this, $context);
             }
+
+            $errors[] = sprintf('Whitelist rule not matched: %s', $rule);
         }
 
         if (\count($errors)) {

--- a/test/Unit/Task/Git/BranchNameTest.php
+++ b/test/Unit/Task/Git/BranchNameTest.php
@@ -93,6 +93,16 @@ class BranchNameTest extends AbstractTaskTestCase
             },
             'Whitelist rule not matched: develop'
         ];
+        yield 'multi-whitelist' => [	
+            [	
+                'whitelist' => ['master', 'develop'],	
+            ],	
+            $this->mockContext(RunContext::class, ['hello.php']),	
+            function () {	
+                $this->repository->run('symbolic-ref', ['HEAD', '--short'])->willReturn('feature/other');	
+            },	
+            'Whitelist rule not matched: master'.PHP_EOL.'Whitelist rule not matched: develop'	
+        ];
         yield 'mixed' => [
             [
                 'whitelist' => ['JIRA-2'],

--- a/test/Unit/Task/Git/BranchNameTest.php
+++ b/test/Unit/Task/Git/BranchNameTest.php
@@ -93,16 +93,6 @@ class BranchNameTest extends AbstractTaskTestCase
             },
             'Whitelist rule not matched: develop'
         ];
-        yield 'multi-whitelist' => [
-            [
-                'whitelist' => ['master', 'develop'],
-            ],
-            $this->mockContext(RunContext::class, ['hello.php']),
-            function () {
-                $this->repository->run('symbolic-ref', ['HEAD', '--short'])->willReturn('master');
-            },
-            'Whitelist rule not matched: develop'
-        ];
         yield 'mixed' => [
             [
                 'whitelist' => ['JIRA-2'],
@@ -147,7 +137,7 @@ class BranchNameTest extends AbstractTaskTestCase
         ];
         yield 'multi-whitelist' => [
             [
-                'whitelist' => ['JIRA-1', '/JIRA-\d+/'],
+                'whitelist' => ['feature/*', 'JIRA-1', '/JIRA-\d+/'],
             ],
             $this->mockContext(RunContext::class, ['hello.php']),
             function () {

--- a/test/Unit/Task/Git/BranchNameTest.php
+++ b/test/Unit/Task/Git/BranchNameTest.php
@@ -103,6 +103,17 @@ class BranchNameTest extends AbstractTaskTestCase
             },	
             'Whitelist rule not matched: master'.PHP_EOL.'Whitelist rule not matched: develop'	
         ];
+        yield 'blacklist-and-whitelist' => [	
+            [	
+                'blacklist' => ['feature/other'],
+                'whitelist' => ['master', 'feature/*'],	
+            ],	
+            $this->mockContext(RunContext::class, ['hello.php']),	
+            function () {	
+                $this->repository->run('symbolic-ref', ['HEAD', '--short'])->willReturn('feature/other');	
+            },	
+            'Matched blacklist rule: feature/other'.PHP_EOL.'Whitelist rule not matched: master'.PHP_EOL.'Matched whitelist rule: feature/* (IGNORED due to presence in blacklist)'	
+        ];
         yield 'mixed' => [
             [
                 'whitelist' => ['JIRA-2'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #866

`git_branch_name` fails if any of the items in the list fail.

PR changes so that any matching item in the whitelist will return a success unless already featured in the blacklist.