### PR TITLE
Fix suffix property for PhpCpd v6

### DIFF
--- a/src/Task/PhpCpd.php
+++ b/src/Task/PhpCpd.php
@@ -60,13 +60,13 @@ class PhpCpd extends AbstractExternalTask
 
         $arguments = $this->processBuilder->createArgumentsForCommand('phpcpd');
         $extensions = array_map(function (string $extension) {
-            return sprintf('*.%s', $extension);
+            return sprintf('.%s', $extension);
         }, $config['triggered_by']);
 
         $arguments->addArgumentArray('--exclude=%s', $config['exclude']);
         $arguments->addRequiredArgument('--min-lines=%u', (string) $config['min_lines']);
         $arguments->addRequiredArgument('--min-tokens=%u', (string) $config['min_tokens']);
-        $arguments->addOptionalCommaSeparatedArgument('--suffix=%s', $extensions);
+        $arguments->addArgumentArray('--suffix=%s', $extensions);
         $arguments->addOptionalArgument('--fuzzy', $config['fuzzy']);
         $arguments->addArgumentArray('%s', $config['directory']);
 

--- a/test/Unit/Task/PhpCpdTest.php
+++ b/test/Unit/Task/PhpCpdTest.php
@@ -29,7 +29,7 @@ class PhpCpdTest extends AbstractExternalTaskTestCase
                 '--exclude=vendor',
                 '--min-lines=5',
                 '--min-tokens=70',
-                '--suffix=*.php',
+                '--suffix=.php',
                 '.',
             ],
         ];
@@ -44,7 +44,7 @@ class PhpCpdTest extends AbstractExternalTaskTestCase
                 '--exclude=vendor',
                 '--min-lines=5',
                 '--min-tokens=70',
-                '--suffix=*.php',
+                '--suffix=.php',
                 'folder-1',
                 'folder-2',
             ],
@@ -61,7 +61,7 @@ class PhpCpdTest extends AbstractExternalTaskTestCase
                 '--exclude=folder-2',
                 '--min-lines=5',
                 '--min-tokens=70',
-                '--suffix=*.php',
+                '--suffix=.php',
                 '.',
             ],
         ];
@@ -76,7 +76,7 @@ class PhpCpdTest extends AbstractExternalTaskTestCase
                 '--exclude=vendor',
                 '--min-lines=5',
                 '--min-tokens=70',
-                '--suffix=*.php',
+                '--suffix=.php',
                 '--fuzzy',
                 '.',
             ],
@@ -92,7 +92,7 @@ class PhpCpdTest extends AbstractExternalTaskTestCase
                 '--exclude=vendor',
                 '--min-lines=10',
                 '--min-tokens=70',
-                '--suffix=*.php',
+                '--suffix=.php',
                 '.',
             ],
         ];
@@ -107,7 +107,7 @@ class PhpCpdTest extends AbstractExternalTaskTestCase
                 '--exclude=vendor',
                 '--min-lines=5',
                 '--min-tokens=10',
-                '--suffix=*.php',
+                '--suffix=.php',
                 '.',
             ],
         ];
@@ -122,7 +122,8 @@ class PhpCpdTest extends AbstractExternalTaskTestCase
                 '--exclude=vendor',
                 '--min-lines=5',
                 '--min-tokens=70',
-                '--suffix=*.php,*.html',
+                '--suffix=.php',
+                '--suffix=.html',
                 '.',
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
In PhpCpd 6.0.0 there're few changes in CLI options: https://github.com/sebastianbergmann/phpcpd/blob/master/ChangeLog.md#600---2020-08-13 which make GrumPHP failing.

However, in current implementation, the suffix argument is passed in this way: `--suffix=*.php,*.myextension`
PhpCpd is expecting this argument in this format: `--suffix=.php --suffix=.myextension`

This PR Updates the way this argument is passed to the PhpCpd command.

Regards
