### PR TITLE
Add security-checker using Composer Audit

### DIFF
--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -54,6 +54,7 @@ grumphp:
         psalm: ~
         rector: ~
         robo: ~
+        securitychecker_composeraudit: ~
         securitychecker_enlightn: ~
         securitychecker_local: ~
         securitychecker_roave: ~
@@ -119,6 +120,7 @@ Every task has its own default configuration. It is possible to overwrite the pa
 - [Rector](tasks/rector.md)
 - [Robo](tasks/robo.md)
 - [Security Checker](tasks/securitychecker.md)
+  - [Composer Audit](tasks/securitychecker/composeraudit.md)
   - [Enlightn](tasks/securitychecker/enlightn.md)
   - [Local](tasks/securitychecker/local.md)
   - [Roave](tasks/securitychecker/roave.md)
@@ -205,7 +207,7 @@ interface TaskInterface
 }
 ```
 
-* `getConfigurableOptions`: This method has to return all configurable options for the task. 
+* `getConfigurableOptions`: This method has to return all configurable options for the task.
 * `canRunInContext`: Tells GrumPHP if it can run in `pre-commit`, `commit-msg` or `run` context.
 * `run`: Executes the task and returns a result
 * `getConfig`: Provides the resolved configuration for the task or an empty config for newly instantiated tasks.
@@ -260,7 +262,7 @@ For a more detailed view on how to use these classes, you can scroll through our
 
 In some cases you might want to run the same task but with different configuration.
 Good news: This is perfectly possible!
-You can use any name you want for the task, as long as you configure an existing task in the metadata section. 
+You can use any name you want for the task, as long as you configure an existing task in the metadata section.
 Configuration of the additional task will look like this:
 
 ```yaml

--- a/doc/tasks/securitychecker.md
+++ b/doc/tasks/securitychecker.md
@@ -4,6 +4,7 @@ The SensioLabs Security Checker API is abandoned
 
 You can use one of following tasks as a replacement:
 
+- [securitychecker_composeraudit](securitychecker/composeraudit.md)
 - [securitychecker_enlightn](securitychecker/enlightn.md)
 - [securitychecker_local](securitychecker/local.md)
 - [securitychecker_roave](securitychecker/roave.md)

--- a/doc/tasks/securitychecker/composeraudit.md
+++ b/doc/tasks/securitychecker/composeraudit.md
@@ -15,7 +15,7 @@ grumphp:
             locked: true
             no_dev: false
             run_always: false
-            working_dir: ./
+            working_dir: null
 ```
 
 **format**
@@ -44,6 +44,6 @@ When this option is set to `false`, the task will only run when the `composer.lo
 
 **working_dir**
 
