### PR TITLE
fix: XML and HTML reports as string paths instead of boolean options

### DIFF
--- a/doc/tasks/codeception.md
+++ b/doc/tasks/codeception.md
@@ -20,8 +20,8 @@ grumphp:
             fail_fast: false
             suite: ~
             test: ~
-            xml: false
-            html: false
+            xml: ~
+            html: ~
 ```
 
 
@@ -52,12 +52,12 @@ This option can only be used in combination with a suite.
 
 **xml**
 
-*Default: false*
+*Default: null*
 
-When this option is enabled, Codeception will output an XML report for the test run.
+When this option is specified, Codeception will output an XML report for the test run. If left `null`, no XML report is generated.
 
 **html**
 
-*Default: false*
+*Default: null*
 
-When this option is enabled, Codeception will output an HTML report for the test run.
+When this option is specified, Codeception will output an HTML report for the test run. If left `null`, no HTML report is generated.

--- a/src/Task/Codeception.php
+++ b/src/Task/Codeception.php
@@ -26,16 +26,16 @@ class Codeception extends AbstractExternalTask
             'suite' => null,
             'test' => null,
             'fail_fast' => false,
-            'xml' => false,
-            'html' => false,
+            'xml' => null,
+            'html' => null,
         ]);
 
         $resolver->addAllowedTypes('config_file', ['null', 'string']);
         $resolver->addAllowedTypes('suite', ['null', 'string']);
         $resolver->addAllowedTypes('test', ['null', 'string']);
         $resolver->addAllowedTypes('fail_fast', ['bool']);
-        $resolver->addAllowedTypes('xml', ['bool']);
-        $resolver->addAllowedTypes('html', ['bool']);
+        $resolver->addAllowedTypes('xml', ['null', 'string']);
+        $resolver->addAllowedTypes('html', ['null', 'string']);
         
         return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
@@ -64,8 +64,8 @@ class Codeception extends AbstractExternalTask
         $arguments->add('run');
         $arguments->addOptionalArgument('--config=%s', $config['config_file']);
         $arguments->addOptionalArgument('--fail-fast', $config['fail_fast']);
-        $arguments->addOptionalArgument('--xml', $config['xml']);
-        $arguments->addOptionalArgument('--html', $config['html']);
+        $arguments->addOptionalArgument('--xml=%s', $config['xml']);
+        $arguments->addOptionalArgument('--html=%s', $config['html']);
         $arguments->addOptionalArgument('%s', $config['suite']);
         $arguments->addOptionalArgument('%s', $config['test']);
 

--- a/test/Unit/Task/CodeceptionTest.php
+++ b/test/Unit/Task/CodeceptionTest.php
@@ -29,8 +29,8 @@ class CodeceptionTest extends AbstractExternalTaskTestCase
                 'suite' => null,
                 'test' => null,
                 'fail_fast' => false,
-                'xml' => false,
-                'html' => false,
+                'xml' => null,
+                'html' => null,
             ]
         ];
     }
@@ -147,24 +147,24 @@ class CodeceptionTest extends AbstractExternalTaskTestCase
         ];
         yield 'xml' => [
             [
-                'xml' => true,
+                'xml' => 'report.xml',
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'codecept',
             [
                 'run',
-                '--xml'
+                '--xml=report.xml'
             ]
         ];
         yield 'html' => [
             [
-                'html' => true,
+                'html' => 'report.html',
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             'codecept',
             [
                 'run',
-                '--html'
+                '--html=report.html'
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | v2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | -

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

Converts the existing 'xml' and 'html' options for Codeception from booleans to strings.
Codeception supports specifying paths for these options.
If a plain option is passed (without the value, i.e. '--xml' or '--html'), Codeception uses defaults of 'report.xml' and 'report.html'.

If a valued option is passed (i.e. '--xml=my-custom-path/report.xml' or '--html=my-custom-path/report.html'), then this is used instead.

This MR just brings this possibility into GrumPHP
