### PR TITLE
There was a double loading of the autoloader

### DIFF
--- a/bin/grumphp
+++ b/bin/grumphp
@@ -8,9 +8,11 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 (function () {
     // First load current projects autoloader for smarter  global / phar installs ....
     // A bit opinionated at the moment though:
-    $autoloaderInWorkingDirectory = getcwd() . '/vendor/autoload.php';
-    if (is_file($autoloaderInWorkingDirectory)) {
-        require_once $autoloaderInWorkingDirectory;
+    if (getenv('GRUMPHP_ONLY_PROJECT') === false) {
+        $autoloaderInWorkingDirectory = getcwd() . '/vendor/autoload.php';
+        if (is_file($autoloaderInWorkingDirectory)) {
+            require_once $autoloaderInWorkingDirectory;
+        }
     }
 
     // Next load the GrumPHP autoloader


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Documented?   | yes/no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->


<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [ ] Are the dependencies added to the composer.json suggestions?
- [ ] Is the doc/tasks.md file updated?
- [ ] Are the task parameters documented?
- [ ] Is the task registered in the tasks.yml file?
- [ ] Does the task contains phpunit tests?
- [ ] Is the configuration having logical allowed types?
- [ ] Does the task run in the correct context?
- [ ] Is the `run()` method readable?
- [ ] Is the `run()` method using the configuration correctly?
- [ ] Are all CI services returning green?
