### PR TITLE
Improve commit-msg escaping

### DIFF
--- a/resources/hooks/local/commit-msg
+++ b/resources/hooks/local/commit-msg
@@ -5,8 +5,8 @@
 # Note: this will be replaced by the real command during copy.
 #
 
-GIT_USER=$(git config user.name)
-GIT_EMAIL=$(git config user.email)
+GIT_USER="$(git config user.name)"
+GIT_EMAIL="$(git config user.email)"
 COMMIT_MSG_FILE=$1
 
 # Fetch the GIT diff and format it as command input:
@@ -17,4 +17,4 @@ $(ENV)
 export GRUMPHP_GIT_WORKING_DIR="$(git rev-parse --show-toplevel)"
 
 # Run GrumPHP
-(cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | $(EXEC_GRUMPHP_COMMAND) $(HOOK_COMMAND) "--git-user='$GIT_USER'" "--git-email='$GIT_EMAIL'" "$COMMIT_MSG_FILE")
+(cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | $(EXEC_GRUMPHP_COMMAND) $(HOOK_COMMAND) --git-user="$GIT_USER" --git-email="$GIT_EMAIL" "$COMMIT_MSG_FILE")


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes/
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #883


Improves the argument escaping in the default `commit-msg` hook.
