### PR TITLE
Config options resolver

### DIFF
--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -197,7 +197,7 @@ When your task is written, you have to register it to the service manager and ad
 
 interface TaskInterface
 {
-    public static function getConfigurableOptions(): OptionsResolver;
+    public static function getConfigurableOptions(): ConfigOptionsResolver;
     public function canRunInContext(ContextInterface $context): bool;
     public function run(ContextInterface $context): TaskResultInterface;
     public function getConfig(): TaskConfigInterface;
@@ -205,7 +205,7 @@ interface TaskInterface
 }
 ```
 
-* `getConfigurableOptions`: This method has to return all configurable options for the task.
+* `getConfigurableOptions`: This method has to return all configurable options for the task. 
 * `canRunInContext`: Tells GrumPHP if it can run in `pre-commit`, `commit-msg` or `run` context.
 * `run`: Executes the task and returns a result
 * `getConfig`: Provides the resolved configuration for the task or an empty config for newly instantiated tasks.
@@ -230,6 +230,21 @@ You now registered your custom task! Pretty cool right?!
 
 
 ❗**Note:** Be careful with adding dependencies to your task. When GrumPHP runs in parallel mode, the task and all of its dependencies get serialized in order to run in a separate process. This could lead to a delay when e.g. serializing a depenency container or lead to errors on unserializable objects. [More info](https://github.com/phpro/grumphp/issues/815)
+
+❗**Note:** You can use Symfony's options-resolver to help configure the options for your task. However, if you want your task to work together with the `grumphp-shim` (phar) distribution, you will have to make sure to use `ConfigOptionsResolver::fromClosure()` This is because the Symfony's options-resolver gets scoped in the phar. Example:
+
+```php
+public static function getConfigurableOptions(): ConfigOptionsResolver
+{
+    $resolver = new OptionsResolver();
+
+    // ..... your config
+
+    return ConfigOptionsResolver::fromClosure(
+        static fn (array $options): array => $resolver->resolve($options)
+    );
+}
+```
 
 
 ## Testing your custom task.

--- a/resources/config/runner.yml
+++ b/resources/config/runner.yml
@@ -85,6 +85,7 @@ services:
         arguments:
             - '@GrumPHP\Configuration\Model\ParallelConfig'
             - '@GrumPHP\Runner\Parallel\PoolFactory'
+            - '@grumphp.io'
         tags:
             - { name: 'grumphp.task_handler', priority: 150 }
     GrumPHP\Runner\TaskHandler\Middleware\ErrorHandlingTaskHandlerMiddleware:

--- a/spec/Configuration/Resolver/TaskConfigResolverSpec.php
+++ b/spec/Configuration/Resolver/TaskConfigResolverSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\GrumPHP\Configuration\Resolver;
 
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use const GrumPHP\Exception\TaskConfigResolverException;
 use GrumPHP\Exception\TaskConfigResolverException;
 use GrumPHP\Runner\TaskResult;
@@ -25,8 +26,8 @@ class TaskConfigResolverSpec extends ObjectBehavior
     {
         $this->shouldHaveType(TaskConfigResolver::class);
     }
-    
-    public function it_can_last_task_names(): void
+
+    public function it_can_list_task_names(): void
     {
         $this->beConstructedWith([
             'task1' => get_class($this->mockTask()),
@@ -44,15 +45,12 @@ class TaskConfigResolverSpec extends ObjectBehavior
         ]);
     }
 
-    public function it_fetches_resolver_for_task_only_once(): void
+    public function it_fetches_resolver_for_task(): void
     {
         $task1 = $this->mockTask();
         $this->beConstructedWith([$taskName = 'task1' => get_class($task1)]);
-        $result = $this->fetchByName($taskName);
-        $result->shouldBeLike($task1::getConfigurableOptions());
-
-        $result2 = $this->fetchByName($taskName);
-        $result2->shouldBe($result);
+        $result = $this->fetchByName($taskName)->resolve([]);
+        $result->shouldBeLike($task1::getConfigurableOptions()->resolve([]));
     }
 
     public function it_fails_when_task_is_unknown(): void
@@ -75,11 +73,11 @@ class TaskConfigResolverSpec extends ObjectBehavior
     {
         return new class implements TaskInterface
         {
-            public static function getConfigurableOptions(): OptionsResolver
+            public static function getConfigurableOptions(): ConfigOptionsResolver
             {
                 $options = new OptionsResolver();
                 $options->setDefault('class', static::class);
-                return $options;
+                return ConfigOptionsResolver::fromOptionsResolver($options);
             }
 
             public function canRunInContext(ContextInterface $context): bool

--- a/src/Configuration/Resolver/TaskConfigResolver.php
+++ b/src/Configuration/Resolver/TaskConfigResolver.php
@@ -5,20 +5,15 @@ declare(strict_types=1);
 namespace GrumPHP\Configuration\Resolver;
 
 use GrumPHP\Exception\TaskConfigResolverException;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\TaskInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TaskConfigResolver
 {
     /**
      * @var array<string, string>
      */
-    private $taskMap = [];
-
-    /**
-     * @var array<OptionsResolver>
-     */
-    private $cachedResolvers = [];
+    private $taskMap;
 
     public function __construct(array $taskMap)
     {
@@ -43,22 +38,17 @@ class TaskConfigResolver
         return $resolver->resolve($config);
     }
 
-    public function fetchByName(string $taskName): OptionsResolver
+    public function fetchByName(string $taskName): ConfigOptionsResolver
     {
         if (!array_key_exists($taskName, $this->taskMap)) {
             throw TaskConfigResolverException::unknownTask($taskName);
         }
 
-        // Try to use cached version first:
         $class = $this->taskMap[$taskName];
-        if (array_key_exists($class, $this->cachedResolvers)) {
-            return $this->cachedResolvers[$class];
-        }
-
         if (!class_exists($class) || !is_subclass_of($class, TaskInterface::class)) {
             throw TaskConfigResolverException::unknownClass($class);
         }
 
-        return $this->cachedResolvers[$class] = $class::getConfigurableOptions();
+        return $class::getConfigurableOptions();
     }
 }

--- a/src/Linter/Json/JsonLinter.php
+++ b/src/Linter/Json/JsonLinter.php
@@ -62,6 +62,9 @@ class JsonLinter implements LinterInterface
         $this->detectKeyConflicts = $detectKeyConflicts;
     }
 
+    /**
+     * @return int-mask-of<JsonParser::*>
+     */
     private function calculateFlags(): int
     {
         $flags = 0;

--- a/src/Task/AbstractLinterTask.php
+++ b/src/Task/AbstractLinterTask.php
@@ -36,7 +36,7 @@ abstract class AbstractLinterTask implements TaskInterface
         $this->config = new EmptyTaskConfig();
     }
 
-    public static function getConfigurableOptions(): OptionsResolver
+    protected static function sharedOptionsResolver(): OptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([

--- a/src/Task/AbstractParserTask.php
+++ b/src/Task/AbstractParserTask.php
@@ -45,7 +45,7 @@ abstract class AbstractParserTask implements TaskInterface
         }
     }
 
-    public static function getConfigurableOptions(): OptionsResolver
+    protected static function sharedOptionsResolver(): OptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([

--- a/src/Task/Ant.php
+++ b/src/Task/Ant.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Ant extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -30,7 +31,7 @@ class Ant extends AbstractExternalTask
         $resolver->addAllowedTypes('build_file', ['null', 'string']);
         $resolver->addAllowedTypes('task', ['null', 'string']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/Atoum.php
+++ b/src/Task/Atoum.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Atoum extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -38,7 +39,7 @@ class Atoum extends AbstractExternalTask
         $resolver->addAllowedTypes('methods', ['array']);
         $resolver->addAllowedTypes('tags', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/Behat.php
+++ b/src/Task/Behat.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Behat extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -34,7 +35,7 @@ class Behat extends AbstractExternalTask
         $resolver->addAllowedTypes('profile', ['null', 'string']);
         $resolver->addAllowedTypes('stop_on_failure', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/Brunch.php
+++ b/src/Task/Brunch.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Brunch extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -34,7 +35,7 @@ class Brunch extends AbstractExternalTask
         $resolver->addAllowedTypes('debug', ['bool']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/CloverCoverage.php
+++ b/src/Task/CloverCoverage.php
@@ -6,6 +6,7 @@ namespace GrumPHP\Task;
 
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Config\EmptyTaskConfig;
 use GrumPHP\Task\Config\TaskConfigInterface;
 use GrumPHP\Task\Context\ContextInterface;
@@ -47,7 +48,7 @@ class CloverCoverage implements TaskInterface
         return $this->config;
     }
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
 
@@ -63,7 +64,7 @@ class CloverCoverage implements TaskInterface
 
         $resolver->setRequired('clover_file');
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/Codeception.php
+++ b/src/Task/Codeception.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Codeception extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -32,7 +33,7 @@ class Codeception extends AbstractExternalTask
         $resolver->addAllowedTypes('test', ['null', 'string']);
         $resolver->addAllowedTypes('fail_fast', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/Composer.php
+++ b/src/Task/Composer.php
@@ -8,6 +8,7 @@ use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -34,7 +35,7 @@ class Composer extends AbstractExternalTask
         $this->filesystem = $filesystem;
     }
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -55,7 +56,7 @@ class Composer extends AbstractExternalTask
         $resolver->addAllowedTypes('with_dependencies', ['bool']);
         $resolver->addAllowedTypes('strict', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/ComposerNormalize.php
+++ b/src/Task/ComposerNormalize.php
@@ -6,6 +6,7 @@ use GrumPHP\Fixer\Provider\FixableProcessResultProvider;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -22,7 +23,7 @@ class ComposerNormalize extends AbstractExternalTask
         return $context instanceof GitPreCommitContext || $context instanceof RunContext;
     }
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -41,7 +42,7 @@ class ComposerNormalize extends AbstractExternalTask
         $resolver->addAllowedTypes('no_update_lock', ['bool']);
         $resolver->addAllowedTypes('verbose', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function run(ContextInterface $context): TaskResultInterface

--- a/src/Task/ComposerRequireChecker.php
+++ b/src/Task/ComposerRequireChecker.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ComposerRequireChecker extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -32,7 +33,7 @@ class ComposerRequireChecker extends AbstractExternalTask
         $resolver->addAllowedTypes('ignore_parse_errors', ['bool']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/ComposerScript.php
+++ b/src/Task/ComposerScript.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ComposerScript extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -30,7 +31,7 @@ class ComposerScript extends AbstractExternalTask
         $resolver->addAllowedTypes('script', ['string']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/Config/ConfigOptionsResolver.php
+++ b/src/Task/Config/ConfigOptionsResolver.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace GrumPHP\Task\Config;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class ConfigOptionsResolver
+{
+    /**
+     * @var \Closure(array): array
+     */
+    private \Closure $resolver;
+
+    /**
+     * @param \Closure(array): array $resolver
+     */
+    private function __construct(\Closure $resolver)
+    {
+        $this->resolver = $resolver;
+    }
+
+    public static function fromOptionsResolver(OptionsResolver $optionsResolver): self
+    {
+        return self::fromClosure(
+            static fn (array $options): array => $optionsResolver->resolve($options)
+        );
+    }
+
+    /**
+     * @param \Closure(array): array $closure
+     */
+    public static function fromClosure(\Closure $closure): self
+    {
+        return new self($closure);
+    }
+
+    public function resolve(array $data): array
+    {
+        return ($this->resolver)($data);
+    }
+}

--- a/src/Task/Config/Metadata.php
+++ b/src/Task/Config/Metadata.php
@@ -18,7 +18,7 @@ class Metadata
         $this->metadata = self::getConfigurableOptions()->resolve($metadata);
     }
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): \GrumPHP\Task\Config\ConfigOptionsResolver
     {
         static $resolver;
         if (null === $resolver) {
@@ -32,7 +32,7 @@ class Metadata
             ]);
         }
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function priority(): int

--- a/src/Task/Deptrac.php
+++ b/src/Task/Deptrac.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Deptrac extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -32,7 +33,7 @@ class Deptrac extends AbstractExternalTask
         $resolver->addAllowedTypes('formatter', ['null', 'string']);
         $resolver->addAllowedTypes('output', ['null', 'string']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/DoctrineOrm.php
+++ b/src/Task/DoctrineOrm.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class DoctrineOrm extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -30,7 +31,7 @@ class DoctrineOrm extends AbstractExternalTask
         $resolver->addAllowedTypes('skip_sync', ['bool']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/ESLint.php
+++ b/src/Task/ESLint.php
@@ -9,6 +9,7 @@ use GrumPHP\Fixer\Provider\FixableProcessResultProvider;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -21,7 +22,7 @@ use Symfony\Component\Process\Process;
  */
 class ESLint extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -67,7 +68,7 @@ class ESLint extends AbstractExternalTask
             }
         );
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/Ecs.php
+++ b/src/Task/Ecs.php
@@ -10,6 +10,7 @@ use GrumPHP\Fixer\Provider\FixableProcessResultProvider;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -21,7 +22,7 @@ use Symfony\Component\Process\Process;
  */
 class Ecs extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -42,7 +43,7 @@ class Ecs extends AbstractExternalTask
         $resolver->addAllowedTypes('triggered_by', ['array']);
         $resolver->addAllowedTypes('files_on_pre_commit', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/FileSize.php
+++ b/src/Task/FileSize.php
@@ -6,6 +6,7 @@ namespace GrumPHP\Task;
 
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Config\EmptyTaskConfig;
 use GrumPHP\Task\Config\TaskConfigInterface;
 use GrumPHP\Task\Context\ContextInterface;
@@ -25,7 +26,7 @@ class FileSize implements TaskInterface
         $this->config = new EmptyTaskConfig();
     }
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -36,7 +37,7 @@ class FileSize implements TaskInterface
         $resolver->addAllowedTypes('max_size', ['string', 'integer']);
         $resolver->addAllowedTypes('ignore_patterns', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function getConfig(): TaskConfigInterface

--- a/src/Task/Gherkin.php
+++ b/src/Task/Gherkin.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Gherkin extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -29,7 +30,7 @@ class Gherkin extends AbstractExternalTask
         $resolver->addAllowedTypes('align', ['null', 'string']);
         $resolver->addAllowedValues('align', [null, 'left', 'right']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/Git/Blacklist.php
+++ b/src/Task/Git/Blacklist.php
@@ -10,6 +10,7 @@ use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
 use GrumPHP\Task\AbstractExternalTask;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -36,7 +37,7 @@ class Blacklist extends AbstractExternalTask
         parent::__construct($processBuilder, $formatter);
     }
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -57,7 +58,7 @@ class Blacklist extends AbstractExternalTask
         $resolver->addAllowedTypes('match_word', ['bool']);
         $resolver->addAllowedTypes('ignore_patterns', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/Git/BranchName.php
+++ b/src/Task/Git/BranchName.php
@@ -8,6 +8,7 @@ use Gitonomy\Git\Exception\ProcessException;
 use GrumPHP\Git\GitRepository;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Config\EmptyTaskConfig;
 use GrumPHP\Task\Config\TaskConfigInterface;
 use GrumPHP\Task\Context\ContextInterface;
@@ -48,7 +49,7 @@ class BranchName implements TaskInterface
         return $this->config;
     }
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -63,7 +64,7 @@ class BranchName implements TaskInterface
         $resolver->addAllowedTypes('additional_modifiers', ['string']);
         $resolver->addAllowedTypes('allow_detached_head', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool
@@ -104,14 +105,14 @@ class BranchName implements TaskInterface
 
             $additionalModifiersArray = array_filter(str_split($config['additional_modifiers']));
             array_map([$regex, 'addPatternModifier'], $additionalModifiersArray);
-            
+
             if (preg_match((string) $regex, $name)) {
                 if ($isBlacklisted) {
                     $errors[] = sprintf('Matched whitelist rule: %s (IGNORED due to presence in blacklist)', $rule);
-                    
+
                     continue;
                 }
-                
+
                 return TaskResult::createPassed($this, $context);
             }
 

--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -8,6 +8,7 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Git\GitRepository;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Config\EmptyTaskConfig;
 use GrumPHP\Task\Config\TaskConfigInterface;
 use GrumPHP\Task\Context\ContextInterface;
@@ -29,7 +30,7 @@ class CommitMessage implements TaskInterface
      */
     private $repository;
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -60,7 +61,7 @@ class CommitMessage implements TaskInterface
         $resolver->addAllowedTypes('matchers', ['array']);
         $resolver->addAllowedTypes('additional_modifiers', ['string']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function __construct(GitRepository $repository)

--- a/src/Task/Grunt.php
+++ b/src/Task/Grunt.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Grunt extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -30,7 +31,7 @@ class Grunt extends AbstractExternalTask
         $resolver->addAllowedTypes('task', ['null', 'string']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/Gulp.php
+++ b/src/Task/Gulp.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Gulp extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -30,7 +31,7 @@ class Gulp extends AbstractExternalTask
         $resolver->addAllowedTypes('task', ['null', 'string']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/Infection.php
+++ b/src/Task/Infection.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Infection extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
 
@@ -47,7 +48,7 @@ class Infection extends AbstractExternalTask
         $resolver->addAllowedTypes('ignore_patterns', ['array']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/JsonLint.php
+++ b/src/Task/JsonLint.php
@@ -8,6 +8,7 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Linter\Json\JsonLinter;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -23,16 +24,16 @@ class JsonLint extends AbstractLinterTask
      */
     protected $linter;
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
-        $resolver = parent::getConfigurableOptions();
+        $resolver = self::sharedOptionsResolver();
         $resolver->setDefaults([
             'detect_key_conflicts' => false,
         ]);
 
         $resolver->addAllowedTypes('detect_key_conflicts', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/Kahlan.php
+++ b/src/Task/Kahlan.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Kahlan extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -63,7 +64,7 @@ class Kahlan extends AbstractExternalTask
         $resolver->addAllowedTypes('cc', ['bool']);
         $resolver->addAllowedTypes('autoclear', ['null', 'array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/Make.php
+++ b/src/Task/Make.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Make extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -30,7 +31,7 @@ class Make extends AbstractExternalTask
         $resolver->addAllowedTypes('task', ['null', 'string']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/NpmScript.php
+++ b/src/Task/NpmScript.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class NpmScript extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -34,7 +35,7 @@ class NpmScript extends AbstractExternalTask
         $resolver->addAllowedTypes('is_run_task', ['bool']);
         $resolver->addAllowedTypes('silent', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/Paratest.php
+++ b/src/Task/Paratest.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Paratest extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults(
@@ -54,7 +55,7 @@ class Paratest extends AbstractExternalTask
         $resolver->addAllowedTypes('testsuite', ['null', 'string']);
         $resolver->addAllowedTypes('verbose', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/Pest.php
+++ b/src/Task/Pest.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Pest extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -32,7 +33,7 @@ class Pest extends AbstractExternalTask
         $resolver->addAllowedTypes('group', ['array']);
         $resolver->addAllowedTypes('always_execute', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/Phan.php
+++ b/src/Task/Phan.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Phan extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults(
@@ -34,7 +35,7 @@ class Phan extends AbstractExternalTask
         $resolver->addAllowedTypes('config_file', ['string']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/Phing.php
+++ b/src/Task/Phing.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Phing extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -30,7 +31,7 @@ class Phing extends AbstractExternalTask
         $resolver->addAllowedTypes('task', ['null', 'string']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/Php7cc.php
+++ b/src/Task/Php7cc.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Php7cc extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -30,7 +31,7 @@ class Php7cc extends AbstractExternalTask
         $resolver->addAllowedTypes('level', ['null', 'string']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/PhpArkitect.php
+++ b/src/Task/PhpArkitect.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class PhpArkitect extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -30,7 +31,7 @@ class PhpArkitect extends AbstractExternalTask
         $resolver->addAllowedTypes('target_php_version', ['null', 'string']);
         $resolver->addAllowedTypes('stop_on_failure', ['boolean']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/PhpCpd.php
+++ b/src/Task/PhpCpd.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class PhpCpd extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -36,7 +37,7 @@ class PhpCpd extends AbstractExternalTask
         $resolver->addAllowedTypes('min_tokens', ['int']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/PhpCsFixer.php
+++ b/src/Task/PhpCsFixer.php
@@ -8,6 +8,7 @@ use GrumPHP\Fixer\Provider\FixableProcessResultProvider;
 use GrumPHP\Formatter\PhpCsFixerFormatter;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -24,7 +25,7 @@ class PhpCsFixer extends AbstractExternalTask
      */
     protected $formatter;
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -49,7 +50,7 @@ class PhpCsFixer extends AbstractExternalTask
         $resolver->addAllowedTypes('diff', ['bool']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/PhpLint.php
+++ b/src/Task/PhpLint.php
@@ -8,6 +8,7 @@ use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\InputWritingProcessRunner;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -19,7 +20,7 @@ use Symfony\Component\Process\Process;
  */
 class PhpLint extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -36,7 +37,7 @@ class PhpLint extends AbstractExternalTask
         $resolver->addAllowedTypes('ignore_patterns', ['array']);
         $resolver->setAllowedTypes('triggered_by', 'array');
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/PhpMd.php
+++ b/src/Task/PhpMd.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class PhpMd extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -35,7 +36,7 @@ class PhpMd extends AbstractExternalTask
         $resolver->addAllowedTypes('ruleset', ['array']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/PhpMnd.php
+++ b/src/Task/PhpMnd.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class PhpMnd extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -48,7 +49,7 @@ class PhpMnd extends AbstractExternalTask
         $resolver->addAllowedTypes('strings', ['bool']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/PhpParser.php
+++ b/src/Task/PhpParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GrumPHP\Task;
 
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -24,17 +25,16 @@ class PhpParser extends AbstractParserTask
      */
     protected $parser;
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
-        $resolver = parent::getConfigurableOptions();
-
+        $resolver = self::sharedOptionsResolver();
         $resolver->setDefaults([
             'triggered_by' => ['php'],
             'kind' => self::KIND_PHP7,
             'visitors' => [],
         ]);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/PhpStan.php
+++ b/src/Task/PhpStan.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class PhpStan extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -51,7 +52,7 @@ class PhpStan extends AbstractExternalTask
         $resolver->addAllowedTypes('triggered_by', ['array']);
         $resolver->addAllowedTypes('use_grumphp_paths', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/PhpVersion.php
+++ b/src/Task/PhpVersion.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Config\EmptyTaskConfig;
 use GrumPHP\Task\Config\TaskConfigInterface;
 use GrumPHP\Task\Context\ContextInterface;
@@ -79,7 +80,7 @@ class PhpVersion implements TaskInterface
         return $this->config;
     }
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -87,6 +88,6 @@ class PhpVersion implements TaskInterface
         ]);
         $resolver->addAllowedTypes('project', ['null', 'string']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 }

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -12,6 +12,7 @@ use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\TmpFileUsingProcessRunner;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -29,7 +30,7 @@ class Phpcs extends AbstractExternalTask
      */
     protected $formatter;
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -64,7 +65,7 @@ class Phpcs extends AbstractExternalTask
         $resolver->addAllowedTypes('exclude', ['array']);
         $resolver->addAllowedTypes('show_sniffs_error_path', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/Phpspec.php
+++ b/src/Task/Phpspec.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Phpspec extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -32,7 +33,7 @@ class Phpspec extends AbstractExternalTask
         $resolver->addAllowedTypes('stop_on_failure', ['bool']);
         $resolver->addAllowedTypes('verbose', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/Phpunit.php
+++ b/src/Task/Phpunit.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Phpunit extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -36,7 +37,7 @@ class Phpunit extends AbstractExternalTask
         $resolver->addAllowedTypes('always_execute', ['bool']);
         $resolver->addAllowedTypes('order', ['null', 'string']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/PhpunitBridge.php
+++ b/src/Task/PhpunitBridge.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class PhpunitBridge extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -36,7 +37,7 @@ class PhpunitBridge extends AbstractExternalTask
         $resolver->addAllowedTypes('always_execute', ['bool']);
         $resolver->addAllowedTypes('order', ['null', 'string']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/Progpilot.php
+++ b/src/Task/Progpilot.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Progpilot extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -28,7 +29,7 @@ class Progpilot extends AbstractExternalTask
         $resolver->addAllowedTypes('config_file', ['string', 'null']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/Psalm.php
+++ b/src/Task/Psalm.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Psalm extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -48,7 +49,7 @@ class Psalm extends AbstractExternalTask
             ]
         );
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/Rector.php
+++ b/src/Task/Rector.php
@@ -8,6 +8,7 @@ use GrumPHP\Fixer\Provider\FixableProcessResultProvider;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -19,7 +20,7 @@ use Symfony\Component\Process\Process;
  */
 class Rector extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -36,7 +37,7 @@ class Rector extends AbstractExternalTask
         $resolver->addAllowedTypes('clear_cache', ['bool']);
         $resolver->addAllowedTypes('no_diffs', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/Robo.php
+++ b/src/Task/Robo.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Robo extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -30,7 +31,7 @@ class Robo extends AbstractExternalTask
         $resolver->addAllowedTypes('task', ['null', 'string']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/SecurityChecker.php
+++ b/src/Task/SecurityChecker.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class SecurityChecker extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -34,7 +35,7 @@ class SecurityChecker extends AbstractExternalTask
         $resolver->addAllowedTypes('timeout', ['null', 'int']);
         $resolver->addAllowedTypes('run_always', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/SecurityCheckerEnlightn.php
+++ b/src/Task/SecurityCheckerEnlightn.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class SecurityCheckerEnlightn extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -28,7 +29,7 @@ class SecurityCheckerEnlightn extends AbstractExternalTask
         $resolver->addAllowedTypes('lockfile', ['string']);
         $resolver->addAllowedTypes('run_always', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/SecurityCheckerLocal.php
+++ b/src/Task/SecurityCheckerLocal.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class SecurityCheckerLocal extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -32,7 +33,7 @@ class SecurityCheckerLocal extends AbstractExternalTask
         $resolver->addAllowedTypes('run_always', ['bool']);
         $resolver->addAllowedTypes('no_dev', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/SecurityCheckerRoave.php
+++ b/src/Task/SecurityCheckerRoave.php
@@ -8,6 +8,7 @@ use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -31,7 +32,7 @@ class SecurityCheckerRoave extends AbstractExternalTask
         $this->filesystem = $filesystem;
     }
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -44,7 +45,7 @@ class SecurityCheckerRoave extends AbstractExternalTask
         $resolver->addAllowedTypes('lockfile', ['string']);
         $resolver->addAllowedTypes('run_always', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/SecurityCheckerSymfony.php
+++ b/src/Task/SecurityCheckerSymfony.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class SecurityCheckerSymfony extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -30,7 +31,7 @@ class SecurityCheckerSymfony extends AbstractExternalTask
         $resolver->addAllowedTypes('format', ['null', 'string']);
         $resolver->addAllowedTypes('run_always', ['bool']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/Shell.php
+++ b/src/Task/Shell.php
@@ -8,6 +8,7 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -19,7 +20,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Shell extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -41,7 +42,7 @@ class Shell extends AbstractExternalTask
             );
         });
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/Stylelint.php
+++ b/src/Task/Stylelint.php
@@ -9,6 +9,7 @@ use GrumPHP\Fixer\Provider\FixableProcessResultProvider;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -20,7 +21,7 @@ use Symfony\Component\Process\Process;
  */
 class Stylelint extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -77,7 +78,7 @@ class Stylelint extends AbstractExternalTask
         $resolver->addAllowedTypes('max_warnings', ['null', 'integer']);
         $resolver->addAllowedTypes('output_file', ['null', 'string']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/TaskInterface.php
+++ b/src/Task/TaskInterface.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace GrumPHP\Task;
 
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Config\TaskConfigInterface;
 use GrumPHP\Task\Context\ContextInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 interface TaskInterface
 {
-    public static function getConfigurableOptions(): OptionsResolver;
+    public static function getConfigurableOptions(): ConfigOptionsResolver;
 
     public function canRunInContext(ContextInterface $context): bool;
 

--- a/src/Task/Tester.php
+++ b/src/Task/Tester.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Tester extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -48,7 +49,7 @@ class Tester extends AbstractExternalTask
         $resolver->addAllowedTypes('coverage', ['null', 'string']);
         $resolver->addAllowedTypes('coverage_src', ['null', 'string']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/TwigCs.php
+++ b/src/Task/TwigCs.php
@@ -7,6 +7,7 @@ namespace GrumPHP\Task;
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -17,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class TwigCs extends AbstractExternalTask
 {
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -36,7 +37,7 @@ class TwigCs extends AbstractExternalTask
         $resolver->addAllowedTypes('ruleset', ['string']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/src/Task/XmlLint.php
+++ b/src/Task/XmlLint.php
@@ -8,6 +8,7 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Linter\Xml\XmlLinter;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -23,9 +24,9 @@ class XmlLint extends AbstractLinterTask
      */
     protected $linter;
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
-        $resolver = parent::getConfigurableOptions();
+        $resolver = self::sharedOptionsResolver();
         $resolver->setDefaults([
             'load_from_net' => false,
             'x_include' => false,
@@ -40,7 +41,7 @@ class XmlLint extends AbstractLinterTask
         $resolver->addAllowedTypes('scheme_validation', ['bool']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     /**

--- a/src/Task/YamlLint.php
+++ b/src/Task/YamlLint.php
@@ -9,6 +9,7 @@ use GrumPHP\Exception\RuntimeException;
 use GrumPHP\Linter\Yaml\YamlLinter;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -25,9 +26,9 @@ class YamlLint extends AbstractLinterTask
      */
     protected $linter;
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
-        $resolver = parent::getConfigurableOptions();
+        $resolver = self::sharedOptionsResolver();
         $resolver->setDefaults([
             'object_support' => false,
             'exception_on_invalid_type' => false,
@@ -42,7 +43,7 @@ class YamlLint extends AbstractLinterTask
         $resolver->addAllowedTypes('parse_custom_tags', ['bool']);
         $resolver->addAllowedTypes('whitelist_patterns', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 
     public function canRunInContext(ContextInterface $context): bool

--- a/test/Unit/Runner/TaskHandler/Middleware/ParallelProcessingMiddlewareTest.php
+++ b/test/Unit/Runner/TaskHandler/Middleware/ParallelProcessingMiddlewareTest.php
@@ -34,6 +34,7 @@ class ParallelProcessingMiddlewareTest extends AbstractTaskHandlerMiddlewareTest
         $this->middleware = new ParallelProcessingMiddleware(
             $config = new ParallelConfig($enabled = false, $maxSize = 10),
             new PoolFactory($config),
+            $this->mockIO()
         );
     }
 

--- a/test/Unit/Task/Config/ConfigOptionsResolverTest.php
+++ b/test/Unit/Task/Config/ConfigOptionsResolverTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace GrumPHPTest\Unit\Task\Config;
+
+use GrumPHP\Task\Config\ConfigOptionsResolver;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ConfigOptionsResolverTest extends TestCase
+{
+    /** @test */
+    public function it_can_resolve_from_closure(): void
+    {
+        $resolver = ConfigOptionsResolver::fromClosure(static fn (array $data): array  => [...$data, 'world']);
+
+        self::assertSame(['hello', 'world'], $resolver->resolve(['hello']));
+    }
+
+    /** @test */
+    public function it_can_resolve_from_symfony_options_resolver(): void
+    {
+        $optionsResolver = new OptionsResolver();
+        $optionsResolver->setRequired('hello');
+
+        $resolver = ConfigOptionsResolver::fromOptionsResolver($optionsResolver);
+
+        self::assertSame(['hello' => 'world'], $resolver->resolve(['hello' => 'world']));
+    }
+}

--- a/test/Unit/Task/ESLintTest.php
+++ b/test/Unit/Task/ESLintTest.php
@@ -207,11 +207,4 @@ class ESLintTest extends AbstractExternalTaskTestCase
             ]
         ];
     }
-
-    /**
-     * @test
-     */
-    public function it_triggers_deprecation_on_null() {
-        self::assertTrue(ESLint::getConfigurableOptions()->isDeprecated('whitelist_patterns'));
-    }
 }

--- a/test/fixtures/e2e/tasks/ValidatePathsTask.php
+++ b/test/fixtures/e2e/tasks/ValidatePathsTask.php
@@ -3,6 +3,7 @@ namespace GrumPHPE2E;
 
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Config\EmptyTaskConfig;
 use GrumPHP\Task\Config\TaskConfigInterface;
 use GrumPHP\Task\Context\ContextInterface;
@@ -42,9 +43,9 @@ class ValidatePathsTask implements TaskInterface
         return $new;
     }
 
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
-        return new OptionsResolver();
+        return ConfigOptionsResolver::fromOptionsResolver(new OptionsResolver());
     }
 
     public function canRunInContext(ContextInterface $context): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | v2
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 

Fixes https://github.com/phpro/grumphp-shim/issues/10

This PR makes sure that the GrumPHP `TaskInterface` only has a dependency to the `GrumPHP\\` namespace.
Symfony OptionsResolver will not be a part of the task interface anymore.

New task interface:


```php
namespace GrumPHP\Task;

