### PR TITLE
Invoke GrumPHP executable using the PHP binary so it respects the PHP version Composer was invoked with.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,9 +108,12 @@
     },
     "scripts": {
         "post-install-cmd": [
-            "GrumPHP\\Composer\\DevelopmentIntegrator::integrate"
+            "@integrate"
         ],
         "post-update-cmd": [
+            "@integrate"
+        ],
+        "integrate": [
             "GrumPHP\\Composer\\DevelopmentIntegrator::integrate"
         ]
     }

--- a/src/Composer/DevelopmentIntegrator.php
+++ b/src/Composer/DevelopmentIntegrator.php
@@ -8,6 +8,7 @@ use Composer\Script\Event;
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Process\ProcessFactory;
 use GrumPHP\Util\Filesystem;
+use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessBuilder;
 
@@ -29,6 +30,10 @@ class DevelopmentIntegrator
         );
 
         $commandlineArgs = ProcessArgumentsCollection::forExecutable($composerExecutable);
+        if ($php = (new PhpExecutableFinder())->find(false)) {
+            $commandlineArgs = ProcessArgumentsCollection::forExecutable($php);
+            $commandlineArgs->add($composerExecutable);
+        }
         $commandlineArgs->add('git:init');
         $process = self::fixInternalComposerProcessVersion($commandlineArgs);
 

--- a/src/Composer/GrumPHPPlugin.php
+++ b/src/Composer/GrumPHPPlugin.php
@@ -17,6 +17,7 @@ use Composer\Package\PackageInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 /**
  * @psalm-suppress MissingConstructor
@@ -90,11 +91,29 @@ class GrumPHPPlugin implements PluginInterface, EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
+            /**
+             * @see GrumPHPPlugin::detectGrumphpAction()
+             */
             PackageEvents::PRE_PACKAGE_INSTALL => 'detectGrumphpAction',
+            /**
+             * @see GrumPHPPlugin::detectGrumphpAction()
+             */
             PackageEvents::POST_PACKAGE_INSTALL => 'detectGrumphpAction',
+            /**
+             * @see GrumPHPPlugin::detectGrumphpAction()
+             */
             PackageEvents::PRE_PACKAGE_UPDATE => 'detectGrumphpAction',
+            /**
+             * @see GrumPHPPlugin::detectGrumphpAction()
+             */
             PackageEvents::PRE_PACKAGE_UNINSTALL => 'detectGrumphpAction',
+            /**
+             * @see GrumPHPPlugin::runScheduledTasks()
+             */
             ScriptEvents::POST_INSTALL_CMD => 'runScheduledTasks',
+            /**
+             * @see GrumPHPPlugin::runScheduledTasks()
+             */
             ScriptEvents::POST_UPDATE_CMD => 'runScheduledTasks',
         ];
     }
@@ -204,13 +223,18 @@ class GrumPHPPlugin implements PluginInterface, EventSubscriberInterface
     {
         $extra = $this->composer->getPackage()->getExtra();
 
-        return !(bool) ($extra['grumphp']['disable-plugin'] ?? false);
+        return !($extra['grumphp']['disable-plugin'] ?? false);
     }
 
     private function runGrumPhpCommand(string $command): void
     {
         if (!$grumphp = $this->detectGrumphpExecutable()) {
             $this->pluginErrored('no-executable');
+            return;
+        }
+
+        if (!$php = (new PhpExecutableFinder())->find(false)) {
+            $this->pluginErrored('no-php-executable');
             return;
         }
 
@@ -236,7 +260,7 @@ class GrumPHPPlugin implements PluginInterface, EventSubscriberInterface
                 function (string $argument): string {
                     return escapeshellarg($argument);
                 },
-                array_filter([$grumphp, $command, $ansi, $silent, $interaction])
+                array_filter([$php, $grumphp, $command, $ansi, $silent, $interaction])
             ))),
             // Map process to current io
             $descriptorspec = array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | invoke-grumphp-using-php-binary
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | -

Fixes #1170