### PR TITLE
Check if PHP is available before trying to run Grumphp (wip)

### DIFF
--- a/resources/hooks/local/commit-msg
+++ b/resources/hooks/local/commit-msg
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+if ! command -v $(EXEC_GRUMPHP_COMMAND) &> /dev/null
+then
+    echo "PHP could not be found... Skipping commit-msg hook."
+    exit
+fi
+
 #
 # Run the hook command.
 # Note: this will be replaced by the real command during copy.

--- a/resources/hooks/local/pre-commit
+++ b/resources/hooks/local/pre-commit
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+if ! command -v $(EXEC_GRUMPHP_COMMAND) &> /dev/null
+then
+    echo "PHP could not be found... Skipping pre-commit hook."
+    exit
+fi
+
 #
 # Run the hook command.
 # Note: this will be replaced by the real command during copy.


### PR DESCRIPTION
Hi,

Do you think such minor update in the hooks are justified in Grumphp?

Thanks

| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no

# New Task Checklist:

- [ ] Are the dependencies added to the composer.json suggestions?
- [ ] Is the doc/tasks.md file updated?
- [ ] Are the task parameters documented?
- [ ] Is the task registered in the tasks.yml file?
- [ ] Does the task contains phpunit tests?
- [ ] Is the configuration having logical allowed types?
- [ ] Does the task run in the correct context?
- [ ] Is the `run()` method readable?
- [ ] Is the `run()` method using the configuration correctly?
- [ ] Are all CI services returning green?
