### PR TITLE
Add Stylelint task

### DIFF
--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -57,6 +57,7 @@ grumphp:
         securitychecker_local: ~
         securitychecker_symfony: ~
         shell: ~
+        stylelint: ~
         tester: ~
         twigcs: ~
         xmllint: ~
@@ -118,6 +119,7 @@ Every task has it's own default configuration. It is possible to overwrite the p
   - [Local](tasks/securitychecker/local.md)
   - [Symfony](tasks/securitychecker/symfony.md)
 - [Shell](tasks/shell.md)
+- [Stylelint](tasks/stylelint.md)
 - [Tester](tasks/tester.md)
 - [TwigCs](tasks/twigcs.md)
 - [XmlLint](tasks/xmllint.md)

--- a/doc/tasks/stylelint.md
+++ b/doc/tasks/stylelint.md
@@ -1,0 +1,195 @@
+# Stylelint ![fixer](https://img.shields.io/badge/-fixer-informational)
+
+[Stylelint](https://stylelint.io/) is a modern linter that helps you avoid errors and enforce conventions in your styles.
+
+## NPM
+If you'd like to install it globally:
+```bash
+npm -g stylelint
+```
+
+If you'd like install it as a dev dependency of your project:
+```bash
+npm install --save-dev stylelint
+```
+
+Done. See the Stylelint [Getting Started](https://stylelint.io/user-guide/get-started) guide for more info.
+
+## Config
+It lives under the `stylelint` namespace and has the following configurable parameters:
+
+```yaml
+# grumphp.yml
+grumphp:
+    tasks:
+        stylelint:
+            bin: node_modules/.bin/stylelint
+            triggered_by: [css, scss, sass, less, sss]
+            whitelist_patterns:
+                - /^resources\/css\/(.*)/
+            config: ~
+            config_basedir: ~
+            ignore_path: ~
+            ignore_pattern: ~
+            syntax: ~
+            custom_syntax: ~
+            ignore_disables: ~
+            disable_default_ignores: ~
+            cache: ~
+            cache_location: ~
+            formatter: ~
+            custom_formatter: ~
+            quiet: ~
+            color: ~
+            report_needless_disables: ~
+            report_invalid_scope_disables: ~
+            report_descriptionless_disables: ~
+            max_warnings: ~
+            output_file: ~
+```
+
+**bin**
+
+*Default: null*
+
+The path to your stylelint bin executable. Not necessary if stylelint is in your $PATH. Can be used to specify path to project's stylelint over globally installed stylelint.
+
+> **Note:** It is possible to add `node_modules/.bin` to the grumphp paths in order for it to be automatically discovered as well:
+> 
+> ```yaml
+> grumphp:
+>     environment:
+>         paths:
+>             - node_modules/.bin
+> ```
+
+**triggered_by**
+
+*Default: [css, scss, sass, less, sss]*
+
+This is a list of extensions which will trigger the Sylelint task.
+
+
+**whitelist_patterns**
+
+*Default: []*
+
+This is a list of regex patterns that will filter files to validate. With this option you can specify the folders containing javascript files and thus skip folders like /tests/ or the /vendor/ directory. This option is used in conjunction with the parameter `triggered_by`.
+For example: to whitelist files in `resources/css/` (Laravel's CSS directory) and `assets/css/` (Symfony's CSS directory) you can use:
+```yml
+whitelist_patterns:
+  - /^resources\/css\/(.*)/
+  - /^assets\/css\/(.*)/
+```
+
+**config**
+
+*Default: null*
+
+Path to a JSON, YAML, or JS file that contains your configuration object. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--config)).
+
+**config_basedir**
+
+*Default: null*
+
+Absolute path to the directory that relative paths defining "extends" and "plugins" are _relative_ to. Only necessary if these values are relative paths. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--config-basedir)).
+
+**ignore_path**
+
+*Default: null*
+
+A path to a file containing patterns describing files to ignore. The path can be absolute or relative to `process.cwd()`. By default, stylelint looks for `.stylelintignore` in `process.cwd()`. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--ignore-path--i)).
+
+**ignore_pattern**
+
+*Default: null*
+
+Pattern of files to ignore (in addition to those in `.stylelintignore`). ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--ignore-pattern---ip)).
+
+**syntax**
+
+*Default: null*
+
+Specify a syntax. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--syntax--s)).
+
+**custom_syntax**
+
+*Default: null*
+
+Specify a custom syntax to use on your code. Use this option if you want to force a specific syntax that's not already built into stylelint. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--custom-syntax)).
+
+**ignore_disables**
+
+*Default: null*
+
+Ignore `styleline-disable` (e.g. `/* stylelint-disable block-no-empty */`) comments. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--ignore-disables---id)).
+
+**disable_default_ignores**
+
+*Default: null*
+
+Disable the default ignores. stylelint will not automatically ignore the contents of `node_modules`. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--disable-default-ignores---di)).
+
+**cache**
+
+*Default: null*
+
+Store the results of processed files so that stylelint only operates on the changed ones. By default, the cache is stored in `./.stylelintcache` in `process.cwd()`. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--cache)).
+
+**cache_location**
+
+*Default: null*
+
+Path to a file or directory for the cache location. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--cache-location)).
+
+**formatter** / **custom_formatter**
+
+*Default: null*
+
+Specify the formatter to format your results. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--formatter--f----custom-formatter)).
+
+**quiet**
+
+*Default: null*
+
+Only register violations for rules with an "error"-level severity (ignore "warning"-level). ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--quiet--q)).
+
+**color**
+
+*Default: null*
+
+Force enabling/disabling of color. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--color---no-color)).
+
+**report_needless_disables**
+
+*Default: null*
+
+Produce a report to clean up your codebase, keeping only the `stylelint-disable` comments that serve a purpose. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--report-needless-disables---rd)).
+
+**report_invalid_scope_disables**
+
+*Default: null*
+
+Produce a report of the `stylelint-disable` comments that used for rules that don't exist within the configuration object. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--report-invalid-scope-disables---risd)).
+
+**report_descriptionless_disables**
+
+*Default: null*
+
+Produce a report of the `stylelint-disable` comments without a description ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--report-descriptionless-disables---rdd)).
+
+**max_warnings**
+
+*Default: null*
+
+Set a limit to the number of warnings accepted. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--max-warnings---mw)).
+
+**output_file**
+
+*Default: null*
+
+Path of file to write a report. stylelint outputs the report to the specified `filename` in addition to the standard output. ([stylelint.io](https://stylelint.io/user-guide/usage/cli#--output-file--o)).
+
+**other settings**
+
+Any other stylelint settings should be able to be set through a [stylelint config file](https://stylelint.io/user-guide/configure).

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -350,6 +350,13 @@ services:
         tags:
             - {name: grumphp.task, task: shell}
 
+    GrumPHP\Task\Stylelint:
+        arguments:
+            - '@process_builder'
+            - '@formatter.raw_process'
+        tags:
+            - {name: grumphp.task, task: stylelint}
+
     GrumPHP\Task\Tester:
         class:
         arguments:

--- a/src/Task/Stylelint.php
+++ b/src/Task/Stylelint.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Task;
+
+use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Fixer\Provider\FixableProcessResultProvider;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Process\Process;
+
+class Stylelint extends AbstractExternalTask
+{
+    public static function getConfigurableOptions(): OptionsResolver
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            // Task config options
+            'bin' => null,
+            'triggered_by' => ['css', 'scss', 'sass', 'less', 'sss'],
+            'whitelist_patterns' => [],
+
+            // Stylelint native config options
+            'config' => null,
+            'config_basedir' => null,
+            'ignore_path' => null,
+            'ignore_pattern' => null,
+            'syntax' => null,
+            'custom_syntax' => null,
+            'ignore_disables' => null,
+            'disable_default_ignores' => null,
+            'cache' => null,
+            'cache_location' => null,
+            'formatter' => null,
+            'custom_formatter' => null,
+            'quiet' => null,
+            'color' => null,
+            'report_needless_disables' => null,
+            'report_invalid_scope_disables' => null,
+            'report_descriptionless_disables' => null,
+            'max_warnings' => null,
+            'output_file' => null,
+        ]);
+
+        // Task config options
+        $resolver->addAllowedTypes('bin', ['null', 'string']);
+        $resolver->addAllowedTypes('triggered_by', ['array']);
+        $resolver->addAllowedTypes('whitelist_patterns', ['array']);
+
+        // Stylelint native config options
+        $resolver->addAllowedTypes('config', ['null', 'string']);
+        $resolver->addAllowedTypes('config_basedir', ['null', 'string']);
+        $resolver->addAllowedTypes('ignore_path', ['null', 'string']);
+        $resolver->addAllowedTypes('ignore_pattern', ['null', 'string']);
+        $resolver->addAllowedTypes('syntax', ['null', 'string']);
+        $resolver->addAllowedTypes('custom_syntax', ['null', 'string']);
+        $resolver->addAllowedTypes('ignore_disables', ['null', 'bool']);
+        $resolver->addAllowedTypes('disable_default_ignores', ['null', 'bool']);
+        $resolver->addAllowedTypes('cache', ['null', 'bool']);
+        $resolver->addAllowedTypes('cache_location', ['null', 'string']);
+        $resolver->addAllowedTypes('formatter', ['null', 'string']);
+        $resolver->addAllowedTypes('custom_formatter', ['null', 'string']);
+        $resolver->addAllowedTypes('quiet', ['null', 'bool']);
+        $resolver->addAllowedTypes('color', ['null', 'bool']);
+        $resolver->addAllowedTypes('report_needless_disables', ['null', 'bool']);
+        $resolver->addAllowedTypes('report_invalid_scope_disables', ['null', 'bool']);
+        $resolver->addAllowedTypes('report_descriptionless_disables', ['null', 'bool']);
+        $resolver->addAllowedTypes('max_warnings', ['null', 'integer']);
+        $resolver->addAllowedTypes('output_file', ['null', 'string']);
+
+        return $resolver;
+    }
+
+    public function canRunInContext(ContextInterface $context): bool
+    {
+        return ($context instanceof GitPreCommitContext || $context instanceof RunContext);
+    }
+
+    public function run(ContextInterface $context): TaskResultInterface
+    {
+        $config = $this->getConfig()->getOptions();
+
+        $files = $context
+            ->getFiles()
+            ->paths($config['whitelist_patterns'])
+            ->extensions($config['triggered_by']);
+
+        if (0 === \count($files)) {
+            return TaskResult::createSkipped($this, $context);
+        }
+
+        $arguments = isset($config['bin'])
+            ? ProcessArgumentsCollection::forExecutable($config['bin'])
+            : $this->processBuilder->createArgumentsForCommand('stylelint');
+
+        $arguments->addOptionalArgument('--config=%s', $config['config']);
+        $arguments->addOptionalArgument('--config-basedir=%s', $config['config_basedir']);
+        $arguments->addOptionalArgument('--ignore-path=%s', $config['ignore_path']);
+        $arguments->addOptionalArgument('--ignore-pattern=%s', $config['ignore_pattern']);
+        $arguments->addOptionalArgument('--syntax=%s', $config['syntax']);
+        $arguments->addOptionalArgument('--custom-syntax=%s', $config['custom_syntax']);
+        $arguments->addOptionalArgument('--ignore-disables', $config['ignore_disables']);
+        $arguments->addOptionalArgument('--disable-default-ignores', $config['disable_default_ignores']);
+        $arguments->addOptionalArgument('--cache', $config['cache']);
+        $arguments->addOptionalArgument('--cache-location=%s', $config['cache_location']);
+        $arguments->addOptionalArgument('--formatter=%s', $config['formatter']);
+        $arguments->addOptionalArgument('--custom-formatter=%s', $config['custom_formatter']);
+        $arguments->addOptionalArgument('--quiet', $config['quiet']);
+        $arguments->addOptionalBooleanArgument('--%s', $config['color'], 'color', 'no-color');
+        $arguments->addOptionalArgument('--report-needless-disables', $config['report_needless_disables']);
+        $arguments->addOptionalArgument('--report-invalid-scope-disables', $config['report_invalid_scope_disables']);
+        $arguments->addOptionalArgument(
+            '--report-descriptionless-disables',
+            $config['report_descriptionless_disables']
+        );
+        $arguments->addOptionalIntegerArgument('--max-warnings=%d', $config['max_warnings']);
+        $arguments->addOptionalArgument('--output-file=%s', $config['output_file']);
+        $arguments->addFiles($files);
+
+        $process = $this->processBuilder->buildProcess($arguments);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            return FixableProcessResultProvider::provide(
+                TaskResult::createFailed($this, $context, $this->formatter->format($process)),
+                function () use ($arguments): Process {
+                    $arguments->add('--fix');
+                    return $this->processBuilder->buildProcess($arguments);
+                }
+            );
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}

--- a/src/Task/Stylelint.php
+++ b/src/Task/Stylelint.php
@@ -120,7 +120,10 @@ class Stylelint extends AbstractExternalTask
         );
         $arguments->addOptionalIntegerArgument('--max-warnings=%d', $config['max_warnings']);
         $arguments->addOptionalArgument('--output-file=%s', $config['output_file']);