-*Default: ./*
+*Default: null
 
 If your `composer.lock` file is located in an exotic location, you can specify the location with this option. By default, the task will try to load a `composer.lock` file in the current directory.

--- a/doc/tasks/securitychecker/composeraudit.md
+++ b/doc/tasks/securitychecker/composeraudit.md
@@ -1,0 +1,48 @@
+# Composer Audit Security Checker
+
+The Security Checker will check your `composer.lock` file for known security vulnerabilities.
+
+***Config***
+
+The task lives under the `securitychecker_composeraudit` namespace and has the following configurable parameters:
+
+```yaml
+# grumphp.yml
+grumphp:
+    tasks:
+        securitychecker_composeraudit:
+            locked: true
+            no_dev: false
+            run_always: false
+            working_dir: ./
+```
+
+**format**
+
+*Default: null*
+
+You can choose the format of the output. The available options are `table`, `plain`, `json` and `summary`. By default, grumphp will use the format `table`.
+
+**locked**
+
+*Default: true*
+
+Audit packages from the lock file, regardless of what is currently in vendor dir.
+
+**no_dev**
+
+*Default: false*
+
+When this option is set to `true`, the task will skip packages under `require-dev`.
+
+**run_always**
+
+*Default: false*
+
+When this option is set to `false`, the task will only run when the `composer.lock` file has changed. If it is set to `true`, the `composer.lock` file will be checked on every commit.
+
+**working_dir**
+
+*Default: ./*
+
+If your `composer.lock` file is located in an exotic location, you can specify the location with this option. By default, the task will try to load a `composer.lock` file in the current directory.

--- a/doc/tasks/securitychecker/composeraudit.md
+++ b/doc/tasks/securitychecker/composeraudit.md
@@ -11,6 +11,7 @@ The task lives under the `securitychecker_composeraudit` namespace and has the f
 grumphp:
     tasks:
         securitychecker_composeraudit:
+            format: null
             locked: true
             no_dev: false
             run_always: false

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -336,6 +336,13 @@ services:
         tags:
             - {name: grumphp.task, task: securitychecker}
 
+    GrumPHP\Task\SecurityCheckerComposeraudit:
+        arguments:
+            - '@process_builder'
+            - '@formatter.raw_process'
+        tags:
+            - {name: grumphp.task, task: securitychecker_composeraudit}
+
     GrumPHP\Task\SecurityCheckerEnlightn:
         arguments:
             - '@process_builder'

--- a/src/Task/SecurityCheckerComposeraudit.php
+++ b/src/Task/SecurityCheckerComposeraudit.php
@@ -26,14 +26,14 @@ class SecurityCheckerComposeraudit extends AbstractExternalTask
             'locked' => true,
             'no_dev' => false,
             'run_always' => false,
-            'working_dir' => './',
+            'working_dir' => null,
         ]);
 
         $resolver->addAllowedTypes('format', ['null', 'string']);
         $resolver->addAllowedTypes('locked', ['bool']);
         $resolver->addAllowedTypes('no_dev', ['bool']);
         $resolver->addAllowedTypes('run_always', ['bool']);
-        $resolver->addAllowedTypes('working_dir', ['string']);
+        $resolver->addAllowedTypes('working_dir', ['null', 'string']);
 
         return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
@@ -47,8 +47,8 @@ class SecurityCheckerComposeraudit extends AbstractExternalTask
     {
         $config = $this->getConfig()->getOptions();
         $files = $context->getFiles()
-            ->path(pathinfo($config['working_dir'] . "/composer.lock", PATHINFO_DIRNAME))
-            ->name(pathinfo($config['working_dir'] . "/composer.lock", PATHINFO_BASENAME));
+            ->path(pathinfo("composer.lock", PATHINFO_DIRNAME))
+            ->name(pathinfo("composer.lock", PATHINFO_BASENAME));
         if (0 === \count($files) && !$config['run_always']) {
             return TaskResult::createSkipped($this, $context);
         }

--- a/src/Task/SecurityCheckerComposeraudit.php
+++ b/src/Task/SecurityCheckerComposeraudit.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Task;
+
+use GrumPHP\Formatter\ProcessFormatterInterface;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @extends AbstractExternalTask<ProcessFormatterInterface>
+ */
+class SecurityCheckerComposeraudit extends AbstractExternalTask
+{
+    public static function getConfigurableOptions(): ConfigOptionsResolver
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'format' => null,
+            'locked' => true,
+            'no_dev' => false,
+            'run_always' => false,
+            'working_dir' => './',
+        ]);
+
+        // $resolver->addAllowedTypes('lockfile', ['string']);
+
+        $resolver->addAllowedTypes('format', ['null', 'string']);
+        $resolver->addAllowedTypes('locked', ['bool']);
+        $resolver->addAllowedTypes('no_dev', ['bool']);
+        $resolver->addAllowedTypes('run_always', ['bool']);
+        $resolver->addAllowedTypes('working_dir', ['string']);
+
+        return ConfigOptionsResolver::fromOptionsResolver($resolver);
+    }
+
+    public function canRunInContext(ContextInterface $context): bool
+    {
+        return $context instanceof GitPreCommitContext || $context instanceof RunContext;
+    }
+
+    public function run(ContextInterface $context): TaskResultInterface
+    {
+        $config = $this->getConfig()->getOptions();
+        $files = $context->getFiles()
+            ->path(pathinfo($config['working_dir'] . "/composer.lock", PATHINFO_DIRNAME))
+            ->name(pathinfo($config['working_dir'] . "/composer.lock", PATHINFO_BASENAME));
+        if (0 === \count($files) && !$config['run_always']) {
+            return TaskResult::createSkipped($this, $context);
+        }
+
+        $arguments = $this->processBuilder->createArgumentsForCommand('composer');
+        $arguments->add('audit');
+        $arguments->addOptionalArgument('--format=%s', $config['format']);
+        $arguments->addOptionalArgument('--locked', $config['locked']);
+        $arguments->addOptionalArgument('--no-dev', $config['no_dev']);
+        $arguments->addOptionalArgument('--working-dir=%s', $config['working_dir']);
+
+        $process = $this->processBuilder->buildProcess($arguments);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}

