### PR TITLE
Add 'cache_file' parameter to 'deptrac' task.

### DIFF
--- a/doc/tasks/deptrac.md
+++ b/doc/tasks/deptrac.md
@@ -12,10 +12,17 @@ namespace and has following configurable parameters:
 grumphp:
     tasks:
         deptrac:
+            cache_file: ~
             depfile: ~
             formatter: ~
             output: ~
 ```
+
+**cache_file**
+
+*Default: null*
+
+Set location where cache file will be stored. Example: `/var/www/src/.deptrac.cache`
 
 **depfile**
 

--- a/src/Task/Deptrac.php
+++ b/src/Task/Deptrac.php
@@ -20,11 +20,13 @@ class Deptrac extends AbstractExternalTask
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
+            'cache_file' => null,
             'depfile' => null,
             'formatter' => null,
             'output' => null,
         ]);
 
+        $resolver->addAllowedTypes('cache_file', ['null', 'string']);
         $resolver->addAllowedTypes('depfile', ['null', 'string']);
         $resolver->addAllowedTypes('formatter', ['null', 'string']);
         $resolver->addAllowedTypes('output', ['null', 'string']);
@@ -50,6 +52,7 @@ class Deptrac extends AbstractExternalTask
         $arguments->add('analyse');
         $arguments->addOptionalArgument('--formatter=%s', $config['formatter']);
         $arguments->addOptionalArgument('--output=%s', $config['output']);
+        $arguments->addOptionalArgument('--cache-file=%s', $config['cache_file']);
         $arguments->addOptionalArgument('--config-file=%s', $config['depfile']);
 
         $process = $this->processBuilder->buildProcess($arguments);

--- a/test/Unit/Task/DeptracTest.php
+++ b/test/Unit/Task/DeptracTest.php
@@ -25,6 +25,7 @@ class DeptracTest extends AbstractExternalTaskTestCase
         yield 'defaults' => [
             [],
             [
+                'cache_file' => null,
                 'depfile' => null,
                 'formatter' => null,
                 'output' => null,

--- a/test/Unit/Task/DeptracTest.php
+++ b/test/Unit/Task/DeptracTest.php
@@ -99,6 +99,17 @@ class DeptracTest extends AbstractExternalTaskTestCase
                 'analyse',
             ]
         ];
+        yield 'cache-file' => [
+            [
+                'cache_file' => 'example.cache',
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'deptrac',
+            [
+                'analyse',
+                '--cache-file=example.cache',
+            ]
+        ];
         yield 'formatter-graphviz' => [
             [
                 'formatter' => 'graphviz-display',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | 

Deptrac provides a `--cache-file` option to control where its cache file will be stored. This PR adds support for it with a new `grumphp.tasks.deptrac.cache_file` option in `grumphp.yml`, i.e.:

```
grumphp:
    tasks:
        deptrac:
            cache_file: ~
```

I updated the corresponding unit test. I didn't see any functional tests, but I manually tested it and it worked great.