### PR TITLE
Update phpcs.md

### DIFF
--- a/doc/tasks/phpcs.md
+++ b/doc/tasks/phpcs.md
@@ -78,7 +78,7 @@ By default, the standard will specify the optimal tab-width of the code. If you 
 
 *Default: null*
 
-The default encoding used by PHP_CodeSniffer (is ISO-8859-1).
+The default encoding used by PHP_CodeSniffer (is UTF-8).
 
 **report**
 


### PR DESCRIPTION
According to wiki, default encoding was change to UTF-8 on january 2018 https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options/de508093882766045fd0bb98da9a7769dee87411

| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->


<!-- Are you creating a new task? Make sure to complete this checklist: -->

# New Task Checklist:

- [ ] Are the dependencies added to the composer.json suggestions?
- [ ] Is the doc/tasks.md file updated?
- [ ] Are the task parameters documented?
- [ ] Is the task registered in the tasks.yml file?
- [ ] Does the task contains phpunit tests?
- [ ] Is the configuration having logical allowed types?
- [ ] Does the task run in the correct context?
- [ ] Is the `run()` method readable?
- [ ] Is the `run()` method using the configuration correctly?
- [ ] Are all CI services returning green?