use GrumPHP\Runner\TaskResultInterface;
use GrumPHP\Task\Config\ConfigOptionsResolver;
use GrumPHP\Task\Config\TaskConfigInterface;
use GrumPHP\Task\Context\ContextInterface;

interface TaskInterface
{
    public static function getConfigurableOptions(): ConfigOptionsResolver;

    public function canRunInContext(ContextInterface $context): bool;

    public function run(ContextInterface $context): TaskResultInterface;

    public function getConfig(): TaskConfigInterface;

    public function withConfig(TaskConfigInterface $config): TaskInterface;
}

```


This makes it possible for extensions to provide tasks that are compatible with the `grumphp-shim` release.
In order to make the task compatible, you'll need to wrap the symfony options-resolver with GrumPHP's own options-resolver:

```php
    public static function getConfigurableOptions(): ConfigOptionsResolver
    {
        $resolver = new OptionsResolver();

        // ..... your config

        return ConfigOptionsResolver::fromClosure(
            static fn (array $options): array => $resolver->resolve($options)
        );
    }
```


❗ In extensions, you do not want to use `\GrumPHP\Task\Config\ConfigOptionsResolver::fromOptionsResolver()` - since Symfony's options resolver will be scoped (prefixed) in `grumphp-shim`'s phar distrubition.



