### PR TITLE
Fix installation link for deptrac

### DIFF
--- a/doc/tasks/deptrac.md
+++ b/doc/tasks/deptrac.md
@@ -1,6 +1,6 @@
 # Deptrac
 
-Follow the [installation instructions](https://qossmic.github.io/deptrac/#installation) to add deptrac to your 
+Follow the [installation instructions](https://deptrac.github.io/deptrac/#installation) to add deptrac to your 
 project.
 
 The Deptrac task will check for dependencies between the software layers of your project. It lives under the `deptrac` 


### PR DESCRIPTION
Updated the installation link for deptrac documentation.

| Q             | A
| ------------- | ---
| Branch        | v2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes

<!-- Please add an advanced description on what this PR is doing to GrumPHP. -->

In the documentation of deptrac, there was an incorrect link to the github.io of deptract
