### PR TITLE
Task enabled

### DIFF
--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -139,6 +139,7 @@ grumphp:
         anytask:
             metadata:
                 blocking: true
+                enabled: true
                 label: null
                 priority: 0
                 task: null
@@ -151,6 +152,14 @@ grumphp:
 This option can be used to make a failing task non-blocking.
 By default all tasks will be marked as blocking.
 When a task is non-blocking, the errors will be displayed but the tests will pass.
+
+**enabled**
+
+*Default: true*
+
+This option can be used to disable task execution.
+By default all tasks will be enabled.
+This makes it possible to conditionally run a task by setting parameters or changing the value through an extension.
 
 **label**
 

--- a/spec/Task/Config/MetadataSpec.php
+++ b/spec/Task/Config/MetadataSpec.php
@@ -25,6 +25,7 @@ class MetadataSpec extends ObjectBehavior
         $result->shouldBe([
             'priority' => 0,
             'blocking' => true,
+            'enabled' => true,
             'task' => '',
             'label' => '',
         ]);
@@ -34,6 +35,7 @@ class MetadataSpec extends ObjectBehavior
     {
         $this->beConstructedWith([]);
         $this->priority()->shouldBe(0);
+        $this->isEnabled()->shouldBe(true);
         $this->isBlocking()->shouldBe(true);
         $this->task()->shouldBe('');
         $this->label()->shouldBe('');
@@ -49,6 +51,12 @@ class MetadataSpec extends ObjectBehavior
     {
         $this->beConstructedWith(['blocking' => true]);
         $this->isBlocking()->shouldBe(true);
+    }
+
+    public function it_knows_if_enabled(): void
+    {
+        $this->beConstructedWith(['enabled' => true]);
+        $this->isEnabled()->shouldBe(true);
     }
 
     public function it_knows_if_not_blocking(): void

--- a/src/Configuration/Compiler/TaskCompilerPass.php
+++ b/src/Configuration/Compiler/TaskCompilerPass.php
@@ -54,6 +54,12 @@ class TaskCompilerPass implements CompilerPassInterface
                 $metadataConfig
             ));
 
+            // Disabled tasks can be skipped
+            // This allows to conditionally disable tasks through parameters or by an extension.
+            if (!$metadata->isEnabled()) {
+                continue;
+            }
+
             // Configure task:
             $taskBuilder = new Definition($taskClass, [
                 new Reference($taskId),

--- a/src/Console/ApplicationConfigurator.php
+++ b/src/Console/ApplicationConfigurator.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputOption;
 class ApplicationConfigurator
 {
     const APP_NAME = 'GrumPHP';
-    const APP_VERSION = '1.8.0';
+    const APP_VERSION = '1.8.1';
 
     public function configure(Application $application): void
     {

--- a/src/Task/Config/Metadata.php
+++ b/src/Task/Config/Metadata.php
@@ -26,6 +26,7 @@ class Metadata
             $resolver->setDefaults([
                 'priority' => 0,
                 'blocking' => true,
+                'enabled' => true,
                 'task' => '',
                 'label' => '',
             ]);
@@ -42,6 +43,11 @@ class Metadata
     public function isBlocking(): bool
     {
         return (bool) $this->metadata['blocking'];
+    }
+
+    public function isEnabled(): bool
+    {
+        return (bool) $this->metadata['enabled'];
     }
 
     public function task(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | 


This PR allows for dynamically enable a task. Usefull for conventions so that you can configurably run a task or not through parameters.

Examples:


```yaml 
# grumphp.yaml
parameters:
    run_security_advisories: true
grumphp:
    tasks:
        securitychecker_roave:
            jsonfile: ./composer.json
            lockfile: ./composer.lock
            run_always: true
            metadata:
                enabled: "%run_security_advisories%"
```



