### PR TITLE
Fix Security Checker Enlightn Allow List

### DIFF
--- a/src/Task/SecurityCheckerEnlightn.php
+++ b/src/Task/SecurityCheckerEnlightn.php
@@ -52,7 +52,7 @@ class SecurityCheckerEnlightn extends AbstractExternalTask
         $arguments = $this->processBuilder->createArgumentsForCommand('security-checker');
         $arguments->add('security:check');
         $arguments->addOptionalArgument('%s', $config['lockfile']);
-        $arguments->addOptionalCommaSeparatedArgument('--allow-list=%s', $config['allow_list']);
+        $arguments->addArgumentArray('--allow-list=%s', $config['allow_list']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->run();

--- a/test/Unit/Task/SecurityCheckerEnlightnTest.php
+++ b/test/Unit/Task/SecurityCheckerEnlightnTest.php
@@ -116,7 +116,8 @@ class SecurityCheckerEnlightnTest extends AbstractExternalTaskTestCase
             [
                 'security:check',
                 './composer.lock',
-                '--allow-list=allow_advisory_1,allow_advisory_2'
+                '--allow-list=allow_advisory_1',
+                '--allow-list=allow_advisory_2',
             ]
         ];
     }


### PR DESCRIPTION
Error: Allow list didn't work with more than one entry
Caused by: list was passed as "--allow-list=allow_advisory_1,allow_advisory_2" but arguments "--allow-list=allow_advisory_1" "--allow-list=allow_advisory_2" were expected
See: https://github.com/enlightn/security-checker?tab=readme-ov-file#allow-vulnerabilities

| Q             | A
| ------------- | ---
| Branch        | 2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no, enlightn introduced the allow list in https://github.com/enlightn/security-checker/pull/21 and has always expected the separate arguments
| Documented?   | yes (documentation already existed)
| Fixed tickets | Didn't create a separate bug report for it
