### PR TITLE
Change deptrac arguments according v0.19

### DIFF
--- a/doc/tasks/deptrac.md
+++ b/doc/tasks/deptrac.md
@@ -1,6 +1,6 @@
 # Deptrac
 
-Follow the [installation instructions](https://github.com/sensiolabs-de/deptrac#installation) to add deptrac to your 
+Follow the [installation instructions](https://qossmic.github.io/deptrac/#installation) to add deptrac to your 
 project.
 
 The Deptrac task will check for dependencies between the software layers of your project. It lives under the `deptrac` 
@@ -14,65 +14,23 @@ grumphp:
         deptrac:
             depfile: ~
             formatter: ~
-            graphviz_display: ~
-            graphviz_dump_image: ~
-            graphviz_dump_dot: ~
-            graphviz_dump_html: ~
-            junit_dump_xml: ~
-            xml_dump: ~
-            baseline_dump: ~
+            output: ~
 ```
 
 **depfile**
 
 *Default: null*
 
-Set path to deptrac configuration file. Example: `/var/www/src/depfile.yml`
+Set path to deptrac configuration file. Example: `/var/www/src/deptrac.yaml`
 
 **formatter**
 
-*Default: []*
+*Default: null*
 
-Enable (multiple) formatters with this option, e.g. `console`, `github-actions`, `graphviz`, `table`, `junit`, `xml`, `baseline`.
+Enable formatter with this option, e.g. `console`, `github-actions`, `graphviz-display`, `graphviz-image`, `graphviz-dot`, `graphviz-html`, `junit`, `table`, `xml`, `baseline`, `json`.
 
-**graphviz_display**
-
-*Default: true*
-
-Open the generated graphviz image. Set to `true` to activate.
-
-**graphviz_dump_image**
+**output**
 
 *Default: null*
 
-Set path to a dumped png file.
-
-**graphviz_dump_dot**
-
-*Default: null*
-
-Set path to a dumped dot file.
-
-**graphviz_dump_html**
-
-*Default: null*
-
-Set path to a dumped html file.
-
-**junit_dump_xml**
-
-*Default: null*
-
-Set path to a dumped JUnit xml file.
-
-**xml_dump**
-
-*Default: null*
-
-Set path to a dumped xml file.
-
-**baseline_dump**
-
-*Default: null*
-
-Set path to a dumped baseline file.
+Set output file path for formatter (if applicable).

--- a/src/Task/Deptrac.php
+++ b/src/Task/Deptrac.php
@@ -21,25 +21,13 @@ class Deptrac extends AbstractExternalTask
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
             'depfile' => null,
-            'formatter' => [],
-            'graphviz_display' => true,
-            'graphviz_dump_image' => null,
-            'graphviz_dump_dot' => null,
-            'graphviz_dump_html' => null,
-            'junit_dump_xml' => null,
-            'xml_dump' => null,
-            'baseline_dump' => null,
+            'formatter' => null,
+            'output' => null,
         ]);
 
         $resolver->addAllowedTypes('depfile', ['null', 'string']);
-        $resolver->addAllowedTypes('formatter', ['string[]']);
-        $resolver->addAllowedTypes('graphviz_display', ['bool']);
-        $resolver->addAllowedTypes('graphviz_dump_image', ['null', 'string']);
-        $resolver->addAllowedTypes('graphviz_dump_dot', ['null', 'string']);
-        $resolver->addAllowedTypes('graphviz_dump_html', ['null', 'string']);
-        $resolver->addAllowedTypes('junit_dump_xml', ['null', 'string']);
-        $resolver->addAllowedTypes('xml_dump', ['null', 'string']);
-        $resolver->addAllowedTypes('baseline_dump', ['null', 'string']);
+        $resolver->addAllowedTypes('formatter', ['null', 'string']);
+        $resolver->addAllowedTypes('output', ['null', 'string']);
 
         return $resolver;
     }
@@ -59,16 +47,10 @@ class Deptrac extends AbstractExternalTask
         }
 
         $arguments = $this->processBuilder->createArgumentsForCommand('deptrac');
-        $arguments->add('analyze');
-        $arguments->addArgumentArray('--formatter=%s', $config['formatter']);
-        $arguments->add('--graphviz-display='.(int) $config['graphviz_display']);
-        $arguments->addOptionalArgument('--graphviz-dump-image=%s', $config['graphviz_dump_image']);
-        $arguments->addOptionalArgument('--graphviz-dump-dot=%s', $config['graphviz_dump_dot']);
-        $arguments->addOptionalArgument('--graphviz-dump-html=%s', $config['graphviz_dump_html']);
-        $arguments->addOptionalArgument('--junit-dump-xml=%s', $config['junit_dump_xml']);
-        $arguments->addOptionalArgument('--xml-dump=%s', $config['xml_dump']);
-        $arguments->addOptionalArgument('--baseline-dump=%s', $config['baseline_dump']);
-        $arguments->addOptionalArgument('%s', $config['depfile']);
+        $arguments->add('analyse');
+        $arguments->addOptionalArgument('--formatter=%s', $config['formatter']);
+        $arguments->addOptionalArgument('--output=%s', $config['output']);
+        $arguments->addOptionalArgument('--config-file=%s', $config['depfile']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();

--- a/test/Unit/Task/DeptracTest.php
+++ b/test/Unit/Task/DeptracTest.php
@@ -26,14 +26,8 @@ class DeptracTest extends AbstractExternalTaskTestCase
             [],
             [
                 'depfile' => null,
-                'formatter' => [],
-                'graphviz_display' => true,
-                'graphviz_dump_image' => null,
-                'graphviz_dump_dot' => null,
-                'graphviz_dump_html' => null,
-                'junit_dump_xml' => null,
-                'xml_dump' => null,
-                'baseline_dump' => null,
+                'formatter' => null,
+                'output' => null,
             ]
         ];
     }
@@ -101,75 +95,57 @@ class DeptracTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'deptrac',
             [
-                'analyze',
-                '--graphviz-display=1',
+                'analyse',
             ]
         ];
         yield 'formatter-graphviz' => [
             [
-                'formatter' => ['graphviz'],
+                'formatter' => 'graphviz-display',
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'deptrac',
             [
-                'analyze',
-                '--formatter=graphviz',
-                '--graphviz-display=1',
-            ]
-        ];
-        yield 'formatter-graphviz-no-display' => [
-            [
-                'formatter' => ['graphviz'],
-                'graphviz_display' => false,
-            ],
-            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
-            'deptrac',
-            [
-                'analyze',
-                '--formatter=graphviz',
-                '--graphviz-display=0',
+                'analyse',
+                '--formatter=graphviz-display',
             ]
         ];
         yield 'formatter-graphviz-dump-image' => [
             [
-                'formatter' => ['graphviz'],
-                'graphviz_dump_image' => 'file.jpg',
+                'formatter' => 'graphviz-image',
+                'output' => 'file.jpg',
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'deptrac',
             [
-                'analyze',
-                '--formatter=graphviz',
-                '--graphviz-display=1',
-                '--graphviz-dump-image=file.jpg',
+                'analyse',
+                '--formatter=graphviz-image',
+                '--output=file.jpg',
             ]
         ];
         yield 'formatter-graphviz-dump-dot' => [
             [
-                'formatter' => ['graphviz'],
-                'graphviz_dump_dot' => 'file.dot',
+                'formatter' => 'graphviz-dot',
+                'output' => 'file.dot',
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'deptrac',
             [
-                'analyze',
-                '--formatter=graphviz',
-                '--graphviz-display=1',
-                '--graphviz-dump-dot=file.dot',
+                'analyse',
+                '--formatter=graphviz-dot',
+                '--output=file.dot',
             ]
         ];
         yield 'formatter-graphviz-dump-html' => [
             [
-                'formatter' => ['graphviz'],
-                'graphviz_dump_html' => 'file.html',
+                'formatter' => 'graphviz-html',
+                'output' => 'file.html',
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'deptrac',
             [
-                'analyze',
-                '--formatter=graphviz',
-                '--graphviz-display=1',
-                '--graphviz-dump-html=file.html',
+                'analyse',
+                '--formatter=graphviz-html',
+                '--output=file.html',
             ]
         ];
         yield 'depfile' => [
@@ -179,51 +155,47 @@ class DeptracTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'deptrac',
             [
-                'analyze',
-                '--graphviz-display=1',
-                'depfile',
+                'analyse',
+                '--config-file=depfile',
             ]
         ];
         yield 'formatter-junit' => [
             [
-                'formatter' => ['junit'],
-                'junit_dump_xml' => 'junit.xml',
+                'formatter' => 'junit',
+                'output' => 'junit.xml',
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'deptrac',
             [
-                'analyze',
+                'analyse',
                 '--formatter=junit',
-                '--graphviz-display=1',
-                '--junit-dump-xml=junit.xml',
+                '--output=junit.xml',
             ]
         ];
         yield 'formatter-xml' => [
             [
-                'formatter' => ['xml'],
-                'xml_dump' => 'file.xml',
+                'formatter' => 'xml',
+                'output' => 'file.xml',
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'deptrac',
             [
-                'analyze',
+                'analyse',
                 '--formatter=xml',
-                '--graphviz-display=1',
-                '--xml-dump=file.xml',
+                '--output=file.xml',
             ]
         ];
         yield 'formatter-baseline' => [
             [
-                'formatter' => ['baseline'],
-                'baseline_dump' => 'baseline.yml',
+                'formatter' => 'baseline',
+                'output' => 'baseline.yaml',
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'deptrac',
             [
-                'analyze',
+                'analyse',
                 '--formatter=baseline',
-                '--graphviz-display=1',
-                '--baseline-dump=baseline.yml',
+                '--output=baseline.yaml',
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes (improvement ?)
| BC breaks?    | yes
| Deprecations? | no
| Documented?   | yes
| Fixed tickets |

Deptrac `analyse` command syntax was changed since 0.19.