### PR TITLE
Fix broken tests

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -21,4 +21,12 @@
     <stubs>
         <file name="stubs/Amp.php"/>
     </stubs>
+
+    <issueHandlers>
+        <UndefinedDocblockClass>
+            <errorLevel type="suppress">
+                <referencedClass name="UnitEnum" />
+            </errorLevel>
+        </UndefinedDocblockClass>
+    </issueHandlers>
 </psalm>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Documented?   | yes/no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

Tests are broken in HEAD, caused by some Symfony components recently upgrading from 5 to 6.

I fixed the issues in Psalm per advice in these upstream issues:

- https://github.com/vimeo/psalm/issues/7738
- https://github.com/symfony/symfony/issues/45609

The bigger issue is a Symfony EventDispatcher deprecated constructor that apparently went unnoticed and was recently completely removed. I'm unable to grok the documentation on how to fix it:

- https://github.com/symfony/event-dispatcher/commit/0bc2e0d8ba8a6eb353a42d19890f57a3dee410a5
- https://symfony.com/doc/current/components/event_dispatcher.html

Have you ever considered implementing deprecation scanning or committing your composer.lock and using Dependabot or Violinist to update dependencies? This wouldn't avoid these problems, but it would at least catch them earlier and pinpoint the cause without breaking tests in HEAD.

<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [ ] Are the dependencies added to the composer.json suggestions?
- [ ] Is the doc/tasks.md file updated?
- [ ] Are the task parameters documented?
- [ ] Is the task registered in the tasks.yml file?
- [ ] Does the task contains phpunit tests?
- [ ] Is the configuration having logical allowed types?
- [ ] Does the task run in the correct context?
- [ ] Is the `run()` method readable?
- [ ] Is the `run()` method using the configuration correctly?
- [ ] Are all CI services returning green?
