### PR TITLE
Apply ternary to null operator

### DIFF
--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -368,21 +368,15 @@ class CommitMessage implements TaskInterface
         $config = $this->getConfig()->getOptions();
         $subjectLine = $this->getSubjectLine($context);
 
-        $types = isset($config['type_scope_conventions']['types'])
-            ? $config['type_scope_conventions']['types']
-            : [];
+        $types = $config['type_scope_conventions']['types'] ?? [];
 
-        $scopes = isset($config['type_scope_conventions']['scopes'])
-            ? $config['type_scope_conventions']['scopes']
-            : [];
+        $scopes = $config['type_scope_conventions']['scopes'] ?? [];
 
         $specialPrefix = '(?:(?:fixup|squash)! )?';
         $typesPattern = '([a-zA-Z0-9]+)';
         $scopesPattern = '(:\s|(\(.+\)?:\s))';
 
-        $subjectPattern = isset($config['type_scope_conventions']['subject_pattern'])
-            ? $config['type_scope_conventions']['subject_pattern']
-            : '([a-zA-Z0-9-_ #@\'\/\\"]+)';
+        $subjectPattern = $config['type_scope_conventions']['subject_pattern'] ?? '([a-zA-Z0-9-_ #@\'\/\\"]+)';
 
         if (count($types) > 0) {
             $types = implode('|', $types);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 2.x
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no

It should use the ternary null operator to process the variable is null.

# New Task Checklist:

- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpunit tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?
