### PR TITLE
Fix parameter typo in example

### DIFF
--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -14,7 +14,7 @@ grumphp:
     ignore_unstaged_changes: false
     hide_circumvention_tip: false
     process_timeout: 60
-    additonal_info: ~
+    additional_info: ~
     ascii:
         failed: resource/grumphp-grumpy.txt
         succeeded: resource/grumphp-happy.txt


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

The "additional_info" parameter from "parameters.md" was misspelled.

<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [ ] Are the dependencies added to the composer.json suggestions?
- [ ] Is the doc/tasks.md file updated?
- [ ] Are the task parameters documented?
- [ ] Is the task registered in the tasks.yml file?
- [ ] Does the task contains phpunit tests?
- [ ] Is the configuration having logical allowed types?
- [ ] Does the task run in the correct context?
- [ ] Is the `run()` method readable?
- [ ] Is the `run()` method using the configuration correctly?
- [ ] Are all CI services returning green?
