### PR TITLE
Add subject pattern configurable option

### DIFF
--- a/doc/tasks/git_commit_message.md
+++ b/doc/tasks/git_commit_message.md
@@ -169,3 +169,19 @@ type_scope_conventions:
       - environment
 ```
 
+**subject_pattern**
+
+*Default: ([a-zA-Z0-9-_ #@'\/\"]+)*
+
+*To be used with `type_scope_conventions`*
+
+Specify a subject pattern. Default allows [a-zA-Z0-9-_ #@'\/\"]+ pattern.
+
+Add pattern like:
+```yaml
+type_scope_conventions:
+  - types: []
+  - scopes: ~
+  - subject_pattern: >-
+      ([a-zA-Zа-яА-Я0-9-_ #@'\/\"]+)
+```

--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -354,7 +354,11 @@ class CommitMessage implements TaskInterface
         $specialPrefix = '(?:(?:fixup|squash)! )?';
         $typesPattern = '([a-zA-Z0-9]+)';
         $scopesPattern = '(:\s|(\(.+\)?:\s))';
-        $subjectPattern = '([a-zA-Z0-9-_ #@\'\/\\"]+)';
+
+        $subjectPattern = isset($config['type_scope_conventions']['subject_pattern'])
+            ? $config['type_scope_conventions']['subject_pattern']
+            : '([a-zA-Z0-9-_ #@\'\/\\"]+)';
+
         $mergePattern =
             '(Merge branch|tag \'.+\'(?:\s.+)?|Merge remote-tracking branch \'.+\'|Merge pull request #\d+\s.+)';
 
@@ -369,7 +373,6 @@ class CommitMessage implements TaskInterface
         }
 
         $rule = '/^' . $specialPrefix . $typesPattern . $scopesPattern . $subjectPattern . '|' . $mergePattern . '/';
-
         try {
             $this->runMatcher($config, $subjectLine, $rule, 'Invalid Type/Scope Format');
         } catch (RuntimeException $e) {

--- a/test/Unit/Task/Git/CommitMessageTest.php
+++ b/test/Unit/Task/Git/CommitMessageTest.php
@@ -376,6 +376,30 @@ class CommitMessageTest extends AbstractTaskTestCase
             },
             'Subject should start with a capital letter.'
         ];
+        yield 'it_fails_on_subject_pattern_default' => [
+            [
+                'enforce_capitalized_subject' => false,
+                'type_scope_conventions' => [
+                    'scopes' => null,
+                ],
+            ],
+            $this->mockCommitMsgContext($this->buildMessage('feat(feature): Это не сработает')),
+            function () {
+            },
+            'Rule not matched: "Invalid Type/Scope Format"'
+        ];
+        yield 'it_fails_on_subject_pattern' => [
+            [
+                'type_scope_conventions' => [
+                    'scopes' => null,
+                    'subject_pattern' => '([0-9]+)'
+                ],
+            ],
+            $this->mockCommitMsgContext($this->buildMessage('It fails')),
+            function () {
+            },
+            'Rule not matched: "Invalid Type/Scope Format"'
+        ];
     }
 
     public function providePassesOnStuff(): iterable
@@ -777,6 +801,29 @@ class CommitMessageTest extends AbstractTaskTestCase
                 'multiline' => false,
             ],
             $this->mockCommitMsgContext($this->buildMessage('hello there', 'good bye')),
+            function () {
+            },
+        ];
+        yield 'it_applies_on_subject_pattern_default' => [
+            [
+                'enforce_capitalized_subject' => false,
+                'type_scope_conventions' => [
+                    'scopes' => null,
+                ],
+            ],
+            $this->mockCommitMsgContext($this->buildMessage('feat(feature): It works')),
+            function () {
+            },
+        ];
+        yield 'it_applies_on_subject_pattern' => [
+            [
+                'enforce_capitalized_subject' => false,
+                'type_scope_conventions' => [
+                    'scopes' => null,
+                    'subject_pattern' => '([a-zA-Zа-яА-Я0-9-_ #@\'\/\\"]+)'
+                ],
+            ],
+            $this->mockCommitMsgContext($this->buildMessage('feat(feature): Это сработает')),
             function () {
             },
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets |

I work in a Russian-speaking team and type/scope checks fails when the subject is written in only Russian.
it would be great if we can define type_scope_conventions.subject_pattern like:
```yaml
type_scope_conventions:
  - types: []
  - scopes: ~
  - subject_pattern: >-
      ([a-zA-Zа-яА-Я0-9-_ #@'\/\"]+)
```