--- a/src/Task/SecurityCheckerComposeraudit.php
+++ b/src/Task/SecurityCheckerComposeraudit.php
@@ -29,8 +29,6 @@ class SecurityCheckerComposeraudit extends AbstractExternalTask
             'working_dir' => './',
         ]);
 
-        // $resolver->addAllowedTypes('lockfile', ['string']);
-
         $resolver->addAllowedTypes('format', ['null', 'string']);
         $resolver->addAllowedTypes('locked', ['bool']);
         $resolver->addAllowedTypes('no_dev', ['bool']);

--- a/test/Unit/Task/SecurityCheckerComposerauditTest.php
+++ b/test/Unit/Task/SecurityCheckerComposerauditTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHPTest\Unit\Task;
+
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\SecurityCheckerComposeraudit;
+use GrumPHP\Task\TaskInterface;
+use GrumPHP\Test\Task\AbstractExternalTaskTestCase;
+
+class SecurityCheckerComposerauditTest extends AbstractExternalTaskTestCase
+{
+    protected function provideTask(): TaskInterface
+    {
+        return new SecurityCheckerComposeraudit(
+            $this->processBuilder->reveal(),
+            $this->formatter->reveal()
+        );
+    }
+
+    public function provideConfigurableOptions(): iterable
+    {
+        yield 'defaults' => [
+            [],
+            [
+                'format' => null,
+                'locked' => true,
+                'no_dev' => false,
+                'run_always' => false,
+                'working_dir' => './',
+            ]
+        ];
+    }
+
+    public function provideRunContexts(): iterable
+    {
+        yield 'run-context' => [
+            true,
+            $this->mockContext(RunContext::class)
+        ];
+
+        yield 'pre-commit-context' => [
+            true,
+            $this->mockContext(GitPreCommitContext::class)
+        ];
+
+        yield 'other' => [
+            false,
+            $this->mockContext()
+        ];
+    }
+
+    public function provideFailsOnStuff(): iterable
+    {
+        yield 'exitCode1' => [
+            [],
+            $this->mockContext(RunContext::class, ['composer.lock']),
+            function () {
+                $this->mockProcessBuilder('composer', $process = $this->mockProcess(1));
+                $this->formatter->format($process)->willReturn('nope');
+            },
+            'nope'
+        ];
+    }
+
+    public function providePassesOnStuff(): iterable
+    {
+        yield 'exitCode0' => [
+            [],
+            $this->mockContext(RunContext::class, ['composer.lock']),
+            function () {
+                $this->mockProcessBuilder('composer', $this->mockProcess(0));
+            }
+        ];
+        yield 'exitCode0WhenRunAlways' => [
+            [
+                'run_always' => true
+            ],
+            $this->mockContext(RunContext::class, ['notrelated.php']),
+            function () {
+                $this->mockProcessBuilder('composer', $this->mockProcess(0));
+            }
+        ];
+    }
+
+    public function provideSkipsOnStuff(): iterable
+    {
+        yield 'no-files' => [
+            [],
+            $this->mockContext(RunContext::class),
+            function () {}
+        ];
+        yield 'no-composer-file' => [
+            [],
+            $this->mockContext(RunContext::class, ['thisisnotacomposerfile.lock']),
+            function () {}
+        ];
+    }
+
+    public function provideExternalTaskRuns(): iterable
+    {
+        yield 'defaults' => [
+            [],
+            $this->mockContext(RunContext::class, ['composer.lock']),
+            'composer',
+            [
+                'audit',
+                '--locked',
+                '--working-dir=./',
+            ]
+        ];
+    }
+}

