### PR TITLE
Add support for doctrine/collections 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "composer-plugin-api": "^2.0",
         "amphp/amp": "^3.0",
         "amphp/parallel": "^2.1",
-        "doctrine/collections": "^1.6.8 || ^2.0",
+        "doctrine/collections": "^1.6.8 || ^2.0 || ^3.0",
         "gitonomy/gitlib": "^1.6",
         "laravel/serializable-closure": "^2.0",
         "monolog/monolog": "^2.0 || ^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0e0e9e2b8bec94254bd30afe611cfb9",
+    "content-hash": "31684f1eec777f8ff990da5f793ba8a3",
     "packages": [
         {
             "name": "amphp/amp",


### PR DESCRIPTION
## Summary

- Extends the `doctrine/collections` version constraint from `^1.6.8 || ^2.0` to `^1.6.8 || ^2.0 || ^3.0`
- No code changes required — GrumPHP's collection classes only use core `ArrayCollection` methods that remain fully compatible in 3.x
- doctrine/collections 3.0.0 requires PHP 8.4+, so Composer's platform resolution automatically selects 3.x on PHP 8.4/8.5 and 2.x on PHP 8.2/8.3

## Compatibility notes

- `filter()` and `map()` gained native `Collection` return types in 3.x; `FilesCollection::filter(): self` is a valid covariant override ✓
- Internally `filter()` still uses `createFrom()` → `new static()`, so subclasses continue to receive their own type at runtime ✓
- No GrumPHP code extends any of the classes made `final` in 3.x (`Criteria`, `Expr\*`, `ExpressionBuilder`) ✓

## Checklist

- [x] Branch: `v2.x`
- [x] Bug fix: no
- [x] New feature: no
- [x] BC breaks: no
- [x] Deprecations: no
- [x] Fixed tickets: N/A