### PR TITLE
Add color on phpcsfixer

### DIFF
--- a/doc/tasks/phpcsfixer.md
+++ b/doc/tasks/phpcsfixer.md
@@ -20,6 +20,7 @@ grumphp:
             allow_risky: ~
             cache_file: ~
             config: ~
+            format: 'txt'
             rules: []
             using_cache: ~
             config_contains_finder: true
@@ -49,6 +50,13 @@ When no cache_file is set, the default file `.php_cs.cache` will be used.
 
 By default, the `.php_cs` wil be used.
 You can specify an alternate location for this file by changing this option.
+
+**format**
+
+*Default: txt*
+
+By default, the `txt` format wil be used.
+You can find more reporters on [PHPCSFixer repository](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/master/src/Console/Report/FixReport).
 
 **rules**
 

--- a/src/Task/PhpCsFixer.php
+++ b/src/Task/PhpCsFixer.php
@@ -28,6 +28,7 @@ class PhpCsFixer extends AbstractExternalTask
             'allow_risky' => null,
             'cache_file' => null,
             'config' => null,
+            'format' => 'txt',
             'rules' => [],
             'using_cache' => null,
             'config_contains_finder' => true,
@@ -39,6 +40,7 @@ class PhpCsFixer extends AbstractExternalTask
         $resolver->addAllowedTypes('allow_risky', ['null', 'bool']);
         $resolver->addAllowedTypes('cache_file', ['null', 'string']);
         $resolver->addAllowedTypes('config', ['null', 'string']);
+        $resolver->addAllowedTypes('format', ['null', 'string']);
         $resolver->addAllowedTypes('rules', ['array']);
         $resolver->addAllowedTypes('using_cache', ['null', 'bool']);
         $resolver->addAllowedTypes('config_contains_finder', ['bool']);
@@ -71,11 +73,12 @@ class PhpCsFixer extends AbstractExternalTask
         $this->formatter->resetCounter();
 
         $arguments = $this->processBuilder->createArgumentsForCommand('php-cs-fixer');
-        $arguments->add('--format=json');
         $arguments->add('--dry-run');
+        $arguments->addOptionalArgument('--format=%s', $config['format']);
         $arguments->addOptionalBooleanArgument('--allow-risky=%s', $config['allow_risky'], 'yes', 'no');
         $arguments->addOptionalArgument('--cache-file=%s', $config['cache_file']);
         $arguments->addOptionalArgument('--config=%s', $config['config']);
