### PR TITLE
Added deprecation to whitelist_patterns with null value

### DIFF
--- a/src/Task/ESLint.php
+++ b/src/Task/ESLint.php
@@ -11,6 +11,7 @@ use GrumPHP\Runner\TaskResultInterface;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\Process;
 
@@ -49,13 +50,18 @@ class ESLint extends AbstractExternalTask
         $resolver->addAllowedTypes('no_eslintrc', ['bool']);
         $resolver->addAllowedTypes('quiet', ['bool']);
 
-        $resolver->setDeprecated('whitelist_patterns', 'phpro/grumphp', '1.13', function (Options $options, $value): string {
-            if (null === $value) {
-                return 'Parsing "null" to option "whitelist_patterns" is deprecated, pass an array instead.';
-            }
+        $resolver->setDeprecated(
+            'whitelist_patterns',
+            'phpro/grumphp',
+            '1.13',
+            function (Options $options, $value): string {
+                if (null === $value) {
+                    return 'Parsing "null" to option "whitelist_patterns" is deprecated, pass an array instead.';
+                }
 
-            return '';
-        });
+                return '';
+            }
+        );
 
         return $resolver;
     }

--- a/src/Task/ESLint.php
+++ b/src/Task/ESLint.php
@@ -23,8 +23,8 @@ class ESLint extends AbstractExternalTask
             // Task config options
             'bin' => null,
             'triggered_by' => ['js', 'jsx', 'ts', 'tsx', 'vue'],
-            'whitelist_patterns' => null,
-            
+            'whitelist_patterns' => [],
+
             // ESLint native config options
             'config' => null,
             'ignore_path' => null,
@@ -39,7 +39,7 @@ class ESLint extends AbstractExternalTask
         $resolver->addAllowedTypes('bin', ['null', 'string']);
         $resolver->addAllowedTypes('whitelist_patterns', ['null', 'array']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
-        
+
         // ESLint native config options
         $resolver->addAllowedTypes('config', ['null', 'string']);
         $resolver->addAllowedTypes('ignore_path', ['null', 'string']);
@@ -48,6 +48,14 @@ class ESLint extends AbstractExternalTask
         $resolver->addAllowedTypes('max_warnings', ['null', 'integer']);
         $resolver->addAllowedTypes('no_eslintrc', ['bool']);
         $resolver->addAllowedTypes('quiet', ['bool']);
+
+        $resolver->setDeprecated('whitelist_patterns', 'phpro/grumphp', '1.13', function (Options $options, $value): string {
+            if (null === $value) {
+                return 'Parsing "null" to option "whitelist_patterns" is deprecated, pass an array instead.';
+            }
+
+            return '';
+        });
 
         return $resolver;
     }

--- a/src/Task/ESLint.php
+++ b/src/Task/ESLint.php
@@ -53,7 +53,7 @@ class ESLint extends AbstractExternalTask
         $resolver->setDeprecated(
             'whitelist_patterns',
             'phpro/grumphp',
-            '1.13',
+            '1.14',
             function (Options $options, $value): string {
                 if (null === $value) {
                     return 'Parsing "null" to option "whitelist_patterns" is deprecated, pass an array instead.';

--- a/test/Unit/Task/ESLintTest.php
+++ b/test/Unit/Task/ESLintTest.php
@@ -29,7 +29,7 @@ class ESLintTest extends AbstractExternalTaskTestCase
                 // Task config options
                 'bin' => null,
                 'triggered_by' => ['js', 'jsx', 'ts', 'tsx', 'vue'],
-                'whitelist_patterns' => null,
+                'whitelist_patterns' => [],
 
                 // ESLint native config options
                 'config' => null,
@@ -206,5 +206,12 @@ class ESLintTest extends AbstractExternalTaskTestCase
                 'hello2.js',
             ]
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_triggers_deprecation_on_null() {
+        self::assertTrue(ESLint::getConfigurableOptions()->isDeprecated('whitelist_patterns'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Documented?   | no
| Fixed tickets | #911

Adds deprecation flag to whitelist_patterns when providing a null value.
Also changed the default value to an empty array.


