### PR TITLE
Add new nette tester options

### DIFF
--- a/doc/tasks/tester.md
+++ b/doc/tasks/tester.md
@@ -29,6 +29,8 @@ grumphp:
             colors: ~
             coverage: ~
             coverage_src: ~
+            php_ini_configuration_path: null
+            load_php_ini_configuration: false
 ```
 
 **path**
@@ -102,3 +104,15 @@ Example: `coverage.html` or `coverage.xml`
 *Default: null*
 
 This is issued with the `coverage` option. This is a path to the source code for which we generate the report.
+
+**php_ini_configuration_path**
+
+*Default: null*
+
+The Tester runs PHP processes from custom php.ini file.
+
+**default_php_ini_configuration**
+
+*Default: false*
+
+When this option is set to `true`, Tester runs PHP processes with system configuration .ini files.

--- a/src/Parser/Php/Visitor/ForbiddenStaticMethodCallsVisitor.php
+++ b/src/Parser/Php/Visitor/ForbiddenStaticMethodCallsVisitor.php
@@ -41,10 +41,12 @@ class ForbiddenStaticMethodCallsVisitor extends AbstractVisitor implements Confi
             return;
         }
 
-        $class = implode(
-            '\\',
-            method_exists($node->class, 'getParts') ? $node->class->getParts() : $node->class->parts
-        );
+        /**
+         * https://github.com/nikic/PHP-Parser/releases/tag/v4.16.0
+         * @psalm-suppress DeprecatedProperty
+         */
+        $class = implode('\\', $node->class->parts);
+
         $method = $node->name;
         $normalized = sprintf('%s::%s', $class, $method);
 

--- a/src/Parser/Php/Visitor/ForbiddenStaticMethodCallsVisitor.php
+++ b/src/Parser/Php/Visitor/ForbiddenStaticMethodCallsVisitor.php
@@ -41,7 +41,10 @@ class ForbiddenStaticMethodCallsVisitor extends AbstractVisitor implements Confi
             return;
         }
 
-        $class = implode('\\', $node->class->getParts());
+        $class = implode(
+            '\\',
+            method_exists($node->class, 'getParts') ? $node->class->getParts() : $node->class->parts
+        );
         $method = $node->name;
         $normalized = sprintf('%s::%s', $class, $method);
 

--- a/src/Parser/Php/Visitor/ForbiddenStaticMethodCallsVisitor.php
+++ b/src/Parser/Php/Visitor/ForbiddenStaticMethodCallsVisitor.php
@@ -41,7 +41,7 @@ class ForbiddenStaticMethodCallsVisitor extends AbstractVisitor implements Confi
             return;
         }
 
-        $class = implode('\\', $node->class->parts);
+        $class = implode('\\', $node->class->getParts());
         $method = $node->name;
         $normalized = sprintf('%s::%s', $class, $method);
 

--- a/src/Parser/Php/Visitor/ForbiddenStaticMethodCallsVisitor.php
+++ b/src/Parser/Php/Visitor/ForbiddenStaticMethodCallsVisitor.php
@@ -37,7 +37,7 @@ class ForbiddenStaticMethodCallsVisitor extends AbstractVisitor implements Confi
      */
     public function leaveNode(Node $node): void
     {
-        if (!$node instanceof Node\Expr\StaticCall) {
+        if (!$node instanceof Node\Expr\StaticCall || !$node->class instanceof Node\Name) {
             return;
         }
 

--- a/src/Task/Tester.php
+++ b/src/Task/Tester.php
@@ -34,6 +34,8 @@ class Tester extends AbstractExternalTask
             'colors' => null,
             'coverage' => null,
             'coverage_src' => null,
+            'php_ini_configuration_path' => null,
+            'default_php_ini_configuration' => false,
         ]);
 
         $resolver->addAllowedTypes('path', ['string']);
@@ -48,6 +50,8 @@ class Tester extends AbstractExternalTask
         $resolver->addAllowedTypes('colors', ['null', 'int']);
         $resolver->addAllowedTypes('coverage', ['null', 'string']);
         $resolver->addAllowedTypes('coverage_src', ['null', 'string']);
+        $resolver->addAllowedTypes('php_ini_configuration_path',  ['null', 'string']);
+        $resolver->addAllowedTypes('default_php_ini_configuration', ['bool']);
 
         return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
@@ -80,6 +84,8 @@ class Tester extends AbstractExternalTask
         $arguments->addOptionalIntegerArgument('%s', $config['colors']);
         $arguments->addOptionalArgumentWithSeparatedValue('--coverage', $config['coverage']);
         $arguments->addOptionalArgumentWithSeparatedValue('--coverage-src', $config['coverage_src']);
+        $arguments->addOptionalArgumentWithSeparatedValue('-c', $config['php_ini_configuration_path']);
+        $arguments->addOptionalArgument('-C', $config['default_php_ini_configuration']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();

--- a/src/Task/Tester.php
+++ b/src/Task/Tester.php
@@ -50,7 +50,7 @@ class Tester extends AbstractExternalTask
         $resolver->addAllowedTypes('colors', ['null', 'int']);
         $resolver->addAllowedTypes('coverage', ['null', 'string']);
         $resolver->addAllowedTypes('coverage_src', ['null', 'string']);
-        $resolver->addAllowedTypes('php_ini_configuration_path',  ['null', 'string']);
+        $resolver->addAllowedTypes('php_ini_configuration_path', ['null', 'string']);
         $resolver->addAllowedTypes('default_php_ini_configuration', ['bool']);
 
         return ConfigOptionsResolver::fromOptionsResolver($resolver);

--- a/test/Unit/Task/TesterTest.php
+++ b/test/Unit/Task/TesterTest.php
@@ -37,6 +37,8 @@ class TesterTest extends AbstractExternalTaskTestCase
                 'colors' => null,
                 'coverage' => null,
                 'coverage_src' => null,
+                'php_ini_configuration_path' => null,
+                'default_php_ini_configuration' => false,
             ]
         ];
     }
@@ -253,6 +255,29 @@ class TesterTest extends AbstractExternalTaskTestCase
                 '.',
                 '--coverage-src',
                 'coverageSrdFile',
+            ]
+        ];
+        yield 'php_ini_configuration_path' => [
+            [
+                'php_ini_configuration_path' => 'customPhpIniFile',
+            ],
+            $this->mockContext(RunContext::class, ['helloTest.php', 'hello2Test.php']),
+            'tester',
+            [
+                '.',
+                '-c',
+                'customPhpIniFile',
+            ]
+        ];
+        yield 'default_php_ini_configuration' => [
+            [
+                'default_php_ini_configuration' => true,
+            ],
+            $this->mockContext(RunContext::class, ['helloTest.php', 'hello2Test.php']),
+            'tester',
+            [
+                '.',
+                '-C',
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | no

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
added new nette tester config options
- php_ini_configuration_path [documentation](https://tester.nette.org/en/running-tests#toc-c-path)
- default_php_ini_configuration [documentation](https://tester.nette.org/en/running-tests#toc-c)

