### PR TITLE
Adds 'skip_initial_tests' and 'coverage' options support to infection…

### DIFF
--- a/doc/tasks/infection.md
+++ b/doc/tasks/infection.md
@@ -28,6 +28,8 @@ grumphp:
             mutators: []
             ignore_patterns: []
             triggered_by: [php]
+            skip_initial_tests: false
+            coverage: ~
 ```
 
 **threads**
@@ -112,3 +114,16 @@ With this option you can skip files like tests. Leave this option blank to run a
 This option will specify which file extensions will trigger the infection task.
 By default, infection will be triggered by altering a php file. 
 You can overwrite this option to whatever file you want to use!
+
+**skip_initial_tests**
+
+*Default: false*
+
+Skip running the initial tests. If set to `true`, it is necessary to set `coverage` to the
+path where `coverage-xml` and `log-junit` is written by `phpunit` task.
+
+**coverage**
+
+*Default: ~*
+
+Path where `coverage-xml` and `log-junit` is written by `phpunit` task.

--- a/src/Task/Infection.php
+++ b/src/Task/Infection.php
@@ -34,6 +34,8 @@ class Infection extends AbstractExternalTask
             'mutators' => [],
             'ignore_patterns' => [],
             'triggered_by' => ['php'],
+            'skip_initial_tests' => false,
+            'coverage' => null,
         ]);
 
         $resolver->addAllowedTypes('threads', ['null', 'int']);
@@ -47,6 +49,8 @@ class Infection extends AbstractExternalTask
         $resolver->addAllowedTypes('mutators', ['array']);
         $resolver->addAllowedTypes('ignore_patterns', ['array']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
+        $resolver->addAllowedTypes('skip_initial_tests', ['bool']);
+        $resolver->addAllowedTypes('coverage', ['null', 'string']);
 
         return ConfigOptionsResolver::fromOptionsResolver($resolver);
     }
@@ -84,6 +88,8 @@ class Infection extends AbstractExternalTask
         $arguments->addOptionalArgument('--configuration=%s', $config['configuration']);
         $arguments->addOptionalArgument('--min-msi=%s', $config['min_msi']);
         $arguments->addOptionalArgument('--min-covered-msi=%s', $config['min_covered_msi']);
+        $arguments->addOptionalArgument('--coverage=%s', $config['coverage']);
+        $arguments->addOptionalArgument('--skip-initial-tests', $config['skip_initial_tests']);
         $arguments->addOptionalCommaSeparatedArgument('--mutators=%s', $config['mutators']);
 
         if ($context instanceof GitPreCommitContext) {

--- a/test/Unit/Task/InfectionTest.php
+++ b/test/Unit/Task/InfectionTest.php
@@ -36,6 +36,8 @@ class InfectionTest extends AbstractExternalTaskTestCase
                 'mutators' => [],
                 'ignore_patterns' => [],
                 'triggered_by' => ['php'],
+                'skip_initial_tests' => false,
+                'coverage' => null
             ]
         ];
     }
@@ -231,6 +233,30 @@ class InfectionTest extends AbstractExternalTaskTestCase
                 '--no-interaction',
                 '--ignore-msi-with-no-mutations',
                 '--filter=hello.php,hello2.php'
+            ]
+        ];
+        yield 'skip-initial-tests' => [
+            [
+                'skip_initial_tests' => true,
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'infection',
+            [
+                '--no-interaction',
+                '--ignore-msi-with-no-mutations',
+                '--skip-initial-tests'
+            ]
+        ];
+        yield 'coverage' => [
+            [
+                'coverage' => '/path/to/coverage',
+            ],
+            $this->mockContext(RunContext::class, ['hello.php', 'hello2.php']),
+            'infection',
+            [
+                '--no-interaction',
+                '--ignore-msi-with-no-mutations',
+                '--coverage=/path/to/coverage'
             ]
         ];
     }


### PR DESCRIPTION
Infection task.

| Q             | A
| ------------- | ---
| Branch        | v2.x
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | none

This pull request adds the options 'skip_initial_tests' and 'coverage' to the Infection task.

So far, when the Infection task is run, all tests are run to check that they pass, also generating the necessary code coverage to detect the mutants. This is the default operation of infection, but it also has the options 'skip_initial_tests' and 'coverage' that allow to reuse the code coverage generated from PHPUnit, speeding up the Infeciton task.