### PR TITLE
Fix workflow deprecations

### DIFF
--- a/.github/workflows/grumphp.yml
+++ b/.github/workflows/grumphp.yml
@@ -31,7 +31,7 @@ jobs:
                 composer --version
             - name: Get composer cache directory
               id: composercache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
             - name: Cache dependencies
               uses: actions/cache@v3
               with:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | -

Fixes the deprecations/warnings in the GitHub Actions workflow.

As per the warning, without this change the actions will error and fail starting from June.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/