### PR TITLE
Fix build path for absolute paths.

### DIFF
--- a/src/Util/Filesystem.php
+++ b/src/Util/Filesystem.php
@@ -60,7 +60,7 @@ class Filesystem extends SymfonyFilesystem
 
     public function buildPath(string $baseDir, string $path): string
     {
-        return $baseDir.DIRECTORY_SEPARATOR.$path;
+        return substr($path, 0, 1) === DIRECTORY_SEPARATOR ? $path : $baseDir.DIRECTORY_SEPARATOR.$path;
     }
 
     public function guessPath(array $paths): string

--- a/src/Util/Filesystem.php
+++ b/src/Util/Filesystem.php
@@ -60,7 +60,7 @@ class Filesystem extends SymfonyFilesystem
 
     public function buildPath(string $baseDir, string $path): string
     {
-        return substr($path, 0, 1) === DIRECTORY_SEPARATOR ? $path : $baseDir.DIRECTORY_SEPARATOR.$path;
+        return $this->isAbsolutePath($path) ? $path : $baseDir.DIRECTORY_SEPARATOR.$path;
     }
 
     public function guessPath(array $paths): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 

When you create a git worktree of your project and then in that project perform a grumphp git:init my .git file contains an absolute path for `gitdir:` which is then appended to another absolute path:
https://github.com/phpro/grumphp/blob/5b696233890ac35e4a8f8a8ef29cafc85669eb93/src/Locator/GitRepositoryDirLocator.php#L31-L41

Easy fix to first check if the path is absolute or not. Then return appended path or not accordingly.

**Steps to reproduce:**

- create a composer project with phpro/grumphp as a dependency in a git repository.
- git clone *yourproject*
- cd *yourproject*
- git worktree add -B *yourprojectnewtree*
- composer install -d *yourprojectnewtree*

Whenever you run grumphp git:init (which it does on composer install) it will concatenate two absolute paths.
Example build here: https://github.com/verbruggenalex/gdc/runs/3883357864?check_suite_focus=true#step:6:464