### PR TITLE
Incorrect global install for stylelint task

### DIFF
--- a/doc/tasks/stylelint.md
+++ b/doc/tasks/stylelint.md
@@ -5,7 +5,7 @@
 ## NPM
 If you'd like to install it globally:
 ```bash
-npm -g stylelint
+npm install -g stylelint
 ```
 
 If you'd like install it as a dev dependency of your project:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | 

I could not install stylelint without `install` in the command.

```
C:\Users\Johan>npm -g stylelint
npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path C:\Users\Johan/package.json
npm ERR! errno -4058
npm ERR! enoent ENOENT: no such file or directory, open 'C:\Users\Johan\package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\Johan\AppData\Local\npm-cache\_logs\2022-02-09T15_43_57_459Z-debug.log

C:\Users\Johan>npm install -g stylelint

added 179 packages, and audited 181 packages in 10s

found 0 vulnerabilities
```