### PR TITLE
Update services.yml to remove suffixes for windows added by default from symfony/process

### DIFF
--- a/resources/config/services.yml
+++ b/resources/config/services.yml
@@ -18,7 +18,7 @@ services:
     executable_finder:
         class: Symfony\Component\Process\ExecutableFinder
         calls:
-            - { method: 'setSuffixes', arguments: [['.phar', '.exe', '.bat', '.cmd', '.com']] }
+            - { method: 'setSuffixes', arguments: [['.phar']] }
 
     process_builder:
       class: GrumPHP\Process\ProcessBuilder


### PR DESCRIPTION
…rom symfony/process

Prevent problem for suffixes for Linux/WSL users

| Q             | A
| ------------- | ---
| Branch        | master for features and deprecations
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | 1185

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->
When using grumPHP with dependencies, if users are on WSL, .bat is present and is taking precedence over "no extension" phpcs and others.


