### PR TITLE
Include filename in AbstractVisitor error messages

### DIFF
--- a/src/Parser/Php/Visitor/AbstractVisitor.php
+++ b/src/Parser/Php/Visitor/AbstractVisitor.php
@@ -27,7 +27,7 @@ class AbstractVisitor extends NodeVisitorAbstract implements ContextAwareVisitor
     protected function addError(string $message, int $line = -1, string $type = ParseError::TYPE_ERROR): void
     {
         $errors = $this->context->getErrors();
-        $fileName = $this->context->getFile()->getPath();
+        $fileName = $this->context->getFile()->getPathname();
         $errors->add(new PhpParserError($type, $message, $fileName, $line));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #1046

Changed the method `getPath` to `getPathname` to include the name of the file along with the path. 

With the given example and steps to reproduce from issue #1046 the output is now the expected result.

**Previous result:**
> [ERROR] src/resources: No "declare(strict_types = 1)" found in file!

**New result:**
> [ERROR] src/resources/nl.php: No "declare(strict_types = 1)" found in file!
