### PR TITLE
Update ParaTest documentation

### DIFF
--- a/doc/tasks/paratest.md
+++ b/doc/tasks/paratest.md
@@ -24,7 +24,6 @@ grumphp:
             phpunit: null
             configuration: null
             runner: null
-            debugger: null
             coverage-clover: null
             coverage-html: null
             coverage-php: null


### PR DESCRIPTION
The debugger option [got removed](https://github.com/phpro/grumphp/commit/ac14a1d8d12d4ad953764bf6dd3e9a6e10510677) 

However the option is still in the documentation