### PR TITLE
New `no-dev` option for local-php-security-checker

### DIFF
--- a/doc/tasks/securitychecker/local.md
+++ b/doc/tasks/securitychecker/local.md
@@ -18,6 +18,7 @@ grumphp:
             lockfile: ./composer.lock
             format: ~
             run_always: false
+            no_dev: false
 ```
 
 **lockfile**
@@ -37,3 +38,9 @@ You can choose the format of the output. The available options are `ansi`, `json
 *Default: false*
 
 When this option is set to `false`, the task will only run when the `composer.lock` file has changed. If it is set to `true`, the `composer.lock` file will be checked on every commit.
+
+**no_dev**
+
+*Default: false*
+
+When this option is set to `true`, the task will skip packages under `require-dev`.

--- a/src/Task/SecurityCheckerLocal.php
+++ b/src/Task/SecurityCheckerLocal.php
@@ -20,11 +20,13 @@ class SecurityCheckerLocal extends AbstractExternalTask
             'lockfile' => './composer.lock',
             'format' => null,
             'run_always' => false,
+            'no_dev' => false,
         ]);
 
         $resolver->addAllowedTypes('lockfile', ['string']);
         $resolver->addAllowedTypes('format', ['null', 'string']);
         $resolver->addAllowedTypes('run_always', ['bool']);
+        $resolver->addAllowedTypes('no_dev', ['bool']);
 
         return $resolver;
     }
@@ -48,6 +50,7 @@ class SecurityCheckerLocal extends AbstractExternalTask
         $arguments = $this->processBuilder->createArgumentsForCommand('local-php-security-checker');
         $arguments->addOptionalArgument('--path=%s', $config['lockfile']);
         $arguments->addOptionalArgument('--format=%s', $config['format']);
+        $arguments->addOptionalArgument('--no-dev', $config['no_dev']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();

--- a/test/Unit/Task/SecurityCheckerLocalTest.php
+++ b/test/Unit/Task/SecurityCheckerLocalTest.php
@@ -28,6 +28,7 @@ class SecurityCheckerLocalTest extends AbstractExternalTaskTestCase
                 'lockfile' => './composer.lock',
                 'format' => null,
                 'run_always' => false,
+                'no_dev' => false,
             ]
         ];
     }
@@ -117,6 +118,18 @@ class SecurityCheckerLocalTest extends AbstractExternalTaskTestCase
             [
                 '--path=./composer.lock',
                 '--format=json'
+            ]
+        ];
+
+        yield 'no-dev' => [
+            [
+                'no_dev' => true,
+            ],
+            $this->mockContext(RunContext::class, ['composer.lock']),
+            'local-php-security-checker',
+            [
+                '--path=./composer.lock',
+                '--no-dev'
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets |

Since v1.2 (https://github.com/fabpot/local-php-security-checker/blob/main/CHANGELOG.md#120-2021-09-21) in the **local-php-security-checker** is available a new `--no-dev` option for skipping `require-dev` packages.