### PR TITLE
Ticket #1157: support specific filenames as trigger for Shell.

### DIFF
--- a/doc/tasks/shell.md
+++ b/doc/tasks/shell.md
@@ -9,6 +9,8 @@ grumphp:
     tasks:
         shell:
             scripts: []
+            ignore_patterns: [],
+            whitelist_patterns: [],
             triggered_by: [php]
 ```
 
@@ -35,11 +37,30 @@ grumphp:
 
 *Note:* When using the `-c` option, the next argument should contain the full executable with all parameters. Be careful: quotes will be escaped!
 
+**ignore_patterns**
+
+*Default: []*
+
+This is a list of file patterns that will be ignored by the Symfony console task.
+Leave this option blank to run the task for all files defined in the whitelist_patterns and or triggered_by extensions.
+
+**whitelist_patterns**
+
+*Default: []*
+
+This is a list of regex patterns that will filter files to validate. With this option you can skip files like tests.
+This option is used in relation with the parameter `triggered_by`.
+For example: whitelist files in `src/FolderA/` and `src/FolderB/` you can use
+```yaml
+whitelist_patterns:
+    - /^src\/FolderA\/(.*)/
+    - /^src\/FolderB\/(.*)/
+```
 
 **triggered_by**
 
 *Default: [php]*
 
 This option will specify which file extensions will trigger the shell tasks.
-By default, Shell will be triggered by altering a PHP file. 
+By default, Shell will be triggered by altering a PHP file.
 You can overwrite this option to whatever file you want to use!

--- a/doc/tasks/shell.md
+++ b/doc/tasks/shell.md
@@ -41,7 +41,7 @@ grumphp:
 
 *Default: []*
 
-This is a list of file patterns that will be ignored by the Symfony console task.
+This is a list of file patterns that will be ignored by the shell tasks.
 Leave this option blank to run the task for all files defined in the whitelist_patterns and or triggered_by extensions.
 
 **whitelist_patterns**

--- a/test/Unit/Task/ShellTest.php
+++ b/test/Unit/Task/ShellTest.php
@@ -26,6 +26,8 @@ class ShellTest extends AbstractExternalTaskTestCase
             [],
             [
                 'scripts' => [],
+                'ignore_patterns' => [],
+                'whitelist_patterns' => [],
                 'triggered_by' => ['php'],
             ]
         ];
@@ -37,6 +39,8 @@ class ShellTest extends AbstractExternalTaskTestCase
                 'scripts' => [
                     ['phpunit']
                 ],
+                'ignore_patterns' => [],
+                'whitelist_patterns' => [],
                 'triggered_by' => ['php'],
             ]
         ];
@@ -50,6 +54,8 @@ class ShellTest extends AbstractExternalTaskTestCase
                 'scripts' => [
                     ['phpunit', 'tests']
                 ],
+                'ignore_patterns' => [],
+                'whitelist_patterns' => [],
                 'triggered_by' => ['php'],
             ]
         ];
@@ -128,6 +134,22 @@ class ShellTest extends AbstractExternalTaskTestCase
             [],
             $this->mockContext(RunContext::class),
             function () {}
+        ];
+        yield 'no-files-after-ignore-patterns' => [
+            [
+                'ignore_patterns' => ['test/'],
+            ],
+            $this->mockContext(RunContext::class, ['test/file.php']),
+            function() {
+            }
+        ];
+        yield 'no-files-after-whitelist-patterns' => [
+            [
+                'whitelist_patterns' => ['src/'],
+            ],
+            $this->mockContext(RunContext::class, ['config/file.php']),
+            function() {
+            }
         ];
         yield 'no-files-after-triggered-by' => [
             [],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | [feature/1157-triggered_by_filenames](https://github.com/evs-xsarus/grumphp/tree/feature/1157-triggered_by_filenames)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | [comma-separated list of tickets fixed by the PR, if any](https://github.com/phpro/grumphp/issues/1157)

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
Question, I would like to be able to specify a pathname in the filename. This fails now because the pattern is checked against the filename without a path. How to fix?

<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [ ] Are the dependencies added to the composer.json suggestions?
- [ ] Is the doc/tasks.md file updated?
- [ ] Are the task parameters documented?
- [ ] Is the task registered in the tasks.yml file?
- [ ] Does the task contains phpunit tests?
- [ ] Is the configuration having logical allowed types?
- [ ] Does the task run in the correct context?
- [ ] Is the `run()` method readable?
- [ ] Is the `run()` method using the configuration correctly?
- [ ] Are all CI services returning green?
