### PR TITLE
Fix psalm errors

### DIFF
--- a/src/Configuration/Compiler/TaskCompilerPass.php
+++ b/src/Configuration/Compiler/TaskCompilerPass.php
@@ -30,7 +30,8 @@ class TaskCompilerPass implements CompilerPassInterface
     {
         $tasksCollection = $container->findDefinition(TasksCollection::class);
         $availableTasks = $this->fetchAvailableTasksInfo($container);
-        $configuredTasks = $container->getParameter('tasks') ?: [];
+        $configuredTasks = $container->getParameter('tasks');
+        $configuredTasks = is_array($configuredTasks) ? $configuredTasks : [];
         $taskConfigResolver = $this->buildTaskConfigResolver($availableTasks);
 
         // Configure tasks

--- a/src/Configuration/Compiler/TestSuiteCompilerPass.php
+++ b/src/Configuration/Compiler/TestSuiteCompilerPass.php
@@ -16,7 +16,9 @@ class TestSuiteCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         $testSuites = $container->getParameter('testsuites');
-        $registeredTasks = (array) $container->getParameter('grumphp.tasks.configured');
+        $testSuites = is_array($testSuites) ? $testSuites : [];
+        $registeredTasks = $container->getParameter('grumphp.tasks.configured');
+        $registeredTasks = is_array($registeredTasks) ? $registeredTasks : [];
         $optionsResolver = $this->createOptionsResolver($registeredTasks);
 
         $collection = new TestSuiteCollection();


### PR DESCRIPTION
Fixes #869

Fix current psalm errors on master:

```
psalm
=====

ERROR: PossiblyInvalidIterator - src/Configuration/Compiler/TaskCompilerPass.php:37:18 - Cannot iterate over scalar (see https://psalm.dev/165)
        foreach ($configuredTasks as $taskName => $config) {


ERROR: PossiblyInvalidArgument - src/Configuration/Compiler/TaskCompilerPass.php:79:73 - Argument 1 of array_keys expects array<array-key, mixed>, possibly different type array<array-key, mixed>|non-empty-scalar provided (see https://psalm.dev/092)
        $container->setParameter('grumphp.tasks.configured', array_keys($configuredTasks));


ERROR: PossiblyNullIterator - src/Configuration/Compiler/TestSuiteCompilerPass.php:23:18 - Cannot iterate over nullable var array<array-key, mixed>|null|scalar (see https://psalm.dev/097)
        foreach ($testSuites as $name => $config) {


INFO: RedundantConditionGivenDocblockType - src/Fixer/Provider/FixableProcessResultProvider.php:22:9 - Found a redundant condition when evaluating docblock-defined type $fixerProcess and trying to reconcile type 'Symfony\Component\Process\Process' to Symfony\Component\Process\Process (see https://psalm.dev/156)
        assert($fixerProcess instanceof Process);
```