-        $arguments->addFiles($files);
+
+        if ($context instanceof GitPreCommitContext) {
+            $arguments->addFiles($files);
+        }
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();

--- a/test/Unit/Task/ESLintTest.php
+++ b/test/Unit/Task/ESLintTest.php
@@ -188,7 +188,7 @@ class ESLintTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.js', 'hello2.js']),
             'eslint',
             [
-             '--max-warnings=10',
+                '--max-warnings=10',
                 'hello.js',
                 'hello2.js',
             ]

--- a/test/Unit/Task/StylelintTest.php
+++ b/test/Unit/Task/StylelintTest.php
@@ -1,0 +1,378 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Test\Unit\Task;
+
+use GrumPHP\Runner\FixableTaskResult;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\Stylelint;
+use GrumPHP\Task\TaskInterface;
+use GrumPHP\Test\Task\AbstractExternalTaskTestCase;
+
+class StylelintTest extends AbstractExternalTaskTestCase
+{
+    protected function provideTask(): TaskInterface
+    {
+        return new Stylelint(
+            $this->processBuilder->reveal(),
+            $this->formatter->reveal()
+        );
+    }
+
+    public function provideConfigurableOptions(): iterable
+    {
+        yield 'defaults' => [
+            [],
+            [
+                // Task config options
+                'bin' => null,
+                'triggered_by' => ['css', 'scss', 'sass', 'less', 'sss'],
+                'whitelist_patterns' => [],
+
+                // Stylelint native config options
+                'config' => null,
+                'config_basedir' => null,
+                'ignore_path' => null,
+                'ignore_pattern' => null,
+                'syntax' => null,
+                'custom_syntax' => null,
+                'ignore_disables' => null,
+                'disable_default_ignores' => null,
+                'cache' => null,
+                'cache_location' => null,
+                'formatter' => null,
+                'custom_formatter' => null,
+                'quiet' => null,
+                'color' => null,
+                'report_needless_disables' => null,
+                'report_invalid_scope_disables' => null,
+                'report_descriptionless_disables' => null,
+                'max_warnings' => null,
+                'output_file' => null,
+            ]
+        ];
+    }
+
+    public function provideRunContexts(): iterable
+    {
+        yield 'run-context' => [
+            true,
+            $this->mockContext(RunContext::class)
+        ];
+
+        yield 'pre-commit-context' => [
+            true,
+            $this->mockContext(GitPreCommitContext::class)
+        ];
+
+        yield 'other' => [
+            false,
+            $this->mockContext()
+        ];
+    }
+
+    public function provideFailsOnStuff(): iterable
+    {
+        yield 'exitCode1' => [
+            [],
+            $this->mockContext(RunContext::class, ['hello.css']),
+            function () {
+                $this->mockProcessBuilder('stylelint', $process = $this->mockProcess(1));
+
+                $this->formatter->format($process)->willReturn($message = 'message');
+            },
+            'message',
+            FixableTaskResult::class
+        ];
+    }
+
+    public function providePassesOnStuff(): iterable
+    {
+        yield 'exitCode0' => [
+            [],
+            $this->mockContext(RunContext::class, ['hello.css']),
+            function () {
+                $this->mockProcessBuilder('stylelint', $this->mockProcess(0));
+            }
+        ];
+    }
+
+    public function provideSkipsOnStuff(): iterable
+    {
+        yield 'no-files' => [
+            [],
+            $this->mockContext(RunContext::class),
+            function () {}
+        ];
+        yield 'no-files-after-triggered-by' => [
+            [],
+            $this->mockContext(RunContext::class, ['notajsfile.txt']),
+            function () {}
+        ];
+        yield 'no-files-after-whitelist-patterns' => [
+            [
+                'whitelist_patterns' => ['/^resources\/css\/(.*)/'],
+            ],
+            $this->mockContext(RunContext::class, ['resources/dont/find/this/file.css']),
+            function () {}
+        ];
+    }
+
+    public function provideExternalTaskRuns(): iterable
+    {
+        yield 'bin' => [
+            [
+                'bin' => 'node_modules/.bin/stylelint',
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                'node_modules/.bin/stylelint',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'config' => [
+            [
+                'config' => '.stylelintrc.json',
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--config=.stylelintrc.json',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'config_basedir' => [
+            [
+                'config_basedir' => 'path/to/base/dir',
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--config-basedir=path/to/base/dir',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'ignore_path' => [
+            [
+                'ignore_path' => 'path/to/.ignorefile',
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--ignore-path=path/to/.ignorefile',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'ignore_pattern' => [
+            [
+                'ignore_pattern' => 'pattern',
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--ignore-pattern=pattern',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'syntax' => [
+            [
+                'syntax' => 'css',
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--syntax=css',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'custom_syntax' => [
+            [
+                'custom_syntax' => 'mysyntax',
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--custom-syntax=mysyntax',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'ignore_disables' => [
+            [
+                'ignore_disables' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--ignore-disables',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'disable_default_ignores' => [
+            [
+                'disable_default_ignores' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--disable-default-ignores',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'cache' => [
+            [
+                'cache' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--cache',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'cache_location' => [
+            [
+                'cache_location' => 'path/to/cache',
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--cache-location=path/to/cache',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'formatter' => [
+            [
+                'formatter' => 'string',
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--formatter=string',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'custom_formatter' => [
+            [
+                'custom_formatter' => 'myformatter',
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--custom-formatter=myformatter',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'quiet' => [
+            [
+                'quiet' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--quiet',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'color' => [
+            [
+                'color' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--color',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'no_color' => [
+            [
+                'color' => false,
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--no-color',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'report_needless_disables' => [
+            [
+                'report_needless_disables' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--report-needless-disables',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'report_invalid_scope_disables' => [
+            [
+                'report_invalid_scope_disables' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--report-invalid-scope-disables',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'report_descriptionless_disables' => [
+            [
+                'report_descriptionless_disables' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--report-descriptionless-disables',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'max_warnings' => [
+            [
+                'max_warnings' => 10,
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--max-warnings=10',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+        yield 'output_file' => [
+            [
+                'output_file' => 'path/to/outputfile',
+            ],
+            $this->mockContext(RunContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                '--output-file=path/to/outputfile',
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
+    }
+}

--- a/test/Unit/Task/StylelintTest.php
+++ b/test/Unit/Task/StylelintTest.php
@@ -122,6 +122,15 @@ class StylelintTest extends AbstractExternalTaskTestCase
 
     public function provideExternalTaskRuns(): iterable
     {
+        yield 'precommit' => [
+            [],
+            $this->mockContext(GitPreCommitContext::class, ['hello.css', 'hello2.css']),
+            'stylelint',
+            [
+                'hello.css',
+                'hello2.css',
+            ]
+        ];
         yield 'bin' => [
             [
                 'bin' => 'node_modules/.bin/stylelint',
@@ -130,8 +139,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 'node_modules/.bin/stylelint',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'config' => [
@@ -142,8 +149,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--config=.stylelintrc.json',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'config_basedir' => [
@@ -154,8 +159,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--config-basedir=path/to/base/dir',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'ignore_path' => [
@@ -166,8 +169,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--ignore-path=path/to/.ignorefile',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'ignore_pattern' => [
@@ -178,8 +179,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--ignore-pattern=pattern',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'syntax' => [
@@ -190,8 +189,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--syntax=css',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'custom_syntax' => [
@@ -202,8 +199,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--custom-syntax=mysyntax',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'ignore_disables' => [
@@ -214,8 +209,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--ignore-disables',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'disable_default_ignores' => [
@@ -226,8 +219,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--disable-default-ignores',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'cache' => [
@@ -238,8 +229,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--cache',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'cache_location' => [
@@ -250,8 +239,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--cache-location=path/to/cache',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'formatter' => [
@@ -262,8 +249,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--formatter=string',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'custom_formatter' => [
@@ -274,8 +259,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--custom-formatter=myformatter',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'quiet' => [
@@ -286,8 +269,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--quiet',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'color' => [
@@ -298,8 +279,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--color',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'no_color' => [
@@ -310,8 +289,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--no-color',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'report_needless_disables' => [
@@ -322,8 +299,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--report-needless-disables',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'report_invalid_scope_disables' => [
@@ -334,8 +309,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--report-invalid-scope-disables',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'report_descriptionless_disables' => [
@@ -346,8 +319,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--report-descriptionless-disables',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'max_warnings' => [
@@ -358,8 +329,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--max-warnings=10',
-                'hello.css',
-                'hello2.css',
             ]
         ];
         yield 'output_file' => [
@@ -370,8 +339,6 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--output-file=path/to/outputfile',
-                'hello.css',
-                'hello2.css',
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

Add a task to support [Stylelint](https://stylelint.io/) tool.
Heavily inspired from the existing ESLint task.
Supports relevant CLI supported arguments, based on the `--help` output, the inspiration for the sorting.
Parameter description is comming from [the official documentation](https://stylelint.io/user-guide/usage/cli)

Extra commit for a small CS fix in ESLint test.

<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpunit tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?
