### PR TITLE
Support --skip-property-types of ValidateSchemaCommand

### DIFF
--- a/doc/tasks/doctrine_orm.md
+++ b/doc/tasks/doctrine_orm.md
@@ -10,6 +10,7 @@ grumphp:
         doctrine_orm:
             skip_mapping: false
             skip_sync: false
+            skip_property_types: false
             triggered_by: ['php', 'xml', 'yml']
 ```
 
@@ -24,6 +25,12 @@ With this parameter you can skip the mapping validation check.
 *Default: false*
 
 With this parameter you can skip checking if the mapping is in sync with the database.
+
+**skip_property_types**
+
+*Default: false*
+
+With this parameter you can skip checking if Entity field property types match the Doctrine types.
 
 **triggered_by**
 

--- a/src/Task/DoctrineOrm.php
+++ b/src/Task/DoctrineOrm.php
@@ -24,6 +24,7 @@ class DoctrineOrm extends AbstractExternalTask
         $resolver->setDefaults([
             'skip_mapping' => false,
             'skip_sync' => false,
+            'skip_property_types' => false,
             'triggered_by' => ['php', 'xml', 'yml'],
         ]);
 
@@ -58,6 +59,7 @@ class DoctrineOrm extends AbstractExternalTask
         $arguments->add('orm:validate-schema');
         $arguments->addOptionalArgument('--skip-mapping', $config['skip_mapping']);
         $arguments->addOptionalArgument('--skip-sync', $config['skip_sync']);
+        $arguments->addOptionalArgument('--skip-property-types', $config['skip_property_types']);
 
         $process = $this->processBuilder->buildProcess($arguments);
 

--- a/test/Unit/Task/DoctrineOrmTest.php
+++ b/test/Unit/Task/DoctrineOrmTest.php
@@ -25,6 +25,7 @@ class DoctrineOrmTest extends AbstractExternalTaskTestCase
         yield 'defaults' => [
             [],
             [
+                'skip_property_types' => false,
                 'skip_mapping' => false,
                 'skip_sync' => false,
                 'triggered_by' => ['php', 'xml', 'yml'],
@@ -118,6 +119,17 @@ class DoctrineOrmTest extends AbstractExternalTaskTestCase
             [
                 'orm:validate-schema',
                 '--skip-sync',
+            ]
+        ];
+        yield 'skip-property-types' => [
+            [
+                'skip_property_types' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'doctrine',
+            [
+                'orm:validate-schema',
+                '--skip-property-types',
             ]
         ];
     }


### PR DESCRIPTION
Doctrine seems to have added property types validation in the aforementioned command This will allow passing the skip property types option where making changes to that is undesirable

| Q             | A
| ------------- | ---
| Branch        | v2.x (Or, IDK?)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no Because the current behaviour is property types are validated depending on your ORM version, this only allows switching that off
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | -

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

There seems to be an option `skip-property-types` in Doctrine's `ValidateSchemaCommand` which can't be turned off and so always blows up on my on-commit hook and is something I can't/won't fix in my project, but I'd still like the rest of what `ValidateSchemaCommand` does. I guess that's an issue with other people as well.

PS Added a test case, please review though