### PR TITLE
Infection: Add missing `show_mutations` (incl. verbose mode)

### DIFF
--- a/doc/tasks/infection.md
+++ b/doc/tasks/infection.md
@@ -21,6 +21,7 @@ grumphp:
             test_framework: ~
             only_covered: false
             show_mutations: false
+            verbose: false
             configuration: ~
             min_msi: ~
             min_covered_msi: ~
@@ -58,6 +59,13 @@ Run the mutation testing only for covered by tests files.
 *Default: false*
 
 Show escaped (and non-covered in verbose mode) mutations to the console.
+
+
+**verbose**
+
+*Default: false*
+
+In verbose mode, non-covered escaped mutations will be shown in the console as well.
 
 
 **configuration**

--- a/doc/tasks/infection.md
+++ b/doc/tasks/infection.md
@@ -20,6 +20,7 @@ grumphp:
             threads: ~
             test_framework: ~
             only_covered: false
+            show_mutations: false
             configuration: ~
             min_msi: ~
             min_covered_msi: ~
@@ -50,6 +51,13 @@ This is the name of a test framework to use. Currently Infection supports `PhpUn
 *Default: false*
 
 Run the mutation testing only for covered by tests files.
+
+
+**show_mutations**
+
+*Default: false*
+
+Show escaped (and non-covered in verbose mode) mutations to the console.
 
 
 **configuration**

--- a/src/Task/Infection.php
+++ b/src/Task/Infection.php
@@ -24,6 +24,7 @@ class Infection extends AbstractExternalTask
             'threads' => null,
             'test_framework' => null,
             'only_covered' => false,
+            'show_mutations' => false,
             'configuration' => null,
             'min_msi' => null,
             'min_covered_msi' => null,
@@ -35,6 +36,7 @@ class Infection extends AbstractExternalTask
         $resolver->addAllowedTypes('threads', ['null', 'int']);
         $resolver->addAllowedTypes('test_framework', ['null', 'string']);
         $resolver->addAllowedTypes('only_covered', ['bool']);
+        $resolver->addAllowedTypes('show_mutations', ['bool']);
         $resolver->addAllowedTypes('configuration', ['null', 'string']);
         $resolver->addAllowedTypes('min_msi', ['null', 'integer']);
         $resolver->addAllowedTypes('min_covered_msi', ['null', 'integer']);
@@ -73,6 +75,7 @@ class Infection extends AbstractExternalTask
         $arguments->addOptionalArgument('--threads=%s', $config['threads']);
         $arguments->addOptionalArgument('--test-framework=%s', $config['test_framework']);
         $arguments->addOptionalArgument('--only-covered', $config['only_covered']);
+        $arguments->addOptionalArgument('--show-mutations', $config['show_mutations']);
         $arguments->addOptionalArgument('--configuration=%s', $config['configuration']);
         $arguments->addOptionalArgument('--min-msi=%s', $config['min_msi']);
         $arguments->addOptionalArgument('--min-covered-msi=%s', $config['min_covered_msi']);

--- a/src/Task/Infection.php
+++ b/src/Task/Infection.php
@@ -25,6 +25,7 @@ class Infection extends AbstractExternalTask
             'test_framework' => null,
             'only_covered' => false,
             'show_mutations' => false,
+            'verbose' => false,
             'configuration' => null,
             'min_msi' => null,
             'min_covered_msi' => null,
@@ -37,6 +38,7 @@ class Infection extends AbstractExternalTask
         $resolver->addAllowedTypes('test_framework', ['null', 'string']);
         $resolver->addAllowedTypes('only_covered', ['bool']);
         $resolver->addAllowedTypes('show_mutations', ['bool']);
+        $resolver->addAllowedTypes('verbose', ['bool']);
         $resolver->addAllowedTypes('configuration', ['null', 'string']);
         $resolver->addAllowedTypes('min_msi', ['null', 'integer']);
         $resolver->addAllowedTypes('min_covered_msi', ['null', 'integer']);
@@ -76,6 +78,7 @@ class Infection extends AbstractExternalTask
         $arguments->addOptionalArgument('--test-framework=%s', $config['test_framework']);
         $arguments->addOptionalArgument('--only-covered', $config['only_covered']);
         $arguments->addOptionalArgument('--show-mutations', $config['show_mutations']);
+        $arguments->addOptionalArgument('-v', $config['verbose']);
         $arguments->addOptionalArgument('--configuration=%s', $config['configuration']);
         $arguments->addOptionalArgument('--min-msi=%s', $config['min_msi']);
         $arguments->addOptionalArgument('--min-covered-msi=%s', $config['min_covered_msi']);

--- a/test/Unit/Task/InfectionTest.php
+++ b/test/Unit/Task/InfectionTest.php
@@ -28,6 +28,7 @@ class InfectionTest extends AbstractExternalTaskTestCase
                 'threads' => null,
                 'test_framework' => null,
                 'only_covered' => false,
+                'show_mutations' => false,
                 'configuration' => null,
                 'min_msi' => null,
                 'min_covered_msi' => null,
@@ -146,6 +147,18 @@ class InfectionTest extends AbstractExternalTaskTestCase
                 '--no-interaction',
                 '--ignore-msi-with-no-mutations',
                 '--only-covered'
+            ]
+        ];
+        yield 'show-mutations' => [
+            [
+                'show_mutations' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'infection',
+            [
+                '--no-interaction',
+                '--ignore-msi-with-no-mutations',
+                '--show-mutations'
             ]
         ];
         yield 'configuration' => [

--- a/test/Unit/Task/InfectionTest.php
+++ b/test/Unit/Task/InfectionTest.php
@@ -29,6 +29,7 @@ class InfectionTest extends AbstractExternalTaskTestCase
                 'test_framework' => null,
                 'only_covered' => false,
                 'show_mutations' => false,
+                'verbose' => false,
                 'configuration' => null,
                 'min_msi' => null,
                 'min_covered_msi' => null,
@@ -159,6 +160,18 @@ class InfectionTest extends AbstractExternalTaskTestCase
                 '--no-interaction',
                 '--ignore-msi-with-no-mutations',
                 '--show-mutations'
+            ]
+        ];
+        yield 'verbose' => [
+            [
+                'verbose' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'infection',
+            [
+                '--no-interaction',
+                '--ignore-msi-with-no-mutations',
+                '-v'
             ]
         ];
         yield 'configuration' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes

Infection does have cli options to directly show the escaped mutations on run (apart from the logfiles). 

However, by default, these are disabled, but can be enabled with the option `--show-mutations`. In verbose mode (`-v`), the non-covered escaped mutations will be shown as well.

@see https://infection.github.io/guide/command-line-options.html#show-mutations-or-s
