### PR TITLE
Allow ondram/ci-detector ^4.0 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/collections": "^1.6.7",
         "gitonomy/gitlib": "^1.0.3",
         "monolog/monolog": "~1.16 || ^2.0",
-        "ondram/ci-detector": "^3.5",
+        "ondram/ci-detector": "^3.5 || ^4.0",
         "opis/closure": "^3.5",
         "psr/container": "^1.0",
         "seld/jsonlint": "~1.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Documented?   | no
| Fixed tickets |

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

Allow upgrade of ondram/ci-detector dependency. After reading [the changelog](https://github.com/OndraM/ci-detector/blob/4.1.0/CHANGELOG.md) there is no BC break.

<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [ ] Are the dependencies added to the composer.json suggestions?
- [ ] Is the doc/tasks.md file updated?
- [ ] Are the task parameters documented?
- [ ] Is the task registered in the tasks.yml file?
- [ ] Does the task contains phpunit tests?
- [ ] Is the configuration having logical allowed types?
- [ ] Does the task run in the correct context?
- [ ] Is the `run()` method readable?
- [ ] Is the `run()` method using the configuration correctly?
- [ ] Are all CI services returning green?
