### PR TITLE
Add support for devenv

### DIFF
--- a/resources/hooks/local/pre-commit
+++ b/resources/hooks/local/pre-commit
@@ -12,5 +12,14 @@ DIFF=$(git -c diff.mnemonicprefix=false -c diff.noprefix=false --no-pager diff -
 $(ENV)
 export GRUMPHP_GIT_WORKING_DIR="$(git rev-parse --show-toplevel)"
 
-# Run GrumPHP
-(cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | $(EXEC_GRUMPHP_COMMAND) $(HOOK_COMMAND) '--skip-success-output')
+# Add path to devenv (if available)
+export PATH="$HOME/.nix-profile/bin:$PATH"
+
+# Check if devenv command is available
+if command -v devenv >/dev/null 2>&1; then
+  # Run GrumPHP inside devenv shell
+  (cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | devenv shell $(EXEC_GRUMPHP_COMMAND) $(HOOK_COMMAND) '--skip-success-output')
+else
+  # Run GrumPHP without devenv
+  (cd "${HOOK_EXEC_PATH}" && printf "%s\n" "${DIFF}" | $(EXEC_GRUMPHP_COMMAND) $(HOOK_COMMAND) '--skip-success-output')
+fi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 

This PR adds support for usage of GrumPHP when developing with a [devenv](https://devenv.sh/) environment. 

## Problem

Devenv basically allows to run different PHP versions per project (amongst other services), but unlike Docker the services run natively.

In my setup, devenv is running in a WSL2 environment (Ubuntu). Doing commits from within WSL2 is not a problem, because direnv is automatically hooking into each bash command so that the correct PHP version is used for example. 

The problem is that my git client (Fork) is running in Windows itself (and is proxying its git commands to WSL2 via [wslgit](https://github.com/andy-5/wslgit)). Therefore when the `pre-commit` hook is running its PHP command, the devenv shell is not loaded, so it's using the wrong PHP version, resulting in Psalm errors (but there might be others of course due to the wrong environment being used).

## Solution

Alter the `pre-commit` hook install script so that the GrumPHP command is running inside the devenv shell

---
PS: I also wondered if the `commit-msg` hook should also be adapted, but since that's only using git afaics it's not necessary. 