### PR TITLE
#876 Update twigcs.md

### DIFF
--- a/doc/tasks/twigcs.md
+++ b/doc/tasks/twigcs.md
@@ -29,7 +29,7 @@ grumphp:
 *Default: null*
 
 By default `.` (current folder) will be used.
-You can specify an alternate location by changing this option.
+You can specify an alternate location by changing this option. If the path doesn't exist or is not accessible an exception will be thrown.
 
 **severity**
 


### PR DESCRIPTION
Fixes #876

Add to the documentation that the path should exist or be accessible.

In FriendsOfTwig\Twigcs\Config\ConfigResolver:
```
                        if (!file_exists($absolutePath)) {
                            throw new InvalidConfigurationException(sprintf('The path "%s" is not readable.', $path));
                        }
```