### PR TITLE
Add ignore_path option for ESLint task

### DIFF
--- a/doc/tasks/eslint.md
+++ b/doc/tasks/eslint.md
@@ -3,17 +3,21 @@
 [ESLint](https://eslint.org/) is a static analysis tool for Javascript code. ESLint covers both code quality and coding style issues.
 
 ## NPM
+
 If you'd like to install it globally:
+
 ```bash
 npm -g eslint
 ```
 
 If you'd like install it as a dev dependency of your project:
+
 ```bash
 npm install eslint --save-dev
 ```
 
-To generate a .eslintrc.* config file:
+To generate a .eslintrc.\* config file:
+
 ```
 npx eslint --init
 ```
@@ -21,45 +25,46 @@ npx eslint --init
 Done. See the ESLint [Getting Started](https://eslint.org/docs/user-guide/getting-started) guide for more info.
 
 ## Config
+
 It lives under the `eslint` namespace and has the following configurable parameters:
 
 ```yaml
 # grumphp.yml
 grumphp:
-    tasks:
-        eslint:
-            bin: node_modules/.bin/eslint
-            triggered_by: [js, jsx, ts, tsx, vue]
-            whitelist_patterns:
-                - /^resources\/js\/(.*)/
-            config: .eslintrc.json
-            debug: false
-            format: ~
-            max_warnings: ~
-            no_eslintrc: false
-            quiet: false
+  tasks:
+    eslint:
+      bin: node_modules/.bin/eslint
+      triggered_by: [js, jsx, ts, tsx, vue]
+      whitelist_patterns:
+        - /^resources\/js\/(.*)/
+      config: .eslintrc.json
+      ignore_path: .eslintignore
+      debug: false
+      format: ~
+      max_warnings: ~
+      no_eslintrc: false
+      quiet: false
 ```
 
 **bin**
 
-*Default: null*
+_Default: null_
 
 The path to your eslint bin executable. Not necessary if eslint is in your $PATH. Can be used to specify path to project's eslint over globally installed eslint.
 
-
 **triggered_by**
 
-*Default: [js, jsx, ts, tsx, vue]*
+_Default: [js, jsx, ts, tsx, vue]_
 
 This is a list of extensions which will trigger the ESLint task.
 
-
 **whitelist_patterns**
 
-*Default: []*
+_Default: []_
 
 This is a list of regex patterns that will filter files to validate. With this option you can specify the folders containing javascript files and thus skip folders like /tests/ or the /vendor/ directory. This option is used in conjunction with the parameter `triggered_by`.
 For example: to whitelist files in `resources/js/` (Laravel's JS directory) and `assets/js/` (Symfony's JS directory) you can use:
+
 ```yml
 whitelist_patterns:
   - /^resources\/js\/(.*)/
@@ -68,37 +73,43 @@ whitelist_patterns:
 
 **config**
 
-*Default: null*
+_Default: null_
 
 The path to your eslint's configuration file. Not necessary if using a standard eslintrc name, eg. .eslintrc.json, .eslint.js, or .eslint.yml
 
+**ignore_path**
+
+_Default: null_
+
+The path to your eslint's ignore file ([eslint.org](https://eslint.org/docs/user-guide/configuring/ignoring-code#using-an-alternate-file)). Not necessary if using standard .eslintignore name.
+
 **debug**
 
-*Default: false*
+_Default: false_
 
 Turn on debug mode ([eslint.org](https://eslint.org/docs/user-guide/command-line-interface#debug)).
 
 **format**
 
-*Default: null*
+_Default: null_
 
 Output format, eslint will use `stylish` by default. Other handy ones on cli are `compact`, `codeframe` and `table` (see full list on [eslint.org](https://eslint.org/docs/user-guide/formatters/)).
 
 **max_warnings**
 
-*Default: null*
+_Default: null_
 
 Number of warnings (not errors) that are allowed before eslint exits with error status ([eslint.org](https://eslint.org/docs/user-guide/command-line-interface#max-warnings)).
 
 **no_eslintrc**
 
-*Default: false*
+_Default: false_
 
 Set to true to ignore local .eslint config file ([eslint.org](https://eslint.org/docs/user-guide/command-line-interface#max-warnings)).
 
 **quiet**
 
-*Default: null*
+_Default: null_
 
 Report errors only (no warnings). [eslint.org](https://eslint.org/docs/user-guide/command-line-interface#quiet)
 

--- a/doc/tasks/eslint.md
+++ b/doc/tasks/eslint.md
@@ -3,21 +3,17 @@
 [ESLint](https://eslint.org/) is a static analysis tool for Javascript code. ESLint covers both code quality and coding style issues.
 
 ## NPM
-
 If you'd like to install it globally:
-
 ```bash
 npm -g eslint
 ```
 
 If you'd like install it as a dev dependency of your project:
-
 ```bash
 npm install eslint --save-dev
 ```
 
-To generate a .eslintrc.\* config file:
-
+To generate a .eslintrc.* config file:
 ```
 npx eslint --init
 ```
@@ -25,46 +21,46 @@ npx eslint --init
 Done. See the ESLint [Getting Started](https://eslint.org/docs/user-guide/getting-started) guide for more info.
 
 ## Config
-
 It lives under the `eslint` namespace and has the following configurable parameters:
 
 ```yaml
 # grumphp.yml
 grumphp:
-  tasks:
-    eslint:
-      bin: node_modules/.bin/eslint
-      triggered_by: [js, jsx, ts, tsx, vue]
-      whitelist_patterns:
-        - /^resources\/js\/(.*)/
-      config: .eslintrc.json
-      ignore_path: .eslintignore
-      debug: false
-      format: ~
-      max_warnings: ~
-      no_eslintrc: false
-      quiet: false
+    tasks:
+        eslint:
+            bin: node_modules/.bin/eslint
+            triggered_by: [js, jsx, ts, tsx, vue]
+            whitelist_patterns:
+                - /^resources\/js\/(.*)/
+            config: .eslintrc.json
+            ignore_path: .eslintignore
+            debug: false
+            format: ~
+            max_warnings: ~
+            no_eslintrc: false
+            quiet: false
 ```
 
 **bin**
 
-_Default: null_
+*Default: null*
 
 The path to your eslint bin executable. Not necessary if eslint is in your $PATH. Can be used to specify path to project's eslint over globally installed eslint.
 
+
 **triggered_by**
 
-_Default: [js, jsx, ts, tsx, vue]_
+*Default: [js, jsx, ts, tsx, vue]*
 
 This is a list of extensions which will trigger the ESLint task.
 
+
 **whitelist_patterns**
 
-_Default: []_
+*Default: []*
 
 This is a list of regex patterns that will filter files to validate. With this option you can specify the folders containing javascript files and thus skip folders like /tests/ or the /vendor/ directory. This option is used in conjunction with the parameter `triggered_by`.
 For example: to whitelist files in `resources/js/` (Laravel's JS directory) and `assets/js/` (Symfony's JS directory) you can use:
-
 ```yml
 whitelist_patterns:
   - /^resources\/js\/(.*)/
@@ -73,43 +69,43 @@ whitelist_patterns:
 
 **config**
 
-_Default: null_
+*Default: null*
 
 The path to your eslint's configuration file. Not necessary if using a standard eslintrc name, eg. .eslintrc.json, .eslint.js, or .eslint.yml
 
 **ignore_path**
 
-_Default: null_
+*Default: null*
 
 The path to your eslint's ignore file ([eslint.org](https://eslint.org/docs/user-guide/configuring/ignoring-code#using-an-alternate-file)). Not necessary if using standard .eslintignore name.
 
 **debug**
 
-_Default: false_
+*Default: false*
 
 Turn on debug mode ([eslint.org](https://eslint.org/docs/user-guide/command-line-interface#debug)).
 
 **format**
 
-_Default: null_
+*Default: null*
 
 Output format, eslint will use `stylish` by default. Other handy ones on cli are `compact`, `codeframe` and `table` (see full list on [eslint.org](https://eslint.org/docs/user-guide/formatters/)).
 
 **max_warnings**
 
-_Default: null_
+*Default: null*
 
 Number of warnings (not errors) that are allowed before eslint exits with error status ([eslint.org](https://eslint.org/docs/user-guide/command-line-interface#max-warnings)).
 
 **no_eslintrc**
 
-_Default: false_
+*Default: false*
 
 Set to true to ignore local .eslint config file ([eslint.org](https://eslint.org/docs/user-guide/command-line-interface#max-warnings)).
 
 **quiet**
 
-_Default: null_
+*Default: null*
 
 Report errors only (no warnings). [eslint.org](https://eslint.org/docs/user-guide/command-line-interface#quiet)
 

--- a/src/Task/ESLint.php
+++ b/src/Task/ESLint.php
@@ -27,6 +27,7 @@ class ESLint extends AbstractExternalTask
             
             // ESLint native config options
             'config' => null,
+            'ignore_path' => null,
             'debug' => false,
             'format' => null,
             'max_warnings' => null,
@@ -41,6 +42,7 @@ class ESLint extends AbstractExternalTask
         
         // ESLint native config options
         $resolver->addAllowedTypes('config', ['null', 'string']);
+        $resolver->addAllowedTypes('ignore_path', ['null', 'string']);
         $resolver->addAllowedTypes('debug', ['bool']);
         $resolver->addAllowedTypes('format', ['null', 'string']);
         $resolver->addAllowedTypes('max_warnings', ['null', 'integer']);
@@ -73,6 +75,7 @@ class ESLint extends AbstractExternalTask
             : $this->processBuilder->createArgumentsForCommand('eslint');
 
         $arguments->addOptionalArgument('--config=%s', $config['config']);
+        $arguments->addOptionalArgument('--ignore-path=%s', $config['ignore_path']);
         $arguments->addOptionalArgument('--debug', $config['debug']);
         $arguments->addOptionalArgument('--format=%s', $config['format']);
         $arguments->addOptionalArgument('--no-eslintrc', $config['no_eslintrc']);

--- a/test/Unit/Task/ESLintTest.php
+++ b/test/Unit/Task/ESLintTest.php
@@ -33,6 +33,7 @@ class ESLintTest extends AbstractExternalTaskTestCase
 
                 // ESLint native config options
                 'config' => null,
+                'ignore_path' => null,
                 'debug' => false,
                 'format' => null,
                 'max_warnings' => null,
@@ -129,6 +130,18 @@ class ESLintTest extends AbstractExternalTaskTestCase
             'eslint',
             [
                 '--config=.eslintrc.json',
+                'hello.js',
+                'hello2.js',
+            ]
+        ];
+        yield 'ignore_path' => [
+            [
+                'ignore_path' => '.eslintignore',
+            ],
+            $this->mockContext(RunContext::class, ['hello.js', 'hello2.js']),
+            'eslint',
+            [
+                '--ignore-path=.eslintignore',
                 'hello.js',
                 'hello2.js',
             ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | https://github.com/phpro/grumphp/discussions/961

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

Use native ignore-path option from [ESLint](https://eslint.org/docs/user-guide/configuring/ignoring-code#using-an-alternate-file).