### PR TITLE
Apply str_contains to replace the strpos usage

### DIFF
--- a/src/Util/Regex.php
+++ b/src/Util/Regex.php
@@ -58,7 +58,7 @@ class Regex
     public function addPatternModifier(string $modifier): void
     {
         /** @psalm-suppress InvalidLiteralArgument */
-        if ('' === $modifier || false === strpos(self::ALLOWED_MODIFIERS, $modifier)) {
+        if ('' === $modifier || !str_contains(self::ALLOWED_MODIFIERS, $modifier)) {
             throw new RuntimeException('Invalid regex modifier: '.$modifier);
         }
 
@@ -68,7 +68,7 @@ class Regex
         $modifiers = $matches[0];
 
         // Skip if the modifier is already available
-        if (false !== strpos($modifiers, $modifier)) {
+        if (str_contains($modifiers, $modifier)) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | v2.x
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

Apply using the `str_contains` function to replace the `strpos` function usage.

# New Task Checklist:

- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpunit tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?
