### PR TITLE
Replace SensioLabs Security Checker with CLI tool

### DIFF
--- a/doc/tasks/securitychecker.md
+++ b/doc/tasks/securitychecker.md
@@ -2,11 +2,9 @@
 
 The Security Checker will check your `composer.lock` file for known security vulnerabilities.
 
-***Composer***
+***Binary***
 
-```
-composer require --dev sensiolabs/security-checker
-```
+Download the latest binary from https://github.com/fabpot/local-php-security-checker/releases and make sure it is parth of your PATH or place it in one of the directories defined by environment.paths in your grumphp.yml file.
 
 ***Config***
 
@@ -19,8 +17,6 @@ grumphp:
         securitychecker:
             lockfile: ./composer.lock
             format: ~
-            end_point: ~
-            timeout: ~
             run_always: false
 ```
 
@@ -34,19 +30,7 @@ If your `composer.lock` file is located in an exotic location, you can specify t
 
 *Default: null*
 
-You can choose the format of the output. The available options are `text`, `json` and `simple`. By default, grumphp will use the format `text`.
-
-**end_point**
-
-*Default: null*
-
-You can use a different end point for the security checks. Grumphp will use the default end point which is [https://security.symfony.com/check_lock](https://security.symfony.com/check_lock).
-
-**timeout**
-
-*Default: null*
-
-You can change the timeout value for the command. By default this value is `20`.
+You can choose the format of the output. The available options are `ansi`, `json`, `markdown` and `yaml`. By default, grumphp will use the format `ansi`.
 
 **run_always**
 

--- a/src/Task/SecurityChecker.php
+++ b/src/Task/SecurityChecker.php
@@ -19,15 +19,11 @@ class SecurityChecker extends AbstractExternalTask
         $resolver->setDefaults([
             'lockfile' => './composer.lock',
             'format' => null,
-            'end_point' => null,
-            'timeout' => null,
             'run_always' => false,
         ]);
 
         $resolver->addAllowedTypes('lockfile', ['string']);
         $resolver->addAllowedTypes('format', ['null', 'string']);
-        $resolver->addAllowedTypes('end_point', ['null', 'string']);
-        $resolver->addAllowedTypes('timeout', ['null', 'int']);
         $resolver->addAllowedTypes('run_always', ['bool']);
 
         return $resolver;
@@ -49,12 +45,9 @@ class SecurityChecker extends AbstractExternalTask
             return TaskResult::createSkipped($this, $context);
         }
 
-        $arguments = $this->processBuilder->createArgumentsForCommand('security-checker');
-        $arguments->add('security:check');
-        $arguments->addOptionalArgument('%s', $config['lockfile']);
+        $arguments = $this->processBuilder->createArgumentsForCommand('local-php-security-checker');
+        $arguments->addOptionalArgument('--path=%s', $config['lockfile']);
         $arguments->addOptionalArgument('--format=%s', $config['format']);
-        $arguments->addOptionalArgument('--end-point=%s', $config['end_point']);
-        $arguments->addOptionalArgument('--timeout=%s', $config['timeout']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();

--- a/test/Unit/Task/SecurityCheckerTest.php
+++ b/test/Unit/Task/SecurityCheckerTest.php
@@ -27,8 +27,6 @@ class SecurityCheckerTest extends AbstractExternalTaskTestCase
             [
                 'lockfile' => './composer.lock',
                 'format' => null,
-                'end_point' => null,
-                'timeout' => null,
                 'run_always' => false,
             ]
         ];
@@ -58,7 +56,7 @@ class SecurityCheckerTest extends AbstractExternalTaskTestCase
             [],
             $this->mockContext(RunContext::class, ['composer.lock']),
             function () {
-                $this->mockProcessBuilder('security-checker', $process = $this->mockProcess(1));
+                $this->mockProcessBuilder('local-php-security-checker', $process = $this->mockProcess(1));
                 $this->formatter->format($process)->willReturn('nope');
             },
             'nope'
@@ -71,7 +69,7 @@ class SecurityCheckerTest extends AbstractExternalTaskTestCase
             [],
             $this->mockContext(RunContext::class, ['composer.lock']),
             function () {
-                $this->mockProcessBuilder('security-checker', $this->mockProcess(0));
+                $this->mockProcessBuilder('local-php-security-checker', $this->mockProcess(0));
             }
         ];
         yield 'exitCode0WhenRunAlways' => [
@@ -80,7 +78,7 @@ class SecurityCheckerTest extends AbstractExternalTaskTestCase
             ],
             $this->mockContext(RunContext::class, ['notrelated.php']),
             function () {
-                $this->mockProcessBuilder('security-checker', $this->mockProcess(0));
+                $this->mockProcessBuilder('local-php-security-checker', $this->mockProcess(0));
             }
         ];
     }
@@ -104,36 +102,21 @@ class SecurityCheckerTest extends AbstractExternalTaskTestCase
         yield 'defaults' => [
             [],
             $this->mockContext(RunContext::class, ['composer.lock']),
-            'security-checker',
+            'local-php-security-checker',
             [
-                'security:check',
-                './composer.lock',
+                '--path=./composer.lock',
             ]
         ];
 
-        yield 'endpoint' => [
+        yield 'format' => [
             [
-                'end_point' => $endpoint = 'http://myserver.com',
+                'format' => 'json',
             ],
             $this->mockContext(RunContext::class, ['composer.lock']),
-            'security-checker',
+            'local-php-security-checker',
             [
-                'security:check',
-                './composer.lock',
-                '--end-point='.$endpoint
-            ]
-        ];
-
-        yield 'timeout' => [
-            [
-                'timeout' => 2,
-            ],
-            $this->mockContext(RunContext::class, ['composer.lock']),
-            'security-checker',
-            [
-                'security:check',
-                './composer.lock',
-                '--timeout=2'
+                '--path=./composer.lock',
+                '--format=json'
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  |no
| BC breaks?    | yes
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | https://github.com/phpro/grumphp/issues/865

This PR replaces sensiolabs/security-checker (which will be abandoned at the end of January) and replaces it by fabpot/local-php-security-checker (as recommended by sensiolabs/security-checker in their readme).
