### PR TITLE
Update phpArkitect default value for stop_on_failure to false

### DIFF
--- a/doc/tasks/phparkitect.md
+++ b/doc/tasks/phparkitect.md
@@ -38,6 +38,6 @@ This can be useful to debug problems and to understand if there are problems wit
 
 **stop_on_failure**
 
-*Default: null*
+*Default: false*
 
 With this option the process will end immediately after the first violation.


### PR DESCRIPTION
Follow-up of #1038

the default value of the stop_on_failure option is no longer null, but false.