### PR TITLE
Make it possible to null out ascii config

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -63,7 +63,10 @@ class Configuration implements ConfigurationInterface
         $rootNode->children()->arrayNode('extensions')->scalarPrototype();
 
         // ascii
-        $ascii = $rootNode->children()->arrayNode('ascii')->addDefaultsIfNotSet();
+        $ascii = $rootNode->children()->arrayNode('ascii')->addDefaultsIfNotSet()->treatNullLike([
+            'failed' => null,
+            'succeeded' => null,
+        ]);
         $ascii->children()->variableNode('failed')->defaultValue('grumphp-grumpy.txt');
         $ascii->children()->variableNode('succeeded')->defaultValue('grumphp-happy.txt');
 

--- a/test/Unit/Configuration/ConfigurationTest.php
+++ b/test/Unit/Configuration/ConfigurationTest.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace GrumPHPTest\Unit\Configuration;
+
+use GrumPHP\Configuration\Configuration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Processor;
+
+class ConfigurationTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideConfigs
+     */
+    public function it_can_be_configuered(array $config, array $expected): void
+    {
+        $actual = $this->parse($config);
+
+        self::assertArrayContains($expected, $actual);
+    }
+
+    public function provideConfigs()
+    {
+        yield 'ascii_not_set' => [
+            [],
+            ['ascii' => [
+                'failed' => 'grumphp-grumpy.txt',
+                'succeeded' => 'grumphp-happy.txt',
+            ]]
+        ];
+        yield 'ascii_nulled_out_items' => [
+            ['ascii' => [
+                'failed' => null,
+                'succeeded' => null,
+            ]],
+            ['ascii' => [
+                'failed' => null,
+                'succeeded' => null,
+            ]]
+        ];
+        yield 'ascii_custom' => [
+            ['ascii' => [
+                'failed' => 'custom-failure.txt',
+                'succeeded' => 'custom-happy.txt',
+            ]],
+            ['ascii' => [
+                'failed' => 'custom-failure.txt',
+                'succeeded' => 'custom-happy.txt',
+            ]]
+        ];
+        yield 'ascii_nulled_out' => [
+            ['ascii' => null],
+            ['ascii' => [
+                'failed' => null,
+                'succeeded' => null,
+            ]]
+        ];
+    }
+
+    private function parse(array $config): array
+    {
+        $configuration = new Configuration();
+        $processor = new Processor();
+
+        return $processor->process($configuration->getConfigTreeBuilder()->buildTree(), ['grumphp' => $config]);
+    }
+
+    private function assertArrayContains(array $needle, array $haystack)
+    {
+        self::assertSame(
+            array_intersect_key($haystack, $needle),
+            $needle
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #1022

Fixes `ascii: null` config.
