### PR TITLE
Add support for display option to TwigCS task

### DIFF
--- a/doc/tasks/twigcs.md
+++ b/doc/tasks/twigcs.md
@@ -19,6 +19,7 @@ grumphp:
         twigcs:
             path: '.'
             severity: 'warning'
+            display: 'all'
             ruleset: 'FriendsOfTwig\Twigcs\Ruleset\Official'
             triggered_by: ['twig']
             exclude: []
@@ -36,6 +37,12 @@ You can specify an alternate location by changing this option. If the path doesn
 *Default: 'warning'*
 
 Severity level of sniffing (possibles values are : 'IGNORE', 'INFO', 'WARNING', 'ERROR').
+
+**display**
+
+*Default: 'all'*
+
+The violations to display (possibles values are : 'all', 'blocking').
 
 **ruleset**
 

--- a/src/Task/TwigCs.php
+++ b/src/Task/TwigCs.php
@@ -19,6 +19,7 @@ class TwigCs extends AbstractExternalTask
         $resolver->setDefaults([
             'path' => '.',
             'severity' => 'warning',
+            'display' => 'all',
             'ruleset' => 'FriendsOfTwig\Twigcs\Ruleset\Official',
             'triggered_by' => ['twig'],
             'exclude' => [],
@@ -27,6 +28,7 @@ class TwigCs extends AbstractExternalTask
         $resolver->addAllowedTypes('path', ['string']);
         $resolver->addAllowedTypes('exclude', ['array']);
         $resolver->addAllowedTypes('severity', ['string']);
+        $resolver->addAllowedTypes('display', ['string']);
         $resolver->addAllowedTypes('ruleset', ['string']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
@@ -51,6 +53,7 @@ class TwigCs extends AbstractExternalTask
         $arguments->add($config['path']);
 
         $arguments->addOptionalArgument('--severity=%s', $config['severity']);
+        $arguments->addOptionalArgument('--display=%s', $config['display']);
         $arguments->addOptionalArgument('--ruleset=%s', $config['ruleset']);
         $arguments->addOptionalArgument('--ansi', true);
 

--- a/test/Unit/Task/TwigCsTest.php
+++ b/test/Unit/Task/TwigCsTest.php
@@ -121,6 +121,21 @@ class TwigCsTest extends AbstractExternalTaskTestCase
             ]
         ];
 
+        yield 'severity' => [
+            [
+                'severity' => 'error',
+            ],
+            $this->mockContext(RunContext::class, ['hello.twig', 'hello2.twig']),
+            'twigcs',
+            [
+                '.',
+                '--severity=error',
+                '--display=all',
+                '--ruleset=FriendsOfTwig\Twigcs\Ruleset\Official',
+                '--ansi',
+            ]
+        ];
+
         yield 'display' => [
             [
                 'display' => 'blocking',

--- a/test/Unit/Task/TwigCsTest.php
+++ b/test/Unit/Task/TwigCsTest.php
@@ -27,6 +27,7 @@ class TwigCsTest extends AbstractExternalTaskTestCase
             [
                 'path' => '.',
                 'severity' => 'warning',
+                'display' => 'all',
                 'ruleset' => 'FriendsOfTwig\Twigcs\Ruleset\Official',
                 'triggered_by' => ['twig'],
                 'exclude' => [],
@@ -99,6 +100,7 @@ class TwigCsTest extends AbstractExternalTaskTestCase
             [
                 '.',
                 '--severity=warning',
+                '--display=all',
                 '--ruleset=FriendsOfTwig\Twigcs\Ruleset\Official',
                 '--ansi',
             ]
@@ -113,6 +115,22 @@ class TwigCsTest extends AbstractExternalTaskTestCase
             [
                 'src',
                 '--severity=warning',
+                '--display=all',
+                '--ruleset=FriendsOfTwig\Twigcs\Ruleset\Official',
+                '--ansi',
+            ]
+        ];
+
+        yield 'display' => [
+            [
+                'display' => 'blocking',
+            ],
+            $this->mockContext(RunContext::class, ['hello.twig', 'hello2.twig']),
+            'twigcs',
+            [
+                '.',
+                '--severity=warning',
+                '--display=blocking',
                 '--ruleset=FriendsOfTwig\Twigcs\Ruleset\Official',
                 '--ansi',
             ]
@@ -127,6 +145,7 @@ class TwigCsTest extends AbstractExternalTaskTestCase
             [
                 '.',
                 '--severity=warning',
+                '--display=all',
                 '--ruleset=FriendsOfTwig\Twigcs\Ruleset\Official',
                 '--ansi',
                 '--exclude=src/',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

TwigCS supports a `display` option in order to [restrict output](https://github.com/friendsoftwig/twigcs#restricting-output) to only the ones that blocks the success of the command, this PR add the support for it.

An extra commit adds a test for the existing `severity` option that was missing.