### PR TITLE
Add --no-check-lock option support

### DIFF
--- a/doc/tasks/composer_normalize.md
+++ b/doc/tasks/composer_normalize.md
@@ -22,6 +22,7 @@ grumphp:
         composer_normalize:
             indent_size: ~
             indent_style: ~
+            no_check_lock: false
             no_update_lock: true
             verbose: false
 ```
@@ -37,6 +38,12 @@ Indent size (an integer greater than 0); must be used with the `indent_style` op
 *Default: null*
 
 Indent style (one of "space", "tab"); must be used with the `indent_size` option
+
+**no_check_lock**
+
+*Default: false*
+
+If `true`, do not check if lock file is up to date.
 
 **no_update_lock**
 

--- a/src/Task/ComposerNormalize.php
+++ b/src/Task/ComposerNormalize.php
@@ -24,6 +24,7 @@ class ComposerNormalize extends AbstractExternalTask
         $resolver->setDefaults([
             'indent_size' => null,
             'indent_style' => null,
+            'no_check_lock' => false,
             'no_update_lock' => true,
             'use_standalone' => false,
             'verbose' => false,
@@ -32,6 +33,7 @@ class ComposerNormalize extends AbstractExternalTask
         $resolver->addAllowedTypes('indent_size', ['int', 'null']);
         $resolver->addAllowedTypes('indent_style', ['string', 'null']);
         $resolver->addAllowedValues('indent_style', ['tab', 'space', null]);
+        $resolver->addAllowedTypes('no_check_lock', ['bool']);
         $resolver->addAllowedTypes('no_update_lock', ['bool']);
         $resolver->addAllowedTypes('verbose', ['bool']);
 
@@ -59,6 +61,7 @@ class ComposerNormalize extends AbstractExternalTask
             $arguments->addOptionalArgument('--indent-size=%s', $config['indent_size']);
         }
 
+        $arguments->addOptionalArgument('--no-check-lock', $config['no_check_lock']);
         $arguments->addOptionalArgument('--no-update-lock', $config['no_update_lock']);
         $arguments->addOptionalArgument('-q', $config['verbose']);
 

--- a/test/Unit/Task/ComposerNormalizeTest.php
+++ b/test/Unit/Task/ComposerNormalizeTest.php
@@ -29,6 +29,7 @@ class ComposerNormalizeTest extends AbstractExternalTaskTestCase
                 'use_standalone' => false,
                 'indent_size' => null,
                 'indent_style' => null,
+                'no_check_lock' => false,
                 'no_update_lock' => true,
                 'verbose' => false,
             ]
@@ -178,5 +179,18 @@ class ComposerNormalizeTest extends AbstractExternalTaskTestCase
                 '--no-update-lock',
             ]
         ];
+        yield 'no-check-lock' => [
+        [
+          'no_check_lock' => true,
+        ],
+        $this->mockContext(RunContext::class, ['composer.json', 'hello2.php']),
+        'composer',
+        [
+          'normalize',
+          '--dry-run',
+          '--no-check-lock',
+          '--no-update-lock',
+        ]
+      ];
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Version         | `GrumPHP 1.5.0`
| Bug?            | no
| New feature?    | yes
| Question?       | no
| Documentation?  | no
| Related tickets | #595 , #596 , #645 , #944, #945

<!-- Please add an advanced description on what this ISSUE is doing to GrumPHP. -->

composer-normalize introduced `--no-check-lock ` option in [2.7.0](https://github.com/ergebnis/composer-normalize/releases/tag/2.7.0) release back in August  2020. 

This option is very useful when you work on a  library project and you only concerned about the `composer.json` file but not that much about the lock file that only exists in the development environment for the library itself.

It would be awesome to see it available via configuration for the `composer_normalize` task.