### PR TITLE
Restore PHP 7.4 compatibility

### DIFF
--- a/.github/workflows/grumphp.yml
+++ b/.github/workflows/grumphp.yml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest, macos-latest] #windows-latest currently not working
-                php-versions: ['8.0', '8.1']
+                php-versions: ['7.4', '8.0', '8.1']
                 composer-options: ['', '--prefer-lowest']
                 composer-versions: ['composer:v2']
             fail-fast: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,8 @@ environment:
       php_version: 8.1
     - dependencies: highest
       php_version: 8.0
+    - dependencies: highest
+      php_version: 7.4
 
   project_directory: c:\projects\grumphp
   composer_directory: c:\tools\composer

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "composer-plugin-api": "~2.0",
         "amphp/amp": "^2.6",

--- a/src/Composer/GrumPHPPlugin.php
+++ b/src/Composer/GrumPHPPlugin.php
@@ -222,10 +222,8 @@ class GrumPHPPlugin implements PluginInterface, EventSubscriberInterface
         // Windows requires double double quotes
         // https://bugs.php.net/bug.php?id=49139
         $windowsIsInsane = function (string $command): string {
-            return $command;
             // Looks like this is not needed anymore since PHP8 - even though the bug is still open.
-            // Leaving this here for reference if the bug pops up again for some poeple!
-            // return $this->runsOnWindows() ? '"'.$command.'"' : $command;
+            return $this->runsOnWindows() ? '"'.$command.'"' : $command;
         };
 
         // Run command

--- a/src/Composer/GrumPHPPlugin.php
+++ b/src/Composer/GrumPHPPlugin.php
@@ -223,7 +223,10 @@ class GrumPHPPlugin implements PluginInterface, EventSubscriberInterface
         // https://bugs.php.net/bug.php?id=49139
         $windowsIsInsane = function (string $command): string {
             // Looks like this is not needed anymore since PHP8 - even though the bug is still open.
-            return $this->runsOnWindows() ? '"'.$command.'"' : $command;
+            if (PHP_MAJOR_VERSION === 7) {
+                return $this->runsOnWindows() ? '"'.$command.'"' : $command;
+            }
+            return $command;
         };
 
         // Run command

--- a/src/Task/TwigCs.php
+++ b/src/Task/TwigCs.php
@@ -57,7 +57,13 @@ class TwigCs extends AbstractExternalTask
         $arguments->addOptionalArgument('--ansi', true);
 
         // removes all NULL, FALSE and Empty Strings
-        $exclude = array_filter($config['exclude'], static fn (mixed $exclude): bool => $exclude && $exclude !== '');
+        $exclude = array_filter(
+            $config['exclude'],
+            /**
+             * @param mixed $exclude
+             */
+            static fn ($exclude): bool => $exclude && $exclude !== ''
+        );
         $arguments->addArgumentArray('--exclude=%s', $exclude);
 
         if ($context instanceof GitPreCommitContext) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #957

https://github.com/phpro/grumphp/pull/956 introduced PHP 8 compatibility. However, it also removed PHP 7.4 compatibility for no reason that I can see. Since PHP 7.4 and 8 are both still officially maintained, this package should support both. It's important that they are supported simultaneously in a single release so that downstream projects with fixed dependencies can run on both PHP 7.4 and 8.

<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [ ] Are the dependencies added to the composer.json suggestions?
- [ ] Is the doc/tasks.md file updated?
- [ ] Are the task parameters documented?
- [ ] Is the task registered in the tasks.yml file?
- [ ] Does the task contains phpunit tests?
- [ ] Is the configuration having logical allowed types?
- [ ] Does the task run in the correct context?
- [ ] Is the `run()` method readable?
- [ ] Is the `run()` method using the configuration correctly?
- [ ] Are all CI services returning green?
