### PR TITLE
Add codeception XML/HTML reporting support to grumphp

### DIFF
--- a/doc/tasks/codeception.md
+++ b/doc/tasks/codeception.md
@@ -20,6 +20,8 @@ grumphp:
             fail_fast: false
             suite: ~
             test: ~
+            xml: false
+            html: false
 ```
 
 
@@ -47,3 +49,15 @@ When this option is specified it will only run tests for the given suite. If lef
 
 When this option is specified it will only run the given test. If left `null` Codeception will run all tests within the suite.
 This option can only be used in combination with a suite.
+
+**xml**
+
+*Default: false*
+
+When this option is enabled, Codeception will output an XML report for the test run.
+
+**html**
+
+*Default: false*
+
+When this option is enabled, Codeception will output an HTML report for the test run.

--- a/src/Task/Codeception.php
+++ b/src/Task/Codeception.php
@@ -60,6 +60,8 @@ class Codeception extends AbstractExternalTask
         $arguments->add('run');
         $arguments->addOptionalArgument('--config=%s', $config['config_file']);
         $arguments->addOptionalArgument('--fail-fast', $config['fail_fast']);
+        $arguments->addOptionalArgument('--xml', $config['xml']);
+        $arguments->addOptionalArgument('--html', $config['html']);
         $arguments->addOptionalArgument('%s', $config['suite']);
         $arguments->addOptionalArgument('%s', $config['test']);
 

--- a/src/Task/Codeception.php
+++ b/src/Task/Codeception.php
@@ -26,13 +26,17 @@ class Codeception extends AbstractExternalTask
             'suite' => null,
             'test' => null,
             'fail_fast' => false,
+            'xml' => false,
+            'html' => false,
         ]);
 
         $resolver->addAllowedTypes('config_file', ['null', 'string']);
         $resolver->addAllowedTypes('suite', ['null', 'string']);
         $resolver->addAllowedTypes('test', ['null', 'string']);
         $resolver->addAllowedTypes('fail_fast', ['bool']);
-
+        $resolver->addAllowedTypes('xml', ['bool']);
+        $resolver->addAllowedTypes('html', ['bool']);
+        
         return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
 

--- a/test/Unit/Task/CodeceptionTest.php
+++ b/test/Unit/Task/CodeceptionTest.php
@@ -29,6 +29,8 @@ class CodeceptionTest extends AbstractExternalTaskTestCase
                 'suite' => null,
                 'test' => null,
                 'fail_fast' => false,
+                'xml' => false,
+                'html' => false,
             ]
         ];
     }
@@ -141,6 +143,28 @@ class CodeceptionTest extends AbstractExternalTaskTestCase
             [
                 'run',
                 'test'
+            ]
+        ];
+        yield 'xml' => [
+            [
+                'xml' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'codecept',
+            [
+                'run',
+                '--xml'
+            ]
+        ];
+        yield 'html' => [
+            [
+                'html' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'codecept',
+            [
+                'run',
+                '--html'
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | v2.x
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | -

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

Codeception allows generating HTML/XML reports after test runs, which is very useful for CI and/or sharing results.
Currently, this is not possible within grumphp, except through a shell script which invokes codeception manually.


This PR adds the capability for the Codeception task to output XML/HTML reports.