### PR TITLE
Insufficient condition to switch interfaces for event interface.

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -6,9 +6,11 @@ namespace GrumPHP\Event;
 
 use Symfony\Contracts\EventDispatcher\Event as SymfonyEventContract;
 use Symfony\Component\EventDispatcher\Event as SymfonyLegacyEvent;
-
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 // @codingStandardsIgnoreStart
-if (class_exists(SymfonyEventContract::class)) {
+if (class_exists(SymfonyEventContract::class) &&
+    in_array('EventDispatcherInterface', class_implements(EventDispatcher::class))) {
     class Event extends SymfonyEventContract
     {
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

Latest version of grumphp uses a workaround to switch Event class implementation depending on the symfony component's versions (for example: event-dispatcher and dependency-injection component versions).

But it doesn't consider the case when, some other contributed components use this new component **directly**: [Event-dispatcher-contracts:](https://github.com/symfony/event-dispatcher-contracts)

Symfony event-dispatcher component uses it starting from the version ^4.3. 
Now, imagine that some other component uses symfony event dispatcher ^3.4 and installs another contributed component that directly uses https://github.com/symfony/event-dispatcher-contracts). It means that now the event dispatcher will be an old one, but the grumphp latest version will bring this workaround and the Event class will be switched to the `SymfonyEventContract`  and the the conflict occurs.

This PR fixes this issue.

<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [ ] Are the dependencies added to the composer.json suggestions?
- [ ] Is the doc/tasks.md file updated?
- [ ] Are the task parameters documented?
- [ ] Is the task registered in the tasks.yml file?
- [ ] Does the task contains phpunit tests?
- [ ] Is the configuration having logical allowed types?
- [ ] Does the task run in the correct context?
- [ ] Is the `run()` method readable?
- [ ] Is the `run()` method using the configuration correctly?
- [ ] Are all CI services returning green?
