### PR TITLE
1126 bin console task sf

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ feel free to do this, but remember to follow this few simple rules:
 
 ## Branching strategy
 
-- __Always__ base your changes on the `master` branch (all new development happens here),
-- When you create Pull Request, always select `master` branch as target, otherwise it
+- __Always__ base your changes on the latest version `v<version>.x` branch (all new development happens here),
+- When you create Pull Request, always select `v<version>.x` branch as target, otherwise it
 will be closed (this is selected by default).
 
 ## Coverage

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,6 @@
         "sebastian/phpcpd": "Lets GrumPHP find duplicated code.",
         "squizlabs/php_codesniffer": "Lets GrumPHP sniff on your code.",
         "sstalle/php7cc": "Lets GrumPHP check PHP 5.3 - 5.6 code compatibility with PHP 7.",
-        "symfony/console": "Lets GrumPHP run Symfony Console commands.",
         "symfony/phpunit-bridge": "Lets GrumPHP run your unit tests with the phpunit-bridge of Symfony.",
         "symplify/easy-coding-standard": "Lets GrumPHP check coding standard.",
         "vimeo/psalm": "Lets GrumPHP discover errors in your code without running it.",

--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
         "sebastian/phpcpd": "Lets GrumPHP find duplicated code.",
         "squizlabs/php_codesniffer": "Lets GrumPHP sniff on your code.",
         "sstalle/php7cc": "Lets GrumPHP check PHP 5.3 - 5.6 code compatibility with PHP 7.",
+        "symfony/console": "Lets GrumPHP run Symfony Console commands.",
         "symfony/phpunit-bridge": "Lets GrumPHP run your unit tests with the phpunit-bridge of Symfony.",
         "symplify/easy-coding-standard": "Lets GrumPHP check coding standard.",
         "vimeo/psalm": "Lets GrumPHP discover errors in your code without running it.",

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -61,6 +61,7 @@ grumphp:
         securitychecker_symfony: ~
         shell: ~
         stylelint: ~
+        symfony_console: ~
         tester: ~
         twigcs: ~
         twigcsfixer: ~
@@ -128,6 +129,7 @@ Every task has its own default configuration. It is possible to overwrite the pa
   - [Symfony](tasks/securitychecker/symfony.md)
 - [Shell](tasks/shell.md)
 - [Stylelint](tasks/stylelint.md)
+- [Symfony Console](tasks/symfony_console.md)
 - [Tester](tasks/tester.md)
 - [TwigCs](tasks/twigcs.md)
 - [Twig-CS-Fixer](tasks/twigcsfixer.md)

--- a/doc/tasks/symfony_console.md
+++ b/doc/tasks/symfony_console.md
@@ -2,13 +2,9 @@
 
 Run a symfony console command.
 
-## Composer
+## Requirements
 
