### PR TITLE
Fix jsonlint.md syntax highlighting

### DIFF
--- a/doc/tasks/jsonlint.md
+++ b/doc/tasks/jsonlint.md
@@ -3,7 +3,7 @@
 The JsonLint task will lint all your json files.
 It lives under the `jsonlint` namespace and has following configurable parameters:
 
-```json
+```yaml
 # grumphp.yml
 grumphp:
     tasks:


### PR DESCRIPTION
Fix incorrect syntax highlighting in [jsonlint.md](https://github.com/phpro/grumphp/blob/6315b5270977ea7171bca3c76745c2c4287d89f4/doc/tasks/jsonlint.md)

Regards.