### PR TITLE
Fix retrieving git worktree path

### DIFF
--- a/src/Locator/GitRepositoryDirLocator.php
+++ b/src/Locator/GitRepositoryDirLocator.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace GrumPHP\Locator;
 
+use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Util\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 class GitRepositoryDirLocator
 {
@@ -36,7 +39,16 @@ class GitRepositoryDirLocator
         $gitRepositoryDir = $matches[1];
 
         if ($this->filesystem->isAbsolutePath($gitRepositoryDir)) {
-            return $gitRepositoryDir;
+            if (!$this->filesystem->isFile($gitRepositoryDir . DIRECTORY_SEPARATOR . 'commondir')) {
+                throw new RuntimeException('The git directory for worktree could not be found.');
+            }
+            $worktreeRelativeRoot = trim($this->filesystem->readPath($gitRepositoryDir . '/commondir'));
+            return $this->filesystem->realpath(
+                $this->filesystem->makePathAbsolute(
+                    $worktreeRelativeRoot,
+                    $gitRepositoryDir
+                )
+            );
         }
 
         return $this->filesystem->buildPath(

--- a/src/Locator/GitRepositoryDirLocator.php
+++ b/src/Locator/GitRepositoryDirLocator.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace GrumPHP\Locator;
 
-use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Util\Filesystem;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
 
 class GitRepositoryDirLocator
 {
@@ -38,28 +35,55 @@ class GitRepositoryDirLocator
 
         $gitRepositoryDir = $matches[1];
 
-        if ($this->filesystem->isAbsolutePath($gitRepositoryDir)) {
-            if (!$this->filesystem->isFile($gitRepositoryDir.DIRECTORY_SEPARATOR.'commondir')) {
-                throw new RuntimeException('The git directory for worktree could not be found.');
-            }
-
-            $worktreeRelativeRoot = trim(
-                $this->filesystem->readPath(
-                    $gitRepositoryDir.DIRECTORY_SEPARATOR.'commondir'
-                )
-            );
-
-            return $this->filesystem->realpath(
-                $this->filesystem->makePathAbsolute(
-                    $worktreeRelativeRoot,
-                    $gitRepositoryDir
-                )
-            );
+        if ($this->isWorktree($gitRepositoryDir)) {
+            return $this->locateWorktreeRoot($gitRepositoryDir);
         }
 
         return $this->filesystem->buildPath(
             dirname($gitDir),
             $gitRepositoryDir
+        );
+    }
+
+    /**
+     * If a given path (from gitdir value) is absolute and there is a commondir file, it is
+     * a worktree.
+     */
+    private function isWorktree(string $gitDir): bool
+    {
+        return $this->filesystem->isAbsolutePath($gitDir)
+            && $this->filesystem->isFile($gitDir.DIRECTORY_SEPARATOR.'commondir');
+    }
+
+    /**
+     * Retreiving repository dir for worktree nominally returns path to the configured worktree,
+     * which does not hold hooks. We need to resolve the actual repository root.
+     *
+     * Example directory structure:
+     * ```
+     * /project
+     *   .git/
+     *     .git/hooks/
+     *     .git/worktrees/
+     *       worktree1
+     *         commondir: relative path to /project/.git
+     * /worktree1
+     *   .git: file with path to /project/.git/worktrees/worktree1
+     * ```
+     */
+    private function locateWorktreeRoot(string $gitRepositoryDir): string
+    {
+        $worktreeRelativeRoot = trim(
+            $this->filesystem->readPath(
+                $gitRepositoryDir.DIRECTORY_SEPARATOR.'commondir'
+            )
+        );
+
+        return $this->filesystem->realpath(
+            $this->filesystem->makePathAbsolute(
+                $worktreeRelativeRoot,
+                $gitRepositoryDir
+            )
         );
     }
 }

--- a/src/Locator/GitRepositoryDirLocator.php
+++ b/src/Locator/GitRepositoryDirLocator.php
@@ -39,10 +39,16 @@ class GitRepositoryDirLocator
         $gitRepositoryDir = $matches[1];
 
         if ($this->filesystem->isAbsolutePath($gitRepositoryDir)) {
-            if (!$this->filesystem->isFile($gitRepositoryDir . DIRECTORY_SEPARATOR . 'commondir')) {
+            if (!$this->filesystem->isFile($gitRepositoryDir.DIRECTORY_SEPARATOR.'commondir')) {
                 throw new RuntimeException('The git directory for worktree could not be found.');
             }
-            $worktreeRelativeRoot = trim($this->filesystem->readPath($gitRepositoryDir . '/commondir'));
+
+            $worktreeRelativeRoot = trim(
+                $this->filesystem->readPath(
+                    $gitRepositoryDir.DIRECTORY_SEPARATOR.'commondir'
+                )
+            );
+
             return $this->filesystem->realpath(
                 $this->filesystem->makePathAbsolute(
                     $worktreeRelativeRoot,

--- a/test/Unit/Locator/GitRepositoryDirLocatorTest.php
+++ b/test/Unit/Locator/GitRepositoryDirLocatorTest.php
@@ -31,7 +31,7 @@ class GitRepositoryDirLocatorTest extends FilesystemTestCase
 
         $this->filesystem               = new Filesystem();
         $this->locator                  = new GitRepositoryDirLocator($this->filesystem);
-        $this->gitDir = $this->workspace . DIRECTORY_SEPARATOR . '.git';
+        $this->gitDir                   = $this->workspace . DIRECTORY_SEPARATOR . '.git';
     }
 
     /**
@@ -69,7 +69,10 @@ class GitRepositoryDirLocatorTest extends FilesystemTestCase
      */
     public function it_can_locate_git_dir_in_workspaces(): void
     {
-        $this->filesystem->dumpFile($this->gitDir, 'gitdir: /dev/null');
-        $this->assertEquals('/dev/null', $this->locator->locate($this->gitDir));
+        $worktreeRoot = $this->workspace.'/git_root/worktrees/git_worktree/';
+        mkdir($worktreeRoot, 0777, true);
+        $this->filesystem->dumpFile($worktreeRoot.'/commondir', '../..');
+        $this->filesystem->dumpFile($this->gitDir, 'gitdir: '.$this->workspace.'/git_root/worktrees/git_worktree');
+        $this->assertEquals($this->workspace.'/git_root', $this->locator->locate($this->gitDir));
     }
 }

--- a/test/Unit/Locator/GitRepositoryDirLocatorTest.php
+++ b/test/Unit/Locator/GitRepositoryDirLocatorTest.php
@@ -73,6 +73,6 @@ class GitRepositoryDirLocatorTest extends FilesystemTestCase
         mkdir($worktreeRoot, 0777, true);
         $this->filesystem->dumpFile($worktreeRoot.'/commondir', '../..');
         $this->filesystem->dumpFile($this->gitDir, 'gitdir: '.$this->workspace.'/git_root/worktrees/git_worktree');
-        $this->assertEquals($this->workspace.'/git_root', $this->locator->locate($this->gitDir));
+        $this->assertEquals($this->workspace.DIRECTORY_SEPARATOR.'git_root', $this->locator->locate($this->gitDir));
     }
 }

--- a/test/Unit/Locator/GitRepositoryDirLocatorTest.php
+++ b/test/Unit/Locator/GitRepositoryDirLocatorTest.php
@@ -69,10 +69,11 @@ class GitRepositoryDirLocatorTest extends FilesystemTestCase
      */
     public function it_can_locate_git_dir_in_workspaces(): void
     {
-        $worktreeRoot = $this->workspace.'/git_root/worktrees/git_worktree/';
-        mkdir($worktreeRoot, 0777, true);
-        $this->filesystem->dumpFile($worktreeRoot.'/commondir', '../..');
-        $this->filesystem->dumpFile($this->gitDir, 'gitdir: '.$this->workspace.'/git_root/worktrees/git_worktree');
-        $this->assertEquals($this->workspace.DIRECTORY_SEPARATOR.'git_root', $this->locator->locate($this->gitDir));
+        $ourWorktreeProject = $this->workspace.'/project1/';
+        $worktreeGitRoot = $this->gitDir.'/worktrees/worktree1/';
+        mkdir($worktreeGitRoot, 0777, true);
+        $this->filesystem->dumpFile($worktreeGitRoot.'/commondir', '../..');
+        $this->filesystem->dumpFile($ourWorktreeProject.'/.git', 'gitdir: '.$this->gitDir.'/worktrees/worktree1');
+        $this->assertEquals($this->gitDir, $this->locator->locate($this->gitDir));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
@veewee Actually, I've made a bad assumption previously submitting PR (#1003) for git worktree path - git does store absolute path in `.git` file, but that's absolute path to the current worktree, while hooks are fired from common worktree root directory.

The hierarchy looks something like:

```
git-worktree
 > hooks
 > worktrees
   > worktree-1
      > commondir
   > worktree-2
      > commondir
worktree-1
  > .git
worktree-2
  > .git
```

With current patch, we are actually getting absolute path to worktree and reading the path from `commondir` file, which usually points up in hierarchy, to the root of git directory.