-Requires the Symfony Console component: [Console Component](https://symfony.com/components/Console)
-
-```bash
-composer require symfony/console
-```
+This task requires a Symfony application with console component.
 
 ## Config
 

--- a/doc/tasks/symfony_console.md
+++ b/doc/tasks/symfony_console.md
@@ -1,0 +1,47 @@
+# Symfony Console
+
+Run a symfony console command.
+
+## Composer
+
+Requires the Symfony Console component: [Console Component](https://symfony.com/components/Console)
+
+```bash
+composer require symfony/console
+```
+
+## Config
+
+The task lives under the `symfony_console` namespace and has following configurable parameters:
+
+```yaml
+# grumphp.yml
+grumphp:
+    tasks:
+        symfony_console:
+            command: [ "lint:container", "-vvv" ]
+```
+
+**command**
+
+Specify the symfony command with defined options and arguments.  
+Verify the installed console component version for available commands `./bin/console list`
+
+## Note: Multiple Console command tasks
+
+[Run the same task twice with different configuration](../tasks.md#run-the-same-task-twice-with-different-configuration)
+
+Specific running multiple symfony console commands:
+
+```yaml
+# grumphp.yml
+grumphp:
+  lint-container:
+      command: [ "lint:container", "-vvv"]
+      metadata:
+        task: symfony_console
+  lint-yaml:
+      command: [ "lint:yaml", "path/to/yaml"]
+      metadata:
+        task: symfony_console
+```

--- a/doc/tasks/symfony_console.md
+++ b/doc/tasks/symfony_console.md
@@ -19,17 +19,62 @@ The task lives under the `symfony_console` namespace and has following configura
 grumphp:
     tasks:
         symfony_console:
+            bin: "./bin/console"
             command: [ "lint:container", "-vvv" ]
+            ignore_patterns: [],
+            whitelist_patterns: [],
+            triggered_by: ['php', 'yml', 'xml'],
+            run_always: false
 ```
-
-**Note:** GrumPHP will use the default Symfony console path `./bin/console` from the project root.
 
 ### Parameters
 
+**bin**
+
+*Default: `./bin/console`*
+
+Specify the path to the Symfony Console script. 
+
 **command**
+
+*Default: `[]`*
 
 Specify the symfony command with defined options and arguments.  
 Verify the installed console component version for available commands `./bin/console list`
+
+**ignore_patterns**
+
+*Default: []*
+
+This is a list of file patterns that will be ignored by the Symfony console task. 
+Leave this option blank to run the task for all files defined in the whitelist_patterns and or triggered_by extensions.
+
+**whitelist_patterns**
+
+*Default: []*
+
+This is a list of regex patterns that will filter files to validate. With this option you can skip files like tests. 
+This option is used in relation with the parameter `triggered_by`.
+For example: whitelist files in `src/FolderA/` and `src/FolderB/` you can use
+```yaml
+whitelist_patterns:
+    - /^src\/FolderA\/(.*)/
+    - /^src\/FolderB\/(.*)/
+```
+
+**triggered_by**
+
+*Default: [php, yml, xml]*
+
+This option will specify which file extensions will trigger the Symfony console task.
+By default, altering a `php`, `yml`, `xml` file will trigger the task.
+You can overwrite this option to whatever filetype you want to validate!
+
+**run_always**
+
+*Default: false*
+
+If this is set to `true` the Symfony console task will be executed on every commit, regardless of any modified files.
 
 ## Multiple Console command tasks
 

--- a/doc/tasks/symfony_console.md
+++ b/doc/tasks/symfony_console.md
@@ -22,12 +22,16 @@ grumphp:
             command: [ "lint:container", "-vvv" ]
 ```
 
+**Note:** GrumPHP will use the default Symfony console path `./bin/console` from the project root.
+
+### Parameters
+
 **command**
 
 Specify the symfony command with defined options and arguments.  
 Verify the installed console component version for available commands `./bin/console list`
 
-## Note: Multiple Console command tasks
+## Multiple Console command tasks
 
 [Run the same task twice with different configuration](../tasks.md#run-the-same-task-twice-with-different-configuration)
 

--- a/resources/config/tasks.yml
+++ b/resources/config/tasks.yml
@@ -386,6 +386,13 @@ services:
         tags:
             - {name: grumphp.task, task: stylelint}
 
+    GrumPHP\Task\SymfonyConsole:
+        arguments:
+            - '@process_builder'
+            - '@formatter.raw_process'
+        tags:
+          - {name: grumphp.task, task: symfony_console}
+
     GrumPHP\Task\Tester:
         class:
         arguments:

--- a/src/Task/SymfonyConsole.php
+++ b/src/Task/SymfonyConsole.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Task;
+
+use GrumPHP\Formatter\ProcessFormatterInterface;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/** @extends AbstractExternalTask<ProcessFormatterInterface> */
+class SymfonyConsole extends AbstractExternalTask
+{
+    public static function getConfigurableOptions(): ConfigOptionsResolver
+    {
+        return ConfigOptionsResolver::fromOptionsResolver(
+            (new OptionsResolver())
+                ->setDefaults([
+                    'bin' => './bin/console',
+                    'command' => [],
+                ])
+                ->addAllowedTypes('command', ['string[]'])
+                ->setRequired('command')
+        );
+    }
+
+    public function canRunInContext(ContextInterface $context): bool
+    {
+        return ($context instanceof GitPreCommitContext || $context instanceof RunContext);
+    }
+
+    public function run(ContextInterface $context): TaskResultInterface
+    {
+        $config = $this->getConfig()->getOptions();
+        if (0 === \count($context->getFiles())) {
+            return TaskResult::createSkipped($this, $context);
+        }
+
+        if (0 === \count($config['command'])) {
+            return TaskResult::createNonBlockingFailed(
+                $this,
+                $context,
+                'Missing "command" configuration for task "symfony_console".'
+            );
+        }
+
+        $arguments = $this->processBuilder->createArgumentsForCommand($config['bin']);
+        $arguments->addArgumentArray('%s', $config['command']);
+
+        $process = $this->processBuilder->buildProcess($arguments);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            return TaskResult::createFailed($this, $context, $this->formatter->format($process));
+        }
+
+        return TaskResult::createPassed($this, $context);
+    }
+}

--- a/src/Task/SymfonyConsole.php
+++ b/src/Task/SymfonyConsole.php
@@ -12,7 +12,6 @@ use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Process\PhpExecutableFinder;
 
 /** @extends AbstractExternalTask<ProcessFormatterInterface> */
 class SymfonyConsole extends AbstractExternalTask
@@ -65,12 +64,7 @@ class SymfonyConsole extends AbstractExternalTask
             return TaskResult::createSkipped($this, $context);
         }
 
-        $php = (new PhpExecutableFinder())->find();
-        if (false === $php) {
-            return TaskResult::createFailed($this, $context, 'Unable to locate the PHP executable.');
-        }
-
-        $arguments = $this->processBuilder->createArgumentsForCommand($php);
+        $arguments = $this->processBuilder->createArgumentsForCommand('php');
         $arguments->add($config['bin']);
         $arguments->addArgumentArray('%s', $config['command']);
 

--- a/src/Task/SymfonyConsole.php
+++ b/src/Task/SymfonyConsole.php
@@ -41,7 +41,7 @@ class SymfonyConsole extends AbstractExternalTask
             return TaskResult::createSkipped($this, $context);
         }
 
-        if (0 === \count($config['command'])) {
+        if ('' === \implode('', $config['command'])) {
             return TaskResult::createNonBlockingFailed(
                 $this,
                 $context,

--- a/src/Test/Task/AbstractTaskTestCase.php
+++ b/src/Test/Task/AbstractTaskTestCase.php
@@ -6,7 +6,6 @@ namespace GrumPHP\Test\Task;
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Runner\TaskResult;
-use GrumPHP\Runner\TaskResultInterface;
 use GrumPHP\Task\Config\EmptyTaskConfig;
 use GrumPHP\Task\Config\Metadata;
 use GrumPHP\Task\Config\TaskConfig;
@@ -47,7 +46,7 @@ abstract class AbstractTaskTestCase extends TestCase
     public function it_contains_configurable_options(array $input, ?array $output): void
     {
         if (!$output) {
-            self::expectException(ExceptionInterface::class);
+            $this->expectException(ExceptionInterface::class);
         }
 
         $resolver = $this->task::getConfigurableOptions();

--- a/test/Unit/Task/SymfonyConsoleTest.php
+++ b/test/Unit/Task/SymfonyConsoleTest.php
@@ -9,17 +9,9 @@ use GrumPHP\Task\Context\RunContext;
 use GrumPHP\Task\SymfonyConsole;
 use GrumPHP\Task\TaskInterface;
 use GrumPHP\Test\Task\AbstractExternalTaskTestCase;
-use Symfony\Component\Process\PhpExecutableFinder;
 
 final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
 {
-    private static string|false $php;
-
-    private static function php(): string|false
-    {
-        return self::$php ??= (new PhpExecutableFinder())->find();
-    }
-
     protected function provideTask(): TaskInterface
     {
         return new SymfonyConsole(
@@ -91,7 +83,7 @@ final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             function() {
                 $process = $this->mockProcess(1);
-                $this->mockProcessBuilder(self::php(), $process);
+                $this->mockProcessBuilder('php', $process);
                 $this->formatter->format($process)->willReturn('nope');
             },
             'nope'
@@ -106,7 +98,7 @@ final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             function() {
-                $this->mockProcessBuilder(self::php(), $this->mockProcess());
+                $this->mockProcessBuilder('php', $this->mockProcess());
             }
         ];
 
@@ -117,7 +109,7 @@ final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
             ],
             $this->mockContext(RunContext::class, ['non-related.log']),
             function() {
-                $this->mockProcessBuilder(self::php(), $this->mockProcess());
+                $this->mockProcessBuilder('php', $this->mockProcess());
             }
         ];
     }
@@ -170,7 +162,7 @@ final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
                 'command' => ['lint:container']
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
-            self::php(),
+            'php',
             [
                 './bin/console',
                 'lint:container',
@@ -187,7 +179,7 @@ final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
                 ]
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
-            self::php(),
+            'php',
             [
                 './bin/console',
                 'task:run',

--- a/test/Unit/Task/SymfonyConsoleTest.php
+++ b/test/Unit/Task/SymfonyConsoleTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHPTest\Unit\Task;
+
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Context\ContextInterface;
+use GrumPHP\Task\Context\GitPreCommitContext;
+use GrumPHP\Task\Context\RunContext;
+use GrumPHP\Task\SymfonyConsole;
+use GrumPHP\Task\TaskInterface;
+use GrumPHP\Test\Task\AbstractExternalTaskTestCase;
+
+final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
+{
+    protected function provideTask(): TaskInterface
+    {
+        return new SymfonyConsole(
+            $this->processBuilder->reveal(),
+            $this->formatter->reveal()
+        );
+    }
+
+    public function provideConfigurableOptions(): iterable
+    {
+        yield 'default' => [
+            [],
+            [
+                'bin' => './bin/console',
+                'command' => [],
+            ]
+        ];
+
+        yield 'single-command' => [
+            [
+                'command' => ['task:run'],
+            ],
+            [
+                'bin' => './bin/console',
+                'command' => [
+                    'task:run'
+                ],
+            ]
+        ];
+
+        yield 'array-command' => [
+            [
+                'command' => ['task:run', '--env', 'dev', '-vvv'],
+            ],
+            [
+                'bin' => './bin/console',
+                'command' => [
+                    'task:run',
+                    '--env',
+                    'dev',
+                    '-vvv'
+                ],
+            ]
+        ];
+    }
+
+    public function provideRunContexts(): iterable
+    {
+        yield 'run-context' => [
+            true,
+            $this->mockContext(RunContext::class)
+        ];
+
+        yield 'pre-commit-context' => [
+            true,
+            $this->mockContext(GitPreCommitContext::class)
+        ];
+
+        yield 'other' => [
+            false,
+            $this->mockContext()
+        ];
+    }
+
+    public function provideFailsOnStuff(): iterable
+    {
+        yield 'exitCode1' => [
+            [
+                'command' => ['--version']
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            function() {
+                $process = $this->mockProcess(1);
+                $this->mockProcessBuilder('./bin/console', $process);
+                $this->formatter->format($process)->willReturn('nope');
+            },
+            'nope'
+        ];
+    }
+
+    public function providePassesOnStuff(): iterable
+    {
+        yield 'exitCode0' => [
+            [
+                'command' => ['--version']
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            function() {
+                $this->mockProcessBuilder('./bin/console', $this->mockProcess());
+            }
+        ];
+    }
+
+    public function provideSkipsOnStuff(): iterable
+    {
+        yield 'no-files' => [
+            [],
+            $this->mockContext(RunContext::class),
+            function() {
+            }
+        ];
+    }
+
+    public function provideExternalTaskRuns(): iterable
+    {
+        yield 'single-command' => [
+            [
+                'command' => ['lint:container']
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            './bin/console',
+            [
+                'lint:container',
+            ]
+        ];
+
+        yield 'array-command' => [
+            [
+                'command' => [
+                    'task:run',
+                    '--env',
+                    'dev',
+                    '-vvv'
+                ]
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            './bin/console',
+            [
+                'task:run',
+                '--env',
+                'dev',
+                '-vvv'
+            ]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider provideFailsNonBlockingOnStuff
+     */
+    public function it_fails_non_blocking_on_stuff(
+        array $config,
+        ContextInterface $context,
+        callable $configurator,
+        string $expectedErrorMessage,
+    ): void {
+        $task = $this->configureTask($config);
+        \Closure::bind($configurator, $this)($task->getConfig()->getOptions(), $context);
+        $result = $task->run($context);
+
+        self::assertInstanceOf(TaskResultInterface::class, $result);
+        self::assertSame(TaskResultInterface::NONBLOCKING_FAILED, $result->getResultCode());
+        self::assertSame($task, $result->getTask());
+        self::assertSame($context, $result->getContext());
+        self::assertSame($expectedErrorMessage, $result->getMessage());
+    }
+
+    public function provideFailsNonBlockingOnStuff(): iterable
+    {
+        yield 'no-command' => [
+            [
+                // missing command
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            function() {},
+            'Missing "command" configuration for task "symfony_console".'
+        ];
+
+        yield 'missing-command-data' => [
+            [
+                'command' => [], // missing command config
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            function() {},
+            'Missing "command" configuration for task "symfony_console".'
+        ];
+    }
+}

--- a/test/Unit/Task/SymfonyConsoleTest.php
+++ b/test/Unit/Task/SymfonyConsoleTest.php
@@ -173,7 +173,7 @@ final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
 
     public function provideFailsNonBlockingOnStuff(): iterable
     {
-        yield 'no-command' => [
+        yield 'missing-command' => [
             [
                 // missing command
             ],
@@ -182,9 +182,18 @@ final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
             'Missing "command" configuration for task "symfony_console".'
         ];
 
-        yield 'missing-command-data' => [
+        yield 'empty-command-array' => [
             [
                 'command' => [], // missing command config
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            function() {},
+            'Missing "command" configuration for task "symfony_console".'
+        ];
+
+        yield 'empty-command-data' => [
+            [
+                'command' => [""], // empty command config
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             function() {},

--- a/test/Unit/Task/SymfonyConsoleTest.php
+++ b/test/Unit/Task/SymfonyConsoleTest.php
@@ -4,16 +4,22 @@ declare(strict_types=1);
 
 namespace GrumPHPTest\Unit\Task;
 
-use GrumPHP\Runner\TaskResultInterface;
-use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use GrumPHP\Task\SymfonyConsole;
 use GrumPHP\Task\TaskInterface;
 use GrumPHP\Test\Task\AbstractExternalTaskTestCase;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
 {
+    private static string|false $php;
+
+    private static function php(): string|false
+    {
+        return self::$php ??= (new PhpExecutableFinder())->find();
+    }
+
     protected function provideTask(): TaskInterface
     {
         return new SymfonyConsole(
@@ -25,26 +31,20 @@ final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
     public function provideConfigurableOptions(): iterable
     {
         yield 'default' => [
-            [],
-            [
-                'bin' => './bin/console',
-                'command' => [],
-            ]
-        ];
-
-        yield 'single-command' => [
             [
                 'command' => ['task:run'],
             ],
             [
                 'bin' => './bin/console',
-                'command' => [
-                    'task:run'
-                ],
+                'command' => ['task:run'],
+                'ignore_patterns' => [],
+                'whitelist_patterns' => [],
+                'triggered_by' => ['php', 'yml', 'xml'],
+                'run_always' => false,
             ]
         ];
 
-        yield 'array-command' => [
+        yield 'with-array-command' => [
             [
                 'command' => ['task:run', '--env', 'dev', '-vvv'],
             ],
@@ -56,6 +56,10 @@ final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
                     'dev',
                     '-vvv'
                 ],
+                'ignore_patterns' => [],
+                'whitelist_patterns' => [],
+                'triggered_by' => ['php', 'yml', 'xml'],
+                'run_always' => false,
             ]
         ];
     }
@@ -87,7 +91,7 @@ final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             function() {
                 $process = $this->mockProcess(1);
-                $this->mockProcessBuilder('./bin/console', $process);
+                $this->mockProcessBuilder(self::php(), $process);
                 $this->formatter->format($process)->willReturn('nope');
             },
             'nope'
@@ -102,7 +106,18 @@ final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
             function() {
-                $this->mockProcessBuilder('./bin/console', $this->mockProcess());
+                $this->mockProcessBuilder(self::php(), $this->mockProcess());
+            }
+        ];
+
+        yield 'exitCode0WhenRunAlways' => [
+            [
+                'command' => ['--version'],
+                'run_always' => true,
+            ],
+            $this->mockContext(RunContext::class, ['non-related.log']),
+            function() {
+                $this->mockProcessBuilder(self::php(), $this->mockProcess());
             }
         ];
     }
@@ -110,8 +125,39 @@ final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
     public function provideSkipsOnStuff(): iterable
     {
         yield 'no-files' => [
-            [],
+            [
+                'command' => ['task:run']
+            ],
             $this->mockContext(RunContext::class),
+            function() {
+            }
+        ];
+
+        yield 'no-files-after-ignore-patterns' => [
+            [
+                'command' => ['task:run'],
+                'ignore_patterns' => ['test/'],
+            ],
+            $this->mockContext(RunContext::class, ['test/file.php']),
+            function() {
+            }
+        ];
+
+        yield 'no-files-after-whitelist-patterns' => [
+            [
+                'command' => ['task:run'],
+                'whitelist_patterns' => ['src/'],
+            ],
+            $this->mockContext(RunContext::class, ['config/file.php']),
+            function() {
+            }
+        ];
+
+        yield 'no-files-after-triggered-by' => [
+            [
+                'command' => ['task:run'],
+            ],
+            $this->mockContext(RunContext::class, ['non-trigger-extension.log']),
             function() {
             }
         ];
@@ -124,8 +170,9 @@ final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
                 'command' => ['lint:container']
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
-            './bin/console',
+            self::php(),
             [
+                './bin/console',
                 'lint:container',
             ]
         ];
@@ -140,64 +187,14 @@ final class SymfonyConsoleTest extends AbstractExternalTaskTestCase
                 ]
             ],
             $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
-            './bin/console',
+            self::php(),
             [
+                './bin/console',
                 'task:run',
                 '--env',
                 'dev',
                 '-vvv'
             ]
-        ];
-    }
-
-    /**
-     * @test
-     * @dataProvider provideFailsNonBlockingOnStuff
-     */
-    public function it_fails_non_blocking_on_stuff(
-        array $config,
-        ContextInterface $context,
-        callable $configurator,
-        string $expectedErrorMessage,
-    ): void {
-        $task = $this->configureTask($config);
-        \Closure::bind($configurator, $this)($task->getConfig()->getOptions(), $context);
-        $result = $task->run($context);
-
-        self::assertInstanceOf(TaskResultInterface::class, $result);
-        self::assertSame(TaskResultInterface::NONBLOCKING_FAILED, $result->getResultCode());
-        self::assertSame($task, $result->getTask());
-        self::assertSame($context, $result->getContext());
-        self::assertSame($expectedErrorMessage, $result->getMessage());
-    }
-
-    public function provideFailsNonBlockingOnStuff(): iterable
-    {
-        yield 'missing-command' => [
-            [
-                // missing command
-            ],
-            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
-            function() {},
-            'Missing "command" configuration for task "symfony_console".'
-        ];
-
-        yield 'empty-command-array' => [
-            [
-                'command' => [], // missing command config
-            ],
-            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
-            function() {},
-            'Missing "command" configuration for task "symfony_console".'
-        ];
-
-        yield 'empty-command-data' => [
-            [
-                'command' => [""], // empty command config
-            ],
-            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
-            function() {},
-            'Missing "command" configuration for task "symfony_console".'
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | v2.x 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | #1126 

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

Added Task: Symfony Console: execute symfony command
- :no_entry_sign:  ~php executable finder~
- [x] configurable bin path, defaults to project root `./bin/console`

<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpunit tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [ ] Are all CI services returning green? :warning: awaiting github ci runner

### Future Improvements (not included)
* :no_entry_sign: ~symfony/flex recipe for console component could be required to generate `bin/console` if not existing on the project~
 