--- a/test/Unit/Task/SecurityCheckerComposerauditTest.php
+++ b/test/Unit/Task/SecurityCheckerComposerauditTest.php
@@ -111,5 +111,58 @@ class SecurityCheckerComposerauditTest extends AbstractExternalTaskTestCase
                 '--working-dir=./',
             ]
         ];
+
+        yield 'format' => [
+            [
+                'format' => 'json',
+            ],
+            $this->mockContext(RunContext::class, ['composer.lock']),
+            'composer',
+            [
+                'audit',
+                '--format=json',
+                '--locked',
+                '--working-dir=./',
+            ]
+        ];
+
+        yield 'locked' => [
+            [
+                'locked' => false,
+            ],
+            $this->mockContext(RunContext::class, ['composer.lock']),
+            'composer',
+            [
+                'audit',
+                '--working-dir=./',
+            ]
+        ];
+
+        yield 'no-dev' => [
+            [
+                'no_dev' => true,
+            ],
+            $this->mockContext(RunContext::class, ['composer.lock']),
+            'composer',
+            [
+                'audit',
+                '--locked',
+                '--no-dev',
+                '--working-dir=./',
+            ]
+        ];
+
+        yield 'working-dir' => [
+            [
+                'working_dir' => './',
+            ],
+            $this->mockContext(RunContext::class, ['composer.lock']),
+            'composer',
+            [
+                'audit',
+                '--locked',
+                '--working-dir=./',
+            ]
+        ];
     }
 }

--- a/test/Unit/Task/SecurityCheckerComposerauditTest.php
+++ b/test/Unit/Task/SecurityCheckerComposerauditTest.php
@@ -29,7 +29,7 @@ class SecurityCheckerComposerauditTest extends AbstractExternalTaskTestCase
                 'locked' => true,
                 'no_dev' => false,
                 'run_always' => false,
-                'working_dir' => './',
+                'working_dir' => null,
             ]
         ];
     }
@@ -108,7 +108,6 @@ class SecurityCheckerComposerauditTest extends AbstractExternalTaskTestCase
             [
                 'audit',
                 '--locked',
-                '--working-dir=./',
             ]
         ];
 
@@ -122,7 +121,6 @@ class SecurityCheckerComposerauditTest extends AbstractExternalTaskTestCase
                 'audit',
                 '--format=json',
                 '--locked',
-                '--working-dir=./',
             ]
         ];
 
@@ -134,7 +132,6 @@ class SecurityCheckerComposerauditTest extends AbstractExternalTaskTestCase
             'composer',
             [
                 'audit',
-                '--working-dir=./',
             ]
         ];
 
@@ -148,20 +145,19 @@ class SecurityCheckerComposerauditTest extends AbstractExternalTaskTestCase
                 'audit',
                 '--locked',
                 '--no-dev',
-                '--working-dir=./',
             ]
         ];
 
         yield 'working-dir' => [
             [
-                'working_dir' => './',
+                'working_dir' => 'dir',
             ],
             $this->mockContext(RunContext::class, ['composer.lock']),
             'composer',
             [
                 'audit',
                 '--locked',
-                '--working-dir=./',
+                '--working-dir=dir',
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | v2.x
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

Add security-checker using Composer Audit

https://getcomposer.org/doc/03-cli.md#audit

<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [ ] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpunit tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?
