### PR TITLE
Remove Monolog v3 as it is not currently compatible with GrumPHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/collections": "^1.6.8",
         "gitonomy/gitlib": "^1.3",
         "laravel/serializable-closure": "^1.1",
-        "monolog/monolog": "^2.0 || ^3.0",
+        "monolog/monolog": "^2.0",
         "ondram/ci-detector": "^4.0",
         "psr/container": "^1.1 || ^2.0",
         "seld/jsonlint": "~1.8",


### PR DESCRIPTION
Fixes #1020