+        $arguments->addOptionalArgument('--ansi', true);
 
         if ($rules = $config['rules']) {
             $arguments->add(sprintf(
@@ -104,7 +107,6 @@ class PhpCsFixer extends AbstractExternalTask
             return FixableProcessResultProvider::provide(
                 TaskResult::createFailed($this, $context, $this->formatter->format($process)),
                 function () use ($arguments): Process {
-                    $arguments->removeElement('--format=json');
                     $arguments->removeElement('--dry-run');
                     return $this->processBuilder->buildProcess($arguments);
                 }

--- a/test/Unit/Task/PhpCsFixerTest.php
+++ b/test/Unit/Task/PhpCsFixerTest.php
@@ -38,6 +38,7 @@ class PhpCsFixerTest extends AbstractExternalTaskTestCase
                 'allow_risky' => null,
                 'cache_file' => null,
                 'config' => null,
+                'format' => 'txt',
                 'rules' => [],
                 'using_cache' => null,
                 'config_contains_finder' => true,
@@ -115,8 +116,9 @@ class PhpCsFixerTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'php-cs-fixer',
             [
-                '--format=json',
                 '--dry-run',
+                '--format=txt',
+                '--ansi',
                 '--verbose',
                 'fix',
             ]
@@ -128,9 +130,10 @@ class PhpCsFixerTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'php-cs-fixer',
             [
-                '--format=json',
                 '--dry-run',
+                '--format=txt',
                 '--allow-risky=yes',
+                '--ansi',
                 '--verbose',
                 'fix',
             ]
@@ -142,9 +145,10 @@ class PhpCsFixerTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'php-cs-fixer',
             [
-                '--format=json',
                 '--dry-run',
+                '--format=txt',
                 '--cache-file=cachefile',
+                '--ansi',
                 '--verbose',
                 'fix',
             ]
@@ -156,9 +160,24 @@ class PhpCsFixerTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'php-cs-fixer',
             [
-                '--format=json',
                 '--dry-run',
+                '--format=txt',
                 '--config=config.php',
+                '--ansi',
+                '--verbose',
+                'fix',
+            ]
+        ];
+        yield 'format' => [
+            [
+                'format' => 'json'
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'php-cs-fixer',
+            [
+                '--dry-run',
+                '--format=json',
+                '--ansi',
                 '--verbose',
                 'fix',
             ]
@@ -170,8 +189,9 @@ class PhpCsFixerTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'php-cs-fixer',
             [
-                '--format=json',
                 '--dry-run',
+                '--format=txt',
+                '--ansi',
                 '--rules=foo,bar',
                 '--verbose',
                 'fix',
@@ -188,8 +208,9 @@ class PhpCsFixerTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'php-cs-fixer',
             [
-                '--format=json',
                 '--dry-run',
+                '--format=txt',
+                '--ansi',
                 '--rules='.json_encode($rules),
                 '--verbose',
                 'fix',
@@ -202,8 +223,9 @@ class PhpCsFixerTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'php-cs-fixer',
             [
-                '--format=json',
                 '--dry-run',
+                '--format=txt',
+                '--ansi',
                 '--using-cache=yes',
                 '--verbose',
                 'fix',
@@ -216,8 +238,9 @@ class PhpCsFixerTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'php-cs-fixer',
             [
-                '--format=json',
                 '--dry-run',
+                '--format=txt',
+                '--ansi',
                 'fix',
             ]
         ];
@@ -228,8 +251,9 @@ class PhpCsFixerTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'php-cs-fixer',
             [
-                '--format=json',
                 '--dry-run',
+                '--format=txt',
+                '--ansi',
                 '--verbose',
                 '--diff',
                 'fix',
@@ -242,8 +266,9 @@ class PhpCsFixerTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'php-cs-fixer',
             [
-                '--format=json',
                 '--dry-run',
+                '--format=txt',
+                '--ansi',
                 '--verbose',
                 'fix',
             ]
@@ -255,8 +280,9 @@ class PhpCsFixerTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'php-cs-fixer',
             [
-                '--format=json',
                 '--dry-run',
+                '--format=txt',
+                '--ansi',
                 '--verbose',
                 'fix',
                 'hello.php',
@@ -270,8 +296,9 @@ class PhpCsFixerTest extends AbstractExternalTaskTestCase
             $this->mockContext(GitPreCommitContext::class, ['hello.php', 'hello2.php']),
             'php-cs-fixer',
             [
-                '--format=json',
                 '--dry-run',
+                '--format=txt',
+                '--ansi',
                 '--verbose',
                 'fix',
                 'hello.php',
@@ -285,8 +312,9 @@ class PhpCsFixerTest extends AbstractExternalTaskTestCase
             $this->mockContext(GitPreCommitContext::class, ['hello.php', 'hello2.php']),
             'php-cs-fixer',
             [
-                '--format=json',
                 '--dry-run',
+                '--format=txt',
+                '--ansi',
                 '--path-mode=intersection',
                 '--verbose',
                 'fix',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 

Hello, 
A picture is worth a thousand words, I let you see the result, which is so much more pleasant.

Before
![before](https://user-images.githubusercontent.com/6593252/178121604-a741cc00-5085-4650-bd24-a707336d5f1c.png)

After
![after](https://user-images.githubusercontent.com/6593252/178121612-29ec23bf-862b-412c-9724-61da564db219.png)

The inspiration comes from ECS.
https://github.com/phpro/grumphp/blob/3ec61c1678c4c370f02b05fef606fd561d923c8e/src/Task/Ecs.php#L71