### PR TITLE
adds order-by argument to phpunit and phpunitBridge tasks

### DIFF
--- a/doc/tasks/phpunit.md
+++ b/doc/tasks/phpunit.md
@@ -21,7 +21,7 @@ grumphp:
             testsuite: ~
             group: []
             always_execute: false
-            order: default
+            order: null
 ```
 
 **config_file**
@@ -57,6 +57,6 @@ Always run the whole test suite, even if no PHP files were changed.
 
 **order**
 
-*Default: default*
+*Default: null*
 
 If you wish to run tests in a specific order. `order: [default,defects,duration,no-depends,random,reverse,size]`

--- a/doc/tasks/phpunit.md
+++ b/doc/tasks/phpunit.md
@@ -59,4 +59,4 @@ Always run the whole test suite, even if no PHP files were changed.
 
 *Default: default*
 
-If you wish to execute order by a specific order. `order: [default,defects,duration,no-depends,random,reverse,size]`
+If you wish to run tests in a specific order. `order: [default,defects,duration,no-depends,random,reverse,size]`

--- a/doc/tasks/phpunit.md
+++ b/doc/tasks/phpunit.md
@@ -21,6 +21,7 @@ grumphp:
             testsuite: ~
             group: []
             always_execute: false
+            order: default
 ```
 
 **config_file**
@@ -54,3 +55,8 @@ If you wish to only run tests from a certain Group.
 
 Always run the whole test suite, even if no PHP files were changed.
 
+**order**
+
+*Default: default*
+
+If you wish to execute order by a specific order. `order: [default,defects,duration,no-depends,random,reverse,size]`

--- a/doc/tasks/phpunitbridge.md
+++ b/doc/tasks/phpunitbridge.md
@@ -21,7 +21,7 @@ grumphp:
             testsuite: ~
             group: []
             always_execute: false
-            order: default
+            order: null
 ```
 
 **config_file**
@@ -57,6 +57,6 @@ Always run the whole test suite, even if no PHP files were changed.
 
 **order**
 
-*Default: default*
+*Default: null*
 
 If you wish to run tests in a specific order. `order: [default,defects,duration,no-depends,random,reverse,size]`

--- a/doc/tasks/phpunitbridge.md
+++ b/doc/tasks/phpunitbridge.md
@@ -59,4 +59,4 @@ Always run the whole test suite, even if no PHP files were changed.
 
 *Default: default*
 
-If you wish to execute order by a specific order. `order: [default,defects,duration,no-depends,random,reverse,size]`
+If you wish to run tests in a specific order. `order: [default,defects,duration,no-depends,random,reverse,size]`

--- a/doc/tasks/phpunitbridge.md
+++ b/doc/tasks/phpunitbridge.md
@@ -21,6 +21,7 @@ grumphp:
             testsuite: ~
             group: []
             always_execute: false
+            order: default
 ```
 
 **config_file**
@@ -54,3 +55,8 @@ If you wish to only run tests from a certain Group.
 
 Always run the whole test suite, even if no PHP files were changed.
 
+**order**
+
+*Default: default*
+
+If you wish to execute order by a specific order. `order: [default,defects,duration,no-depends,random,reverse,size]`

--- a/src/Task/Phpunit.php
+++ b/src/Task/Phpunit.php
@@ -21,12 +21,22 @@ class Phpunit extends AbstractExternalTask
             'testsuite' => null,
             'group' => [],
             'always_execute' => false,
+            'order' => 'default',
         ]);
 
         $resolver->addAllowedTypes('config_file', ['null', 'string']);
         $resolver->addAllowedTypes('testsuite', ['null', 'string']);
         $resolver->addAllowedTypes('group', ['array']);
         $resolver->addAllowedTypes('always_execute', ['bool']);
+        $resolver->addAllowedValues('order', [
+            'default',
+            'defects',
+            'duration',
+            'no-depends',
+            'random',
+            'reverse',
+            'size',
+        ]);
 
         return $resolver;
     }
@@ -49,6 +59,7 @@ class Phpunit extends AbstractExternalTask
         $arguments->addOptionalArgument('--configuration=%s', $config['config_file']);
         $arguments->addOptionalArgument('--testsuite=%s', $config['testsuite']);
         $arguments->addOptionalCommaSeparatedArgument('--group=%s', $config['group']);
