### PR TITLE
Adding PHPCS specific rule (-s) to display which rule triggered the e…

### DIFF
--- a/doc/tasks/phpcs.md
+++ b/doc/tasks/phpcs.md
@@ -30,7 +30,7 @@ grumphp:
             sniffs: []
             triggered_by: [php]
             exclude: []
-            
+            show_sniffs_error_path: true
 ```
 
 **standard**
@@ -129,6 +129,12 @@ This is a list of extensions to be sniffed. This list is also passed to phpcs us
 *Default: []*
 
 A list of rules that should not be checked. Leave this option blank to run all configured rules for the selected standard.
+
+**show_sniffs_error_path**
+
+*Default: true*
+
+Displays the sniff that triggered the error, allowing you to more easily find the specific rules with their namespaces.
 
 ## Framework presets
 

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -42,6 +42,7 @@ class Phpcs extends AbstractExternalTask
             'report' => 'full',
             'report_width' => null,
             'exclude' => [],
+            'show_sniffs_error_path' => true
         ]);
 
         $resolver->addAllowedTypes('standard', ['array', 'null', 'string']);
@@ -57,6 +58,7 @@ class Phpcs extends AbstractExternalTask
         $resolver->addAllowedTypes('report', ['null', 'string']);
         $resolver->addAllowedTypes('report_width', ['null', 'int']);
         $resolver->addAllowedTypes('exclude', ['array']);
+        $resolver->addAllowedTypes('show_sniffs_error_path', ['bool']);
 
         return $resolver;
     }
@@ -153,6 +155,7 @@ class Phpcs extends AbstractExternalTask
         $arguments->addOptionalCommaSeparatedArgument('--sniffs=%s', $config['sniffs']);
         $arguments->addOptionalCommaSeparatedArgument('--ignore=%s', $config['ignore_patterns']);
         $arguments->addOptionalCommaSeparatedArgument('--exclude=%s', $config['exclude']);
+        $arguments->addOptionalArgument('-s', $config['show_sniffs_error_path']);
 
         return $arguments;
     }

--- a/test/Unit/Task/PhpcsTest.php
+++ b/test/Unit/Task/PhpcsTest.php
@@ -49,6 +49,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 'report' => 'full',
                 'report_width' => null,
                 'exclude' => [],
+                'show_sniffs_error_path' => true
             ]
         ];
     }
@@ -160,6 +161,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
             [
                 '--extensions=php',
                 '--report=full',
+                '-s',
                 '--report-json',
                 $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
@@ -174,6 +176,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--standard=PSR1,PSR2',
                 '--extensions=php',
                 '--report=full',
+                '-s',
                 '--report-json',
                 $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
@@ -187,6 +190,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
             [
                 '--extensions=php,phtml',
                 '--report=full',
+                '-s',
                 '--report-json',
                 $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
@@ -201,6 +205,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--extensions=php',
                 '--tab-width=4',
                 '--report=full',
+                '-s',
                 '--report-json',
                 $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
@@ -215,6 +220,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--extensions=php',
                 '--encoding=UTF-8',
                 '--report=full',
+                '-s',
                 '--report-json',
                 $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
@@ -228,6 +234,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
             [
                 '--extensions=php',
                 '--report=small',
+                '-s',
                 '--report-json',
                 $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
@@ -242,6 +249,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--extensions=php',
                 '--report=full',
                 '--report-width=20',
+                '-s',
                 '--report-json',
                 $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
@@ -256,6 +264,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--extensions=php',
                 '--report=full',
                 '--severity=5',
+                '-s',
                 '--report-json',
                 $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
@@ -270,6 +279,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--extensions=php',
                 '--report=full',
                 '--error-severity=5',
+                '-s',
                 '--report-json',
                 $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
@@ -284,6 +294,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--extensions=php',
                 '--report=full',
                 '--warning-severity=5',
+                '-s',
                 '--report-json',
                 $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
@@ -298,6 +309,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--extensions=php',
                 '--report=full',
                 '--sniffs=sniff1,sniff2',
+                '-s',
                 '--report-json',
                 $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
@@ -312,6 +324,7 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--extensions=php',
                 '--report=full',
                 '--ignore=ignore1,ignore2',
+                '-s',
                 '--report-json',
                 $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]
@@ -326,6 +339,20 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 '--extensions=php',
                 '--report=full',
                 '--exclude=exclude1,exclude2',
+                '-s',
+                '--report-json',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
+            ]
+        ];
+        yield 's' => [
+            [
+                'show_sniffs_error_path' => false
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'phpcs',
+            [
+                '--extensions=php',
+                '--report=full',
                 '--report-json',
                 $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]


### PR DESCRIPTION
### Summary

| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | **yes**
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

This PR adds the `-s` which displays the rule that triggered the error when running phpcs. 

As an example : 

![image](https://user-images.githubusercontent.com/49562288/208147904-17b19a36-a447-4004-9191-23091a17b450.png)

### Configuration

The configuration is set to `true` by default so that developers can more easily find the rule that blocks the validation of `phpcs`.

As `s` was not clear enough, the rule was renamed to `show_sniffs_error_path` inside `grumphp` configuration.

<!-- Are you creating a new task? Make sure to complete this checklist: -->

### Reference

The reference of the `phpcs` configuration can be found here : https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting#printing-full-and-summary-reports