### PR TITLE
Always call addFiles in Stylelint task (like in ESLint)

### DIFF
--- a/src/Task/Stylelint.php
+++ b/src/Task/Stylelint.php
@@ -120,10 +120,7 @@ class Stylelint extends AbstractExternalTask
         );
         $arguments->addOptionalIntegerArgument('--max-warnings=%d', $config['max_warnings']);
         $arguments->addOptionalArgument('--output-file=%s', $config['output_file']);
-
-        if ($context instanceof GitPreCommitContext) {
-            $arguments->addFiles($files);
-        }
+        $arguments->addFiles($files);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();

--- a/test/Unit/Task/StylelintTest.php
+++ b/test/Unit/Task/StylelintTest.php
@@ -139,6 +139,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 'node_modules/.bin/stylelint',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'config' => [
@@ -149,6 +151,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--config=.stylelintrc.json',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'config_basedir' => [
@@ -159,6 +163,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--config-basedir=path/to/base/dir',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'ignore_path' => [
@@ -169,6 +175,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--ignore-path=path/to/.ignorefile',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'ignore_pattern' => [
@@ -179,6 +187,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--ignore-pattern=pattern',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'syntax' => [
@@ -189,6 +199,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--syntax=css',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'custom_syntax' => [
@@ -199,6 +211,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--custom-syntax=mysyntax',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'ignore_disables' => [
@@ -209,6 +223,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--ignore-disables',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'disable_default_ignores' => [
@@ -219,6 +235,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--disable-default-ignores',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'cache' => [
@@ -229,6 +247,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--cache',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'cache_location' => [
@@ -239,6 +259,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--cache-location=path/to/cache',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'formatter' => [
@@ -249,6 +271,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--formatter=string',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'custom_formatter' => [
@@ -259,6 +283,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--custom-formatter=myformatter',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'quiet' => [
@@ -269,6 +295,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--quiet',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'color' => [
@@ -279,6 +307,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--color',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'no_color' => [
@@ -289,6 +319,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--no-color',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'report_needless_disables' => [
@@ -299,6 +331,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--report-needless-disables',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'report_invalid_scope_disables' => [
@@ -309,6 +343,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--report-invalid-scope-disables',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'report_descriptionless_disables' => [
@@ -319,6 +355,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--report-descriptionless-disables',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'max_warnings' => [
@@ -329,6 +367,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--max-warnings=10',
+                'hello.css',
+                'hello2.css',
             ]
         ];
         yield 'output_file' => [
@@ -339,6 +379,8 @@ class StylelintTest extends AbstractExternalTaskTestCase
             'stylelint',
             [
                 '--output-file=path/to/outputfile',
+                'hello.css',
+                'hello2.css',
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #926 

The current Stylelint task does not add files to the command if run outside of a git commit. This results in an error because stylelint expects a list of files or a glob.

This pull request changes the behaviour of Stylelint task to the one of ESLint, to fix the error.

There was some discussion about the current implementation in https://github.com/phpro/grumphp/pull/904#discussion_r646086110. But i couldn't find a way to specify files or a globs in the stylelint config file.