+        $arguments->addOptionalArgument('--order-by=%s', $config['order']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();

--- a/src/Task/Phpunit.php
+++ b/src/Task/Phpunit.php
@@ -21,22 +21,14 @@ class Phpunit extends AbstractExternalTask
             'testsuite' => null,
             'group' => [],
             'always_execute' => false,
-            'order' => 'default',
+            'order' => null,
         ]);
 
         $resolver->addAllowedTypes('config_file', ['null', 'string']);
         $resolver->addAllowedTypes('testsuite', ['null', 'string']);
         $resolver->addAllowedTypes('group', ['array']);
         $resolver->addAllowedTypes('always_execute', ['bool']);
-        $resolver->addAllowedValues('order', [
-            'default',
-            'defects',
-            'duration',
-            'no-depends',
-            'random',
-            'reverse',
-            'size',
-        ]);
+        $resolver->addAllowedTypes('order', ['null', 'string']);
 
         return $resolver;
     }

--- a/src/Task/PhpunitBridge.php
+++ b/src/Task/PhpunitBridge.php
@@ -21,22 +21,14 @@ class PhpunitBridge extends AbstractExternalTask
             'testsuite' => null,
             'group' => [],
             'always_execute' => false,
-            'order' => 'default',
+            'order' => null,
         ]);
 
         $resolver->addAllowedTypes('config_file', ['null', 'string']);
         $resolver->addAllowedTypes('testsuite', ['null', 'string']);
         $resolver->addAllowedTypes('group', ['array']);
         $resolver->addAllowedTypes('always_execute', ['bool']);
-        $resolver->addAllowedValues('order', [
-            'default',
-            'defects',
-            'duration',
-            'no-depends',
-            'random',
-            'reverse',
-            'size',
-        ]);
+        $resolver->addAllowedTypes('order', ['null', 'string']);
 
         return $resolver;
     }

--- a/src/Task/PhpunitBridge.php
+++ b/src/Task/PhpunitBridge.php
@@ -21,12 +21,22 @@ class PhpunitBridge extends AbstractExternalTask
             'testsuite' => null,
             'group' => [],
             'always_execute' => false,
+            'order' => 'default',
         ]);
 
         $resolver->addAllowedTypes('config_file', ['null', 'string']);
         $resolver->addAllowedTypes('testsuite', ['null', 'string']);
         $resolver->addAllowedTypes('group', ['array']);
         $resolver->addAllowedTypes('always_execute', ['bool']);
+        $resolver->addAllowedValues('order', [
+            'default',
+            'defects',
+            'duration',
+            'no-depends',
+            'random',
+            'reverse',
+            'size',
+        ]);
 
         return $resolver;
     }
@@ -49,6 +59,7 @@ class PhpunitBridge extends AbstractExternalTask
         $arguments->addOptionalArgument('--configuration=%s', $config['config_file']);
         $arguments->addOptionalArgument('--testsuite=%s', $config['testsuite']);
         $arguments->addOptionalCommaSeparatedArgument('--group=%s', $config['group']);
+        $arguments->addOptionalArgument('--order-by=%s', $config['order']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();

--- a/test/Unit/Task/PhpunitBridgeTest.php
+++ b/test/Unit/Task/PhpunitBridgeTest.php
@@ -29,7 +29,7 @@ class PhpunitBridgeTest extends AbstractExternalTaskTestCase
                 'testsuite' => null,
                 'group' => [],
                 'always_execute' => false,
-                'order' => 'default',
+                'order' => null,
             ]
         ];
     }
@@ -100,9 +100,7 @@ class PhpunitBridgeTest extends AbstractExternalTaskTestCase
             [],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'simple-phpunit',
-            [
-                'order' => '--order-by=default',
-            ]
+            []
         ];
         yield 'config-file' => [
             [
@@ -111,7 +109,7 @@ class PhpunitBridgeTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'simple-phpunit',
             [
-                '--configuration=config.xml', '--order-by=default',
+                '--configuration=config.xml',
             ]
         ];
         yield 'testsuite' => [
@@ -121,7 +119,7 @@ class PhpunitBridgeTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'simple-phpunit',
             [
-                '--testsuite=suite', '--order-by=default',
+                '--testsuite=suite',
             ]
         ];
         yield 'group' => [
@@ -131,10 +129,10 @@ class PhpunitBridgeTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'simple-phpunit',
             [
-                '--group=group1,group2', '--order-by=default',
+                '--group=group1,group2',
             ]
         ];
-        yield 'order random' => [
+        yield 'random order' => [
             [
                 'order' => 'random',
             ],

--- a/test/Unit/Task/PhpunitBridgeTest.php
+++ b/test/Unit/Task/PhpunitBridgeTest.php
@@ -29,6 +29,7 @@ class PhpunitBridgeTest extends AbstractExternalTaskTestCase
                 'testsuite' => null,
                 'group' => [],
                 'always_execute' => false,
+                'order' => 'default',
             ]
         ];
     }
