### PR TITLE
Resolve env placeholders in configuration

### DIFF
--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -322,3 +322,19 @@ grumphp:
         paths:
             - tools
 ```
+
+## Configuration
+
+**Environment variables:**
+
+```yaml
+# grumphp.yml
+parameters:
+  env(FIXER_ENABLED): 'true'
+
+grumphp:
+    fixer:
+      enabled: '%env(bool:FIXER_ENABLED)%'
+```
+
+More about [Environment Variable Processors](https://symfony.com/doc/current/configuration/env_var_processors.html)

--- a/src/Configuration/ContainerBuilder.php
+++ b/src/Configuration/ContainerBuilder.php
@@ -51,7 +51,7 @@ final class ContainerBuilder
         $container->setParameter('config_file', $path);
 
         // Compile configuration to make sure that tasks are added to the taskrunner
-        $container->compile();
+        $container->compile(true);
 
         return $container;
     }

--- a/test/E2E/ConfigurationTest.php
+++ b/test/E2E/ConfigurationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHPTest\E2E;
+
+class ConfigurationTest extends AbstractE2ETestCase
+{
+    /** @test */
+    function it_should_be_able_to_resolve_env_variable_in_configuration()
+    {
+        $this->initializeGitInRootDir();
+        $this->initializeComposer($this->rootDir);
+        $grumphpFile = $this->initializeGrumphpConfig(path: $this->rootDir, customConfig: [
+            'parameters' => [
+                'env(GRUMPHP_PARAMETER_TEST)' => '~'
+            ],
+            'grumphp' => [
+                'ascii' => [
+                    'succeeded' => '%env(string:GRUMPHP_PARAMETER_TEST)%',
+                ],
+            ],
+        ]);
+
+        $this->installComposer($this->rootDir);
+        $this->ensureHooksExist();
+
+        $this->enableValidatePathsTask($grumphpFile, $this->rootDir);
+
+        $this->commitAll();
+        $process = $this->runGrumphp(projectPath: $this->rootDir, environment: [
+            'GRUMPHP_PARAMETER_TEST' => 'succeeded.txt',
+        ]);
+
+        $this->assertStringContainsString(
+            file_get_contents(PROJECT_BASE_PATH . '/resources/ascii/succeeded.txt'),
+            $process->getOutput(),
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      |  no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | https://github.com/phpro/grumphp/issues/1042

Example:
```yaml
# grumphp.yml
parameters:
  env(FIXER_ENABLED): 'true'

grumphp:
    fixer:
      enabled: '%env(bool:FIXER_ENABLED)%'
```
