### PR TITLE
Add possibility to append files to shell task

### DIFF
--- a/doc/tasks/shell.md
+++ b/doc/tasks/shell.md
@@ -10,6 +10,7 @@ grumphp:
         shell:
             scripts: []
             triggered_by: [php]
+            append_files: false
 ```
 
 **scripts**
@@ -43,3 +44,11 @@ grumphp:
 This option will specify which file extensions will trigger the shell tasks.
 By default Shell will be triggered by altering a PHP file. 
 You can overwrite this option to whatever file you want to use!
+
+
+**append_files**
+
+*Default: false*
+
+When set to true, this option will append the list of files to the executed command.  
+Mostly useful when you have a command, using `-c`, that takes the files as arguments.

--- a/test/Unit/Task/ShellTest.php
+++ b/test/Unit/Task/ShellTest.php
@@ -27,6 +27,7 @@ class ShellTest extends AbstractExternalTaskTestCase
             [
                 'scripts' => [],
                 'triggered_by' => ['php'],
+                'append_files' => false,
             ]
         ];
         yield 'string_script' => [
@@ -38,6 +39,7 @@ class ShellTest extends AbstractExternalTaskTestCase
                     ['phpunit']
                 ],
                 'triggered_by' => ['php'],
+                'append_files' => false,
             ]
         ];
         yield 'array_script' => [
@@ -51,6 +53,17 @@ class ShellTest extends AbstractExternalTaskTestCase
                     ['phpunit', 'tests']
                 ],
                 'triggered_by' => ['php'],
+                'append_files' => false,
+            ]
+        ];
+        yield 'append_files' => [
+            [
+                'append_files' => true,
+            ],
+            [
+                'scripts' => [],
+                'triggered_by' => ['php'],
+                'append_files' => true,
             ]
         ];
     }
@@ -158,6 +171,20 @@ class ShellTest extends AbstractExternalTaskTestCase
             [
                 'phpunit',
                 'tests'
+            ]
+        ];
+
+        yield 'append-files' => [
+            [
+                'scripts' => ['phpunit'],
+                'append_files' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'sh',
+            [
+                'phpunit',
+                'hello.php',
+                'hello2.php',
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | 

Some commands may take the list of changed files as arguments.

My case is that I have several PHP scripts that are checking different kind of things, and they all take the list of changed files as arguments.
I plan to define a custom task per PHP script/command thanks to the `metadata.task` parameter