### PR TITLE
Fix #887 - Paratest: parallel- and configuration-argument was passed incorrectly

### DIFF
--- a/src/Task/Paratest.php
+++ b/src/Task/Paratest.php
@@ -68,9 +68,9 @@ class Paratest extends AbstractExternalTask
         }
 
         $arguments = $this->processBuilder->createArgumentsForCommand('paratest');
-        $arguments->addOptionalArgument('-p=%s', $config['processes']);
+        $arguments->addOptionalArgument('--processes=%s', $config['processes']);
         $arguments->addOptionalArgument('-f', $config['functional']);
-        $arguments->addOptionalArgument('-c=%s', $config['configuration']);
+        $arguments->addOptionalArgument('--configuration=%s', $config['configuration']);
         $arguments->addOptionalArgument('--phpunit=%s', $config['phpunit']);
         $arguments->addOptionalArgument('--runner=%s', $config['runner']);
         $arguments->addOptionalArgument('--coverage-clover=%s', $config['coverage-clover']);

--- a/test/Unit/Task/ParatestTest.php
+++ b/test/Unit/Task/ParatestTest.php
@@ -115,7 +115,7 @@ class ParatestTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'paratest',
             [
-                '-p=10',
+                '--processes=10',
             ]
         ];
         yield 'functional' => [
@@ -135,7 +135,7 @@ class ParatestTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'paratest',
             [
-                '-c=phpunit.xml',
+                '--configuration=phpunit.xml',
             ]
         ];
         yield 'runner' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #887

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
Solves incorrectly passed arguments to paratest.
