### PR TITLE
Adds 'parallel' option support to phpcs task.

### DIFF
--- a/doc/tasks/phpcs.md
+++ b/doc/tasks/phpcs.md
@@ -31,6 +31,7 @@ grumphp:
             triggered_by: [php]
             exclude: []
             show_sniffs_error_path: true
+            parallel: null
 ```
 
 **standard**
@@ -135,6 +136,13 @@ A list of rules that should not be checked. Leave this option blank to run all c
 *Default: true*
 
 Displays the sniff that triggered the error, allowing you to more easily find the specific rules with their namespaces.
+
+**parallel**
+
+*Default: null*
+
+Determines the number of processes that phpcs / phpcbf will use when running. Pass a positive integer for multiple
+processes. You can also pass the string 'auto' and it will use the number of cores / vCPUs your machine supports.
 
 ## Framework presets
 

--- a/doc/tasks/phpcs.md
+++ b/doc/tasks/phpcs.md
@@ -141,8 +141,7 @@ Displays the sniff that triggered the error, allowing you to more easily find th
 
 *Default: null*
 
-Determines the number of processes that phpcs / phpcbf will use when running. Pass a positive integer for multiple
-processes. You can also pass the string 'auto' and it will use the number of cores / vCPUs your machine supports.
+Determines the number of processes that phpcs / phpcbf will use when running. Defaults to a single process.
 
 ## Framework presets
 

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -65,7 +65,7 @@ class Phpcs extends AbstractExternalTask
         $resolver->addAllowedTypes('report_width', ['null', 'int']);
         $resolver->addAllowedTypes('exclude', ['array']);
         $resolver->addAllowedTypes('show_sniffs_error_path', ['bool']);
-        $resolver->addAllowedTypes('parallel', ['null', 'int', 'string']);
+        $resolver->addAllowedTypes('parallel', ['null', 'int']);
 
         return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }

--- a/src/Task/Phpcs.php
+++ b/src/Task/Phpcs.php
@@ -18,6 +18,7 @@ use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 /**
@@ -47,7 +48,8 @@ class Phpcs extends AbstractExternalTask
             'report' => 'full',
             'report_width' => null,
             'exclude' => [],
-            'show_sniffs_error_path' => true
+            'show_sniffs_error_path' => true,
+            'parallel' => null,
         ]);
 
         $resolver->addAllowedTypes('standard', ['array', 'null', 'string']);
@@ -64,6 +66,7 @@ class Phpcs extends AbstractExternalTask
         $resolver->addAllowedTypes('report_width', ['null', 'int']);
         $resolver->addAllowedTypes('exclude', ['array']);
         $resolver->addAllowedTypes('show_sniffs_error_path', ['bool']);
+        $resolver->addAllowedTypes('parallel', ['null', 'int', 'string']);
 
         return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
@@ -161,7 +164,76 @@ class Phpcs extends AbstractExternalTask
         $arguments->addOptionalCommaSeparatedArgument('--ignore=%s', $config['ignore_patterns']);
         $arguments->addOptionalCommaSeparatedArgument('--exclude=%s', $config['exclude']);
         $arguments->addOptionalArgument('-s', $config['show_sniffs_error_path']);
+        $arguments->addOptionalArgument('--parallel=%s', $this->getParallelValue($config['parallel']));
 
         return $arguments;
+    }
+
+    protected function getParallelValue(string|int|null $option): ?int
+    {
+        if ($option === null) {
+            return null;
+        }
+
+        if (is_string($option)) {
+            if ($option === 'auto') {
+                return $this->getNumberOfCpuCores() ?? 1;
+            }
+
+            throw new \InvalidArgumentException(
+                sprintf("When option 'parallel' is a string it can only be 'auto', got '%s'", $option)
+            );
+        }
+
+        if ($option < 1) {
+            throw new \InvalidArgumentException(
+                sprintf("When option 'parallel' is an integer it must be greater than zero, got %d", $option)
+            );
+        }
+
+        return $option;
+    }
+
+    /**
+     * @return int|null
+     */
+    protected function getNumberOfCpuCores(): ?int
+    {
+        try {
+            if (strncasecmp(PHP_OS, 'WIN', 3) === 0) {
+                $process = new Process(['wmic', 'cpu', 'get', 'NumberOfCores']);
+            }
+
+            if (strncasecmp(PHP_OS, 'Linux', 5) === 0 || strncasecmp(PHP_OS, 'Darwin', 6) === 0) {
+                $process = new Process(['nproc']);
+            }
+
+            if (!isset($process)) {
+                return null;
+            }
+
+            $process->run();
+
+            if (!$process->isSuccessful()) {
+                throw new ProcessFailedException($process);
+            }
+
+            $output = $process->getOutput();
+
+            if (strncasecmp(PHP_OS, 'WIN', 3) === 0) {
+                $lines = explode("\n", trim($output));
+                foreach ($lines as $line) {
+                    $cores = (int) trim($line);
+                    if ($cores > 0) {
+                        return $cores;
+                    }
+                }
+                return null;
+            }
+
+            return (int) trim($output);
+        } catch (\Exception) {
+            return null;
+        }
     }
 }

--- a/test/Unit/Task/PhpcsTest.php
+++ b/test/Unit/Task/PhpcsTest.php
@@ -49,7 +49,8 @@ class PhpcsTest extends AbstractExternalTaskTestCase
                 'report' => 'full',
                 'report_width' => null,
                 'exclude' => [],
-                'show_sniffs_error_path' => true
+                'show_sniffs_error_path' => true,
+                'parallel' => null,
             ]
         ];
     }
@@ -353,6 +354,21 @@ class PhpcsTest extends AbstractExternalTaskTestCase
             [
                 '--extensions=php',
                 '--report=full',
+                '--report-json',
+                $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
+            ]
+        ];
+        yield 'parallel' => [
+            [
+              'parallel' => 4,
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'phpcs',
+            [
+                '--extensions=php',
+                '--report=full',
+                '-s',
+                '--parallel=4',
                 '--report-json',
                 $this->expectFileList('hello.php'.PHP_EOL.'hello2.php'),
             ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

This change adds support for 'parallel' option for the phpcs and phpcbf fixer. By default the option is set to null, which means it
runs normally, if it's a positive integer that's the number of processes that will be used. If 'auto' is used the number of processors on the machine will determine the number.

# New Task Checklist:

- [x] Are the dependencies added to the composer.json suggestions?
- [x] Is the doc/tasks.md file updated?
- [x] Are the task parameters documented?
- [x] Is the task registered in the tasks.yml file?
- [x] Does the task contains phpunit tests?
- [x] Is the configuration having logical allowed types?
- [x] Does the task run in the correct context?
- [x] Is the `run()` method readable?
- [x] Is the `run()` method using the configuration correctly?
- [x] Are all CI services returning green?
