### PR TITLE
Fix typo in GrumPHPPlugin.php

### DIFF
--- a/src/Composer/GrumPHPPlugin.php
+++ b/src/Composer/GrumPHPPlugin.php
@@ -210,7 +210,7 @@ class GrumPHPPlugin implements PluginInterface, EventSubscriberInterface
     private function runGrumPhpCommand(string $command): void
     {
         if (!$grumphp = $this->detectGrumphpExecutable()) {
-            $this->pluginErrored('no-exectuable');
+            $this->pluginErrored('no-executable');
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | patch-1
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | -

Fix a typo in GrumPHPPlugin - `no-exectuable` -> `no-executable`.