@@ -99,7 +100,9 @@ class PhpunitBridgeTest extends AbstractExternalTaskTestCase
             [],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'simple-phpunit',
-            []
+            [
+                'order' => '--order-by=default',
+            ]
         ];
         yield 'config-file' => [
             [
@@ -108,7 +111,7 @@ class PhpunitBridgeTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'simple-phpunit',
             [
-                '--configuration=config.xml',
+                '--configuration=config.xml', '--order-by=default',
             ]
         ];
         yield 'testsuite' => [
@@ -118,7 +121,7 @@ class PhpunitBridgeTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'simple-phpunit',
             [
-                '--testsuite=suite',
+                '--testsuite=suite', '--order-by=default',
             ]
         ];
         yield 'group' => [
@@ -128,7 +131,17 @@ class PhpunitBridgeTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'simple-phpunit',
             [
-                '--group=group1,group2',
+                '--group=group1,group2', '--order-by=default',
+            ]
+        ];
+        yield 'order random' => [
+            [
+                'order' => 'random',
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'simple-phpunit',
+            [
+                'order' => '--order-by=random',
             ]
         ];
     }

--- a/test/Unit/Task/PhpunitTest.php
+++ b/test/Unit/Task/PhpunitTest.php
@@ -29,7 +29,7 @@ class PhpunitTest extends AbstractExternalTaskTestCase
                 'testsuite' => null,
                 'group' => [],
                 'always_execute' => false,
-                'order' => 'default',
+                'order' => null,
             ]
         ];
     }
@@ -100,9 +100,7 @@ class PhpunitTest extends AbstractExternalTaskTestCase
             [],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'phpunit',
-            [
-                'order' => '--order-by=default',
-            ]
+            []
         ];
         yield 'config-file' => [
             [
@@ -111,7 +109,7 @@ class PhpunitTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'phpunit',
             [
-                '--configuration=config.xml', '--order-by=default',
+                '--configuration=config.xml',
             ]
         ];
         yield 'testsuite' => [
@@ -121,7 +119,7 @@ class PhpunitTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'phpunit',
             [
-                '--testsuite=suite', '--order-by=default',
+                '--testsuite=suite',
             ]
         ];
         yield 'group' => [
@@ -131,10 +129,10 @@ class PhpunitTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'phpunit',
             [
-                '--group=group1,group2', '--order-by=default',
+                '--group=group1,group2',
             ]
         ];
-        yield 'order random' => [
+        yield 'random order' => [
             [
                 'order' => 'random',
             ],

--- a/test/Unit/Task/PhpunitTest.php
+++ b/test/Unit/Task/PhpunitTest.php
@@ -29,6 +29,7 @@ class PhpunitTest extends AbstractExternalTaskTestCase
                 'testsuite' => null,
                 'group' => [],
                 'always_execute' => false,
+                'order' => 'default',
             ]
         ];
     }
@@ -99,7 +100,9 @@ class PhpunitTest extends AbstractExternalTaskTestCase
             [],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'phpunit',
-            []
+            [
+                'order' => '--order-by=default',
+            ]
         ];
         yield 'config-file' => [
             [
@@ -108,7 +111,7 @@ class PhpunitTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'phpunit',
             [
-                '--configuration=config.xml',
+                '--configuration=config.xml', '--order-by=default',
             ]
         ];
         yield 'testsuite' => [
@@ -118,7 +121,7 @@ class PhpunitTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'phpunit',
             [
-                '--testsuite=suite',
+                '--testsuite=suite', '--order-by=default',
             ]
         ];
         yield 'group' => [
@@ -128,7 +131,17 @@ class PhpunitTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'phpunit',
             [
-                '--group=group1,group2',
+                '--group=group1,group2', '--order-by=default',
+            ]
+        ];
+        yield 'order random' => [
+            [
+                'order' => 'random',
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'phpunit',
+            [
+                'order' => '--order-by=random',
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->


<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [ ] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [ ] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpunit tests?
- [x] Is the configuration having logical allowed types?
- [ ] Does the task run in the correct context?
- [ ] Is the `run()` method readable?
- [ ] Is the `run()` method using the configuration correctly?
- [ ] Are all CI services returning green?
