### PR TITLE
Replace the array_merge with spread array operator

### DIFF
--- a/src/Runner/Reporting/TaskResultsReporter.php
+++ b/src/Runner/Reporting/TaskResultsReporter.php
@@ -80,7 +80,7 @@ class TaskResultsReporter
 
         // Always add content if we decided that an overwrite is not possible!
         if (!$this->isOverwritePossible()) {
-            $this->outputSection->writeln(array_merge($message, ['']));
+            $this->outputSection->writeln([...$message, '']);
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | v2.x
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

- According to the [reference](https://wiki.php.net/rfc/spread_operator_for_array), it's great to use the spread array operator to replace the `array_merge` function.
- There're two reasons about using the spread array operator:
  - Spread operator should have a better performance than array_merge and compile time optimization can be performant for constant arrays.
  - `array_merge` only supports array, while the spread operator also supports objects implementing `Traversable`.

# New Task Checklist:

- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpunit tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?
