### PR TITLE
Add support for grumphp.dist.{yml,yaml}

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Having trouble installing GrumPHP? Find out how to:
 
 ## Configuration
 
-Some things in GrumPHP can be configured in a `grumphp.yml` or `grumphp.yml.dist` file in the root of your project (the directory where you run the grumphp command).
+Some things in GrumPHP can be configured in a `grumphp.yml` or `grumphp.yml.dist` or `grumphp.dist.yml` file in the root of your project (the directory where you run the grumphp command).
 You can specify a custom config filename and location in `composer.json` or in the `--config` option of the console commands.
 
 ```yaml

--- a/src/Locator/GuessedPathsLocator.php
+++ b/src/Locator/GuessedPathsLocator.php
@@ -110,6 +110,8 @@ class GuessedPathsLocator
                 'grumphp.yaml',
                 'grumphp.yml.dist',
                 'grumphp.yaml.dist',
+                'grumphp.dist.yml',
+                'grumphp.dist.yaml',
             ]
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #1069 

I didn't modify `GrumPHPTest\Unit\Locator` or `GrumPHPTest\Unit\Util\FilesystemTest` as all current naming options for `.yaml` weren't present. 
