### PR TITLE
Reduce memory consumption in FilesCollection

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -32,5 +32,10 @@
                 <directory name="src/" />
             </errorLevel>
         </ClassMustBeFinal>
+        <DeprecatedMethod>
+            <errorLevel type="suppress">
+                <directory name="src/" />
+            </errorLevel>
+        </DeprecatedMethod>
     </issueHandlers>
 </psalm>

--- a/src/Collection/FilesCollection.php
+++ b/src/Collection/FilesCollection.php
@@ -7,26 +7,17 @@ namespace GrumPHP\Collection;
 use Closure;
 use Doctrine\Common\Collections\ArrayCollection;
 use GrumPHP\Util\Regex;
-use Symfony\Component\Finder\Comparator;
-use Symfony\Component\Finder\Iterator;
 use SplFileInfo;
-use Symfony\Component\Finder\SplFileInfo as SymfonySplFileInfo;
 use Traversable;
 
 /**
- * @extends ArrayCollection<array-key, \SplFileInfo>
+ * @extends ArrayCollection<array-key, string>
  */
 class FilesCollection extends ArrayCollection
 {
     /**
-     * @param \Traversable<array-key, \SplFileInfo> $iterator
-     */
-    public static function fromTraversable(\Traversable $iterator): FilesCollection
-    {
-        return new self(array_values(iterator_to_array($iterator)));
-    }
-
-    /**
+     * @deprecated use FilesCollectionFilter::name directly
+     *
      * Adds a rule that files must match.
      *
      * You can use a pattern (delimited with / sign), a glob or a simple string.
@@ -39,10 +30,12 @@ class FilesCollection extends ArrayCollection
      */
     public function name($pattern): self
     {
-        return $this->names([$pattern]);
+        return FilesCollectionFilter::name($this, $pattern);
     }
 
     /**
+     * @deprecated use FilesCollectionFilter::names directly
+     *
      * Adds rules that files must match.
      *
      * You can use patterns (delimited with / sign), globs or simple strings.
@@ -53,12 +46,12 @@ class FilesCollection extends ArrayCollection
      */
     public function names(array $patterns): self
     {
-        $filter = new Iterator\FilenameFilterIterator($this->getIterator(), $patterns, []);
-
-        return self::fromTraversable($filter);
+        return FilesCollectionFilter::names($this, $patterns);
     }
 
     /**
+     * @deprecated use FilesCollectionFilter::notName directly
+     *
      * Adds rules that files must match.
      *
      * You can use patterns (delimited with / sign), globs or simple strings.
@@ -69,36 +62,36 @@ class FilesCollection extends ArrayCollection
      */
     public function notName(string $pattern): self
     {
-        $filter = new Iterator\FilenameFilterIterator($this->getIterator(), [], [$pattern]);
-
-        return self::fromTraversable($filter);
+        return FilesCollectionFilter::notName($this, $pattern);
     }
 
     /**
+     * @deprecated use FilesCollectionFilter::path directly
+     *
      * Filter by path.
      *
      * $collection->path('/^spec\/')
      */
     public function path(string $pattern): self
     {
-        return $this->paths([$pattern]);
+        return FilesCollectionFilter::path($this, $pattern);
     }
 
     /**
+     * @deprecated use FilesCollectionFilter::paths directly
+     *
      * Filter by paths.
      *
      * $collection->paths(['/^spec\/','/^src\/'])
-     *
-     * @psalm-suppress ArgumentTypeCoercion - Works on int, \SplFileInfo as well
      */
     public function paths(array $patterns): self
     {
-        $filter = new Iterator\PathFilterIterator($this->getIterator(), $patterns, []);
-
-        return self::fromTraversable($filter);
+        return FilesCollectionFilter::paths($this, $patterns);
     }
 
     /**
+     * @deprecated use FilesCollectionFilter::notPath directly
+     *
      * Adds rules that filenames must not match.
      *
      * You can use patterns (delimited with / sign) or simple strings.
@@ -107,54 +100,50 @@ class FilesCollection extends ArrayCollection
      */
     public function notPath(string $pattern): self
     {
-        return $this->notPaths([$pattern]);
+        return FilesCollectionFilter::notPath($this, $pattern);
     }
 
     /**
+     * @deprecated use FilesCollectionFilter::notPaths directly
+     *
      * Adds rules that filenames must not match.
      *
      * You can use patterns (delimited with / sign) or simple strings.
      *
      * $collection->notPaths(['/^spec\/','/^src\/'])
-     *
-     * @psalm-suppress ArgumentTypeCoercion - Works on int, \SplFileInfo as well
      */
     public function notPaths(array $pattern): self
     {
-        $filter = new Iterator\PathFilterIterator($this->getIterator(), [], $pattern);
-
-        return self::fromTraversable($filter);
-    }
-
-    public function extensions(array $extensions): self
-    {
-        if (!\count($extensions)) {
-            return new self();
-        }
-
-        return $this->name(sprintf('/\.(%s)$/i', implode('|', $extensions)));
+        return FilesCollectionFilter::notPaths($this, $pattern);
     }
 
     /**
+     * @deprecated use FilesCollectionFilter::extensions directly
+     */
+    public function extensions(array $extensions): self
+    {
+        return FilesCollectionFilter::extensions($this, $extensions);
+    }
+
+    /**
+     * @deprecated use FilesCollectionFilter::size directly
+     *
      * Adds tests for file sizes.
      *
      * $collection->filterBySize('> 10K');
      * $collection->filterBySize('<= 1Ki');
      * $collection->filterBySize(4);
      *
-     *
-     *
      * @see NumberComparator
      */
     public function size(string $size): self
     {
-        $comparator = new Comparator\NumberComparator($size);
-        $filter = new Iterator\SizeRangeFilterIterator($this->getIterator(), [$comparator]);
-
-        return self::fromTraversable($filter);
+        return FilesCollectionFilter::size($this, $size);
     }
 
     /**
+     * @deprecated use FilesCollectionFilter::date directly
+     *
      * Adds tests for file dates (last modified).
      *
      * The date must be something that strtotime() is able to parse:
@@ -164,25 +153,20 @@ class FilesCollection extends ArrayCollection
      * $collection->filterByDate('> now - 2 hours');
      * $collection->filterByDate('>= 2005-10-15');
      *
-     *
-     *
      * @see DateComparator
      */
     public function date(string $date): self
     {
-        $comparator = new Comparator\DateComparator($date);
-        $filter = new Iterator\DateRangeFilterIterator($this->getIterator(), [$comparator]);
-
-        return self::fromTraversable($filter);
+        return FilesCollectionFilter::date($this, $date);
     }
 
     /**
+     * @deprecated use FilesCollectionFilter::filter directly
+     *
      * Filters the iterator with an anonymous function.
      *
      * The anonymous function receives a \SplFileInfo and must return false
      * to remove files.
-     *
-     *
      *
      * @see CustomFilterIterator
      *
@@ -192,26 +176,20 @@ class FilesCollection extends ArrayCollection
      */
     public function filter(Closure $p): self
     {
-        $filter = new Iterator\CustomFilterIterator($this->getIterator(), [$p]);
-
-        return self::fromTraversable($filter);
+        return FilesCollectionFilter::filter($this, $p);
     }
 
     /**
+     * @deprecated use FilesCollectionFilter::filterByFileList directly
+     *
      * @param Traversable<array-key, SplFileInfo> $fileList
      */
-    public function filterByFileList(Traversable $fileList): FilesCollection
+    public function filterByFileList(Traversable $fileList): self
     {
-        $allowedFiles = array_map(function (SplFileInfo $file) {
-            return $file->getPathname();
-        }, iterator_to_array($fileList));
-
-        return $this->filter(function (SplFileInfo $file) use ($allowedFiles) {
-            return \in_array($file->getPathname(), $allowedFiles, true);
-        });
+        return FilesCollectionFilter::filterByFileList($this, $fileList);
     }
 
-    public function ensureFiles(self $files): FilesCollection
+    public function ensureFiles(self $files): self
     {
         $newFiles = new self($this->toArray());
 
@@ -224,47 +202,25 @@ class FilesCollection extends ArrayCollection
         return $newFiles;
     }
 
-    public function ignoreSymlinks(): FilesCollection
+    /**
+     * @deprecated use FilesCollectionFilter::ignoreSymlinks directly
+     */
+    public function ignoreSymlinks(): self
     {
-        return $this->filter(function (SplFileInfo $file) {
-            return !$file->isLink();
-        });
+        return FilesCollectionFilter::ignoreSymlinks($this);
     }
 
-    /**
-     * SplFileInfo cannot be serialized. Therefor, we help PHP a bit.
-     * This stuff is used for running tasks in parallel.
-     */
     public function __serialize(): array
     {
-        return $this->map(function (SplFileInfo $fileInfo): string {
-            return $fileInfo instanceof SymfonySplFileInfo
-                ? $fileInfo->getRelativePathname()
-                : $fileInfo->getPathname();
-        })->toArray();
+        return $this->toArray();
     }
 
-    /**
-     * SplFileInfo cannot be serialized. Therefor, we help PHP a bit.
-     * This stuff is used for running tasks in parallel.
-     */
     public function __unserialize(array $data): void
     {
-        $files = $data;
         $this->clear();
-        foreach ($files as $file) {
-            $this->add(new SymfonySplFileInfo($file, dirname($file), $file));
+        foreach ($data as $path) {
+            $this->add($path);
         }
-    }
-
-    /**
-     * Help Psalm out a bit:
-     *
-     * @return \ArrayIterator<array-key, SplFileInfo>
-     */
-    public function getIterator(): \ArrayIterator
-    {
-        return new \ArrayIterator($this->toArray());
     }
 
     public function toFileList(): string

--- a/src/Collection/FilesCollectionFilter.php
+++ b/src/Collection/FilesCollectionFilter.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GrumPHP\Collection;
+
+use Closure;
+use GrumPHP\Util\Regex;
+use Symfony\Component\Finder\Comparator;
+use Symfony\Component\Finder\Iterator;
+use Symfony\Component\Finder\SplFileInfo as SymfonySplFileInfo;
+use Traversable;
+
+/**
+ * Stateless helper that applies SplFileInfo-based filters on a FilesCollection
+ * of string paths. SplFileInfo instances are created transiently for the
+ * Symfony Finder iterators
+ */
+final class FilesCollectionFilter
+{
+    /**
+     * Adds a rule that files must match.
+     *
+     * You can use a pattern (delimited with / sign), a glob or a simple string.
+     *
+     * FilesCollectionFilter::name($collection, '*.php')
+     * FilesCollectionFilter::name($collection, '/\.php$/') // same as above
+     * FilesCollectionFilter::name($collection, 'test.php')
+     *
+     * @param string|Regex $pattern A pattern (a regexp, a glob, or a string)
+     */
+    public static function name(FilesCollection $files, $pattern): FilesCollection
+    {
+        return self::names($files, [$pattern]);
+    }
+
+    /**
+     * Adds rules that files must match.
+     *
+     * You can use patterns (delimited with / sign), globs or simple strings.
+     *
+     * FilesCollectionFilter::names($collection, ['*.php'])
+     * FilesCollectionFilter::names($collection, ['/\.php$/']) // same as above
+     * FilesCollectionFilter::names($collection, ['test.php'])
+     */
+    public static function names(FilesCollection $files, array $patterns): FilesCollection
+    {
+        $filter = new Iterator\FilenameFilterIterator(self::toFileInfoIterator($files), $patterns, []);
+
+        return self::toFilesCollection($filter);
+    }
+
+    /**
+     * Adds rules that files must not match.
+     *
+     * You can use a pattern (delimited with / sign), a glob or a simple string.
+     *
+     * FilesCollectionFilter::notName($collection, '*.php')
+     * FilesCollectionFilter::notName($collection, '/\.php$/') // same as above
+     * FilesCollectionFilter::notName($collection, 'test.php')
+     */
+    public static function notName(FilesCollection $files, string $pattern): FilesCollection
+    {
+        $filter = new Iterator\FilenameFilterIterator(self::toFileInfoIterator($files), [], [$pattern]);
+
+        return self::toFilesCollection($filter);
+    }
+
+    /**
+     * Filter by path.
+     *
+     * FilesCollectionFilter::path($collection, '/^spec\/')
+     */
+    public static function path(FilesCollection $files, string $pattern): FilesCollection
+    {
+        return self::paths($files, [$pattern]);
+    }
+
+    /**
+     * Filter by paths.
+     *
+     * FilesCollectionFilter::paths($collection, ['/^spec\/','/^src\/'])
+     */
+    public static function paths(FilesCollection $files, array $patterns): FilesCollection
+    {
+        $filter = new Iterator\PathFilterIterator(self::toFileInfoIterator($files), $patterns, []);
+
+        return self::toFilesCollection($filter);
+    }
+
+    /**
+     * Adds rules that filenames must not match.
+     *
+     * You can use patterns (delimited with / sign) or simple strings.
+     *
+     * FilesCollectionFilter::notPath($collection, '/^spec\/')
+     */
+    public static function notPath(FilesCollection $files, string $pattern): FilesCollection
+    {
+        return self::notPaths($files, [$pattern]);
+    }
+
+    /**
+     * Adds rules that filenames must not match.
+     *
+     * You can use patterns (delimited with / sign) or simple strings.
+     *
+     * FilesCollectionFilter::notPaths($collection, ['/^spec\/','/^src\/'])
+     */
+    public static function notPaths(FilesCollection $files, array $patterns): FilesCollection
+    {
+        $filter = new Iterator\PathFilterIterator(self::toFileInfoIterator($files), [], $patterns);
+
+        return self::toFilesCollection($filter);
+    }
+
+    public static function extensions(FilesCollection $files, array $extensions): FilesCollection
+    {
+        if (!\count($extensions)) {
+            return new FilesCollection();
+        }
+
+        return self::name($files, sprintf('/\.(%s)$/i', implode('|', $extensions)));
+    }
+
+    /**
+     * Adds tests for file sizes.
+     *
+     * FilesCollectionFilter::size($collection, '> 10K');
+     * FilesCollectionFilter::size($collection, '<= 1Ki');
+     * FilesCollectionFilter::size($collection, '4');
+     *
+     * @see NumberComparator
+     */
+    public static function size(FilesCollection $files, string $size): FilesCollection
+    {
+        $comparator = new Comparator\NumberComparator($size);
+        $filter = new Iterator\SizeRangeFilterIterator(self::toFileInfoIterator($files), [$comparator]);
+
+        return self::toFilesCollection($filter);
+    }
+
+    /**
+     * Adds tests for file dates (last modified).
+     *
+     * The date must be something that strtotime() is able to parse:
+     *
+     * FilesCollectionFilter::date($collection, 'since yesterday');
+     * FilesCollectionFilter::date($collection, 'until 2 days ago');
+     * FilesCollectionFilter::date($collection, '> now - 2 hours');
+     * FilesCollectionFilter::date($collection, '>= 2005-10-15');
+     *
+     * @see DateComparator
+     */
+    public static function date(FilesCollection $files, string $date): FilesCollection
+    {
+        $comparator = new Comparator\DateComparator($date);
+        $filter = new Iterator\DateRangeFilterIterator(self::toFileInfoIterator($files), [$comparator]);
+
+        return self::toFilesCollection($filter);
+    }
+
+    /**
+     * Filters the iterator with an anonymous function.
+     *
+     * @see CustomFilterIterator
+     */
+    public static function filter(FilesCollection $files, Closure $p): FilesCollection
+    {
+        $filter = new Iterator\CustomFilterIterator(self::toFileInfoIterator($files), [$p]);
+
+        return self::toFilesCollection($filter);
+    }
+
+    public static function ignoreSymlinks(FilesCollection $files): FilesCollection
+    {
+        return self::filter($files, static function (\SplFileInfo $file): bool {
+            return !$file->isLink();
+        });
+    }
+
+    /**
+     * Keeps only files whose pathname is present in the given file list.
+     *
+     * @param Traversable<array-key, \SplFileInfo> $fileList
+     */
+    public static function filterByFileList(FilesCollection $files, Traversable $fileList): FilesCollection
+    {
+        $allowedFiles = [];
+        foreach ($fileList as $file) {
+            $allowedFiles[$file->getPathname()] = true;
+        }
+
+        return self::filter($files, static function (\SplFileInfo $file) use ($allowedFiles): bool {
+            return isset($allowedFiles[$file->getPathname()]);
+        });
+    }
+
+    /**
+     * @return \Generator<string, SymfonySplFileInfo>
+     */
+    private static function toFileInfoIterator(FilesCollection $files): \Generator
+    {
+        foreach ($files as $path) {
+            yield $path => new SymfonySplFileInfo($path, \dirname($path), $path);
+        }
+    }
+
+    /**
+     * @param Traversable<array-key, \SplFileInfo> $iterator
+     */
+    private static function toFilesCollection(Traversable $iterator): FilesCollection
+    {
+        $paths = [];
+        foreach ($iterator as $file) {
+            $paths[] = $file->getPathname();
+        }
+
+        return new FilesCollection($paths);
+    }
+}

--- a/src/Collection/ProcessArgumentsCollection.php
+++ b/src/Collection/ProcessArgumentsCollection.php
@@ -93,35 +93,18 @@ class ProcessArgumentsCollection extends ArrayCollection
     public function addFiles(FilesCollection $files): void
     {
         foreach ($files as $file) {
-            $this->addFile($file);
+            $this->add($file);
         }
-    }
-
-    public function addFile(\SplFileInfo $file): void
-    {
-        $this->add($file->getPathname());
     }
 
     public function addCommaSeparatedFiles(FilesCollection $files): void
     {
-        $paths = [];
-
-        foreach ($files as $file) {
-            $paths[] = $file->getPathname();
-        }
-
-        $this->add(implode(',', $paths));
+        $this->add(implode(',', $files->toArray()));
     }
 
     public function addArgumentWithCommaSeparatedFiles(string $argument, FilesCollection $files): void
     {
-        $paths = [];
-
-        foreach ($files as $file) {
-            $paths[] = $file->getPathname();
-        }
-
-        $this->add(sprintf($argument, implode(',', $paths)));
+        $this->add(sprintf($argument, implode(',', $files->toArray())));
     }
 
     public function addOptionalBooleanArgument(

--- a/src/Console/Command/Git/CommitMsgCommand.php
+++ b/src/Console/Command/Git/CommitMsgCommand.php
@@ -119,6 +119,16 @@ class CommitMsgCommand extends Command
 
         $results = $this->taskRunner->run($context);
 
+        if ($this->io->isVerbose()) {
+            $this->io->write([
+                PHP_EOL,
+                sprintf(
+                    '<comment>Peak memory usage: %.1f MB</comment>',
+                    (float) memory_get_peak_usage(true) / 1024.0 / 1024.0
+                )
+            ]);
+        }
+
         return $results->isFailed() ? self::EXIT_CODE_NOK : self::EXIT_CODE_OK;
     }
 

--- a/src/Console/Command/Git/PreCommitCommand.php
+++ b/src/Console/Command/Git/PreCommitCommand.php
@@ -90,6 +90,16 @@ class PreCommitCommand extends Command
 
         $results = $this->taskRunner->run($context);
 
+        if ($this->io->isVerbose()) {
+            $this->io->write([
+                PHP_EOL,
+                sprintf(
+                    '<comment>Peak memory usage: %.1f MB</comment>',
+                    (float) memory_get_peak_usage(true) / 1024.0 / 1024.0
+                )
+            ]);
+        }
+
         return $results->isFailed() ? self::EXIT_CODE_NOK : self::EXIT_CODE_OK;
     }
 

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -102,6 +102,16 @@ class RunCommand extends Command
 
         $results = $this->taskRunner->run($context);
 
+        if ($this->io->isVerbose()) {
+            $this->io->write([
+                PHP_EOL,
+                sprintf(
+                    '<comment>Peak memory usage: %.1f MB</comment>',
+                    (float) memory_get_peak_usage(true) / 1024.0 / 1024.0
+                )
+            ]);
+        }
+
         return $results->isFailed() ? self::EXIT_CODE_NOK : self::EXIT_CODE_OK;
     }
 

--- a/src/Linter/Json/JsonLintError.php
+++ b/src/Linter/Json/JsonLintError.php
@@ -10,9 +10,9 @@ use SplFileInfo;
 
 class JsonLintError extends LintError
 {
-    public static function fromParsingException(SplFileInfo $file, ParsingException $exception): self
+    public static function fromParsingException(string $file, ParsingException $exception): self
     {
-        return new self(LintError::TYPE_ERROR, $exception->getMessage(), $file->getPathname(), 0);
+        return new self(LintError::TYPE_ERROR, $exception->getMessage(), $file, 0);
     }
 
     public function __toString(): string

--- a/src/Linter/Json/JsonLinter.php
+++ b/src/Linter/Json/JsonLinter.php
@@ -37,13 +37,13 @@ class JsonLinter implements LinterInterface
     /**
      * @throws ParsingException
      */
-    public function lint(SplFileInfo $file): LintErrorsCollection
+    public function lint(string $file): LintErrorsCollection
     {
         $errors = new LintErrorsCollection();
         $flags = $this->calculateFlags();
 
         try {
-            $json = $this->filesystem->readFromFileInfo($file);
+            $json = $this->filesystem->readPath($file);
             $this->jsonParser->parse($json, $flags);
         } catch (ParsingException $exception) {
             $errors->add(JsonLintError::fromParsingException($file, $exception));

--- a/src/Linter/LinterInterface.php
+++ b/src/Linter/LinterInterface.php
@@ -9,7 +9,7 @@ use SplFileInfo;
 
 interface LinterInterface
 {
-    public function lint(SplFileInfo $file): LintErrorsCollection;
+    public function lint(string $file): LintErrorsCollection;
 
     public function isInstalled(): bool;
 }

--- a/src/Linter/Xml/XmlLinter.php
+++ b/src/Linter/Xml/XmlLinter.php
@@ -33,7 +33,7 @@ class XmlLinter implements LinterInterface
      */
     private $schemeValidation = false;
 
-    public function lint(SplFileInfo $file): LintErrorsCollection
+    public function lint(string $file): LintErrorsCollection
     {
         $errors = new LintErrorsCollection();
         $useInternalErrors = $this->useInternalXmlLoggin(true);
@@ -96,7 +96,7 @@ class XmlLinter implements LinterInterface
         return libxml_use_internal_errors($useInternalErrors);
     }
 
-    private function loadDocument(SplFileInfo $file): ?DOMDocument
+    private function loadDocument(string $file): ?DOMDocument
     {
         $this->registerXmlStreamContext();
 
@@ -104,7 +104,7 @@ class XmlLinter implements LinterInterface
         $document->resolveExternals = $this->loadFromNet;
         $document->preserveWhiteSpace = false;
         $document->formatOutput = false;
-        $loaded = $document->load($file->getPathname());
+        $loaded = $document->load($file);
 
         return $loaded ? $document : null;
     }
@@ -156,7 +156,7 @@ class XmlLinter implements LinterInterface
         return $document->validate();
     }
 
-    private function validateInternalSchemes(SplFileInfo $file, DOMDocument $document): bool
+    private function validateInternalSchemes(string $file, DOMDocument $document): bool
     {
         $schemas = [];
         $attributes = $document->documentElement->attributes;
@@ -187,13 +187,13 @@ class XmlLinter implements LinterInterface
     /**
      * @return null|string
      */
-    private function locateScheme(SplFileInfo $xmlFile, string $scheme)
+    private function locateScheme(string $xmlFile, string $scheme)
     {
         if (filter_var($scheme, FILTER_VALIDATE_URL)) {
             return $this->loadFromNet ? $scheme : null;
         }
 
-        $xmlFilePath = $xmlFile->getPath();
+        $xmlFilePath = \dirname($xmlFile);
         $schemePath = empty($xmlFilePath) ? $scheme : rtrim($xmlFilePath, '/').DIRECTORY_SEPARATOR.$scheme;
 
         $schemeFile = new SplFileInfo($schemePath);

--- a/src/Linter/Yaml/YamlLinter.php
+++ b/src/Linter/Yaml/YamlLinter.php
@@ -56,15 +56,15 @@ class YamlLinter implements LinterInterface
         $this->filesystem = $filesystem;
     }
 
-    public function lint(SplFileInfo $file): LintErrorsCollection
+    public function lint(string $file): LintErrorsCollection
     {
         $errors = new LintErrorsCollection();
 
         try {
-            $content = $this->filesystem->readFromFileInfo($file);
+            $content = $this->filesystem->readPath($file);
             $this->parseYaml($content);
         } catch (ParseException $exception) {
-            $exception->setParsedFile($file->getPathname());
+            $exception->setParsedFile($file);
             $errors[] = YamlLintError::fromParseException($exception);
         }
 

--- a/src/Locator/ChangedFiles.php
+++ b/src/Locator/ChangedFiles.php
@@ -63,7 +63,7 @@ class ChangedFiles
                 continue;
             }
 
-            $files[] = $fileObject;
+            $files[] = $fileObject->getPathname();
         }
 
         return new FilesCollection($files);

--- a/src/Locator/ListedFiles.php
+++ b/src/Locator/ListedFiles.php
@@ -26,8 +26,7 @@ class ListedFiles
 
         $files = [];
         foreach (array_filter($filePaths) as $file) {
-            $relativeFile = $this->paths->makePathRelativeToProjectDir($file);
-            $files[] = new SplFileInfo($relativeFile, dirname($relativeFile), $relativeFile);
+            $files[] = $this->paths->makePathRelativeToProjectDir($file);
         }
 
         return new FilesCollection($files);

--- a/src/Parser/ParserInterface.php
+++ b/src/Parser/ParserInterface.php
@@ -9,7 +9,7 @@ use SplFileInfo;
 
 interface ParserInterface
 {
-    public function parse(SplFileInfo $file): ParseErrorsCollection;
+    public function parse(string $file): ParseErrorsCollection;
 
     public function isInstalled(): bool;
 }

--- a/src/Parser/Php/PhpParser.php
+++ b/src/Parser/Php/PhpParser.php
@@ -54,19 +54,20 @@ class PhpParser implements ParserInterface
         $this->parserOptions = $options;
     }
 
-    public function parse(SplFileInfo $file): ParseErrorsCollection
+    public function parse(string $file): ParseErrorsCollection
     {
+        $fileObject = new SplFileInfo($file);
         $errors = new ParseErrorsCollection();
-        $context = new ParserContext($file, $errors);
+        $context = new ParserContext($fileObject, $errors);
         $parser = $this->parserFactory->createFromOptions($this->parserOptions);
         $traverser = $this->traverserFactory->createForTaskContext($this->parserOptions, $context);
 
         try {
-            $code = $this->filesystem->readFromFileInfo($file);
+            $code = $this->filesystem->readFromFileInfo($fileObject);
             $stmts = $parser->parse($code);
             $traverser->traverse((array) $stmts);
         } catch (Error $e) {
-            $errors->add(PhpParserError::fromParseException($e, $file->getRealPath()));
+            $errors->add(PhpParserError::fromParseException($e, $fileObject->getRealPath()));
         }
 
         return $errors;

--- a/src/Task/Composer.php
+++ b/src/Task/Composer.php
@@ -102,9 +102,9 @@ class Composer extends AbstractExternalTask
         return TaskResult::createPassed($this, $context);
     }
 
-    private function hasLocalRepository(SplFileInfo $composerFile): bool
+    private function hasLocalRepository(string $composerFile): bool
     {
-        $json = $this->filesystem->readFromFileInfo($composerFile);
+        $json = $this->filesystem->readPath($composerFile);
         $package = json_decode($json, true);
 
         if (!array_key_exists('repositories', $package)) {

--- a/src/Task/FileSize.php
+++ b/src/Task/FileSize.php
@@ -78,7 +78,7 @@ class FileSize implements TaskInterface
             foreach ($files as $file) {
                 $errorMessage .= sprintf(
                     '- %s exceeded the maximum size of %s.'.PHP_EOL,
-                    $file->getFilename(),
+                    $file,
                     $maxSize
                 );
             }

--- a/src/Test/Task/AbstractTaskTestCase.php
+++ b/src/Test/Task/AbstractTaskTestCase.php
@@ -168,14 +168,7 @@ abstract class AbstractTaskTestCase extends TestCase
         /** @var ContextInterface|ObjectProphecy $context */
         $context = (new Prophet())->prophesize($class);
         $context->getFiles()->willReturn(
-            new FilesCollection(
-                array_map(
-                    static function ($file): SplFileInfo {
-                        return $file instanceof SplFileInfo ? $file : new SplFileInfo($file, $file, $file);
-                    },
-                    $files
-                )
-            )
+            new FilesCollection($files)
         );
 
         return $context->reveal();

--- a/test/Unit/Linter/Xml/XmlLinterTest.php
+++ b/test/Unit/Linter/Xml/XmlLinterTest.php
@@ -26,7 +26,7 @@ class XmlLinterTest extends TestCase
     /**
      * @param string $fixture
      *
-     * @return SplFileInfo
+     * @return string
      */
     private function getFixture($fixture)
     {
@@ -35,7 +35,7 @@ class XmlLinterTest extends TestCase
             throw new RuntimeException(sprintf('The fixture %s could not be loaded!', $fixture));
         }
 
-        return $file;
+        return $file->getPathname();
     }
 
     /**

--- a/test/Unit/Task/ComposerTest.php
+++ b/test/Unit/Task/ComposerTest.php
@@ -10,7 +10,6 @@ use GrumPHP\Task\Composer;
 use GrumPHP\Task\TaskInterface;
 use GrumPHP\Test\Task\AbstractExternalTaskTestCase;
 use GrumPHP\Util\Filesystem;
-use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 
 class ComposerTest extends AbstractExternalTaskTestCase
@@ -83,7 +82,7 @@ class ComposerTest extends AbstractExternalTaskTestCase
             self::mockContext(RunContext::class, ['composer.json']),
             function () {
                 $this->mockProcessBuilder('composer', self::mockProcess(0));
-                $this->filesystem->readFromFileInfo(Argument::which('getBasename', 'composer.json'))->willReturn(
+                $this->filesystem->readPath('composer.json')->willReturn(
                     json_encode([
                         'repositories' => [
                             ['type' => 'path'],
@@ -100,7 +99,7 @@ class ComposerTest extends AbstractExternalTaskTestCase
             self::mockContext(RunContext::class, ['composer.json']),
             function () {
                 $this->mockProcessBuilder('composer', self::mockProcess(0));
-                $this->filesystem->readFromFileInfo(Argument::which('getBasename', 'composer.json'))->willReturn(
+                $this->filesystem->readPath('composer.json')->willReturn(
                     json_encode([
                         'repositories' => [
                             ['type' => 'path'],
@@ -129,7 +128,7 @@ class ComposerTest extends AbstractExternalTaskTestCase
             self::mockContext(RunContext::class, ['composer.json']),
             function () {
                 $this->mockProcessBuilder('composer', self::mockProcess(0));
-                $this->filesystem->readFromFileInfo(Argument::which('getBasename', 'composer.json'))->willReturn(
+                $this->filesystem->readPath('composer.json')->willReturn(
                     json_encode([
                         'name' => 'my/package',
                     ])
@@ -143,7 +142,7 @@ class ComposerTest extends AbstractExternalTaskTestCase
             self::mockContext(RunContext::class, ['composer.json']),
             function () {
                 $this->mockProcessBuilder('composer', self::mockProcess(0));
-                $this->filesystem->readFromFileInfo(Argument::which('getBasename', 'composer.json'))->willReturn(
+                $this->filesystem->readPath('composer.json')->willReturn(
                     json_encode([
                         'repositories' => [
                             ['type' => 'git'],
@@ -159,7 +158,7 @@ class ComposerTest extends AbstractExternalTaskTestCase
             self::mockContext(RunContext::class, ['composer.json']),
             function () {
                 $this->mockProcessBuilder('composer', self::mockProcess(0));
-                $this->filesystem->readFromFileInfo(Argument::which('getBasename', 'composer.json'))->willReturn(
+                $this->filesystem->readPath('composer.json')->willReturn(
                     json_encode([
                         'repositories' => [
                             ['packagist.org' => false],

--- a/test/Unit/Task/FileSizeTest.php
+++ b/test/Unit/Task/FileSizeTest.php
@@ -10,11 +10,12 @@ use GrumPHP\Task\Context\RunContext;
 use GrumPHP\Task\FileSize;
 use GrumPHP\Task\TaskInterface;
 use GrumPHP\Test\Task\AbstractTaskTestCase;
-use Prophecy\Prophet;
-use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Filesystem\Filesystem;
 
 class FileSizeTest extends AbstractTaskTestCase
 {
+    protected static ?Filesystem $filesystem;
+
     protected function provideTask(): TaskInterface
     {
         return new FileSize();
@@ -58,42 +59,41 @@ class FileSizeTest extends AbstractTaskTestCase
 
     public static function provideFailsOnStuff(): iterable
     {
+        $singleFile1 = self::fixture('single-invalid/file1.php', 6);
+        $singleFile2 = self::fixture('single-invalid/file2.php', 12);
         yield 'single-invalid-filesizes' => [
             [],
-            self::mockContext(RunContext::class, [
-                self::mockFile('file1.php', 6),
-                self::mockFile('file2.php', 12),
-            ]),
+            self::mockContext(RunContext::class, [$singleFile1, $singleFile2]),
             function (array $options, ContextInterface $context) {
             },
             'Large files detected:'.PHP_EOL.
-            '- file2.php exceeded the maximum size of 10M.'.PHP_EOL,
+            '- '. $singleFile2 .' exceeded the maximum size of 10M.'.PHP_EOL,
         ];
+
+        $invalidFile1 = self::fixture('invalid/file1.php', 12);
+        $invalidFile2 = self::fixture('invalid/file2.php', 12);
         yield 'invalid-filesizes' => [
             [],
-            self::mockContext(RunContext::class, [
-                self::mockFile('file1.php', 12),
-                self::mockFile('file2.php', 12),
-            ]),
+            self::mockContext(RunContext::class, [$invalidFile1, $invalidFile2]),
             function (array $options, ContextInterface $context) {
             },
             'Large files detected:'.PHP_EOL.
-            '- file1.php exceeded the maximum size of 10M.'.PHP_EOL.
-            '- file2.php exceeded the maximum size of 10M.'.PHP_EOL,
+            '- '.$invalidFile1.' exceeded the maximum size of 10M.'.PHP_EOL.
+            '- '.$invalidFile2.' exceeded the maximum size of 10M.'.PHP_EOL,
         ];
+
+        $customFile1 = self::fixture('invalid-custom/file1.php', 12);
+        $customFile2 = self::fixture('invalid-custom/file2.php', 12);
         yield 'invalid-filesizes-custom-size' => [
             [
                 'max_size' => '5M'
             ],
-            self::mockContext(RunContext::class, [
-                self::mockFile('file1.php', 12),
-                self::mockFile('file2.php', 12),
-            ]),
+            self::mockContext(RunContext::class, [$customFile1, $customFile2]),
             function (array $options, ContextInterface $context) {
             },
             'Large files detected:'.PHP_EOL.
-            '- file1.php exceeded the maximum size of 5M.'.PHP_EOL.
-            '- file2.php exceeded the maximum size of 5M.'.PHP_EOL,
+            '- '.$customFile1.' exceeded the maximum size of 5M.'.PHP_EOL.
+            '- '.$customFile2.' exceeded the maximum size of 5M.'.PHP_EOL,
         ];
     }
 
@@ -102,8 +102,8 @@ class FileSizeTest extends AbstractTaskTestCase
         yield 'valid-filesizes' => [
             [],
             self::mockContext(RunContext::class, [
-                self::mockFile('file1.php', 6),
-                self::mockFile('file2.php', 6),
+                self::fixture('valid/file1.php', 6),
+                self::fixture('valid/file2.php', 6),
             ]),
             function () {
             }
@@ -113,14 +113,14 @@ class FileSizeTest extends AbstractTaskTestCase
                 'ignore_patterns' => ['test/'],
             ],
             self::mockContext(RunContext::class, [
-                self::mockFile('test/file.php', 2323, true),
+                self::fixture('ignored/test/file.php', 12),
             ]),
             function () {}
         ];
         yield 'dont-validate-symlinks' => [
             [],
             self::mockContext(RunContext::class, [
-                self::mockFile('file.php', 2323, true),
+                self::fixtureSymlink('symlinks/file.php', 12),
             ]),
             function () {}
         ];
@@ -136,16 +136,51 @@ class FileSizeTest extends AbstractTaskTestCase
         ];
     }
 
-    private static function mockFile(string $file, int $megaBytes, $isSymlink = false): SplFileInfo
+    public static function tearDownAfterClass(): void
     {
-        /** @var SplFileInfo $mock */
-        $mock = (new Prophet())->prophesize(SplFileInfo::class);
-        $mock->getFilename()->willReturn($file);
-        $mock->getRelativePathname()->willReturn($file);
-        $mock->isLink()->willReturn($isSymlink);
-        $mock->isFile()->willReturn(true);
-        $mock->getSize()->willReturn($megaBytes * 1024 * 1024);
+        self::filesystem()->remove(self::fixtureRoot());
+    }
 
-        return $mock->reveal();
+    private static function fixture(string $relative, int $sizeMB): string
+    {
+        $path = self::fixtureRoot() . '/' . $relative;
+
+        self::filesystem()->mkdir(\dirname($path));
+        self::createFileWithContent($path, $sizeMB);
+
+        return $path;
+    }
+
+    private static function fixtureSymlink(string $relative, int $sizeMB): string
+    {
+        $linkPath = self::fixtureRoot() . '/' . $relative;
+        self::filesystem()->mkdir(\dirname($linkPath));
+
+        $targetPath = \dirname($linkPath) . '/_target_' . \basename($linkPath);
+        self::createFileWithContent($targetPath, $sizeMB);
+
+        self::filesystem()->remove($linkPath);
+        self::filesystem()->symlink($targetPath, $linkPath);
+
+        return $linkPath;
+    }
+
+    private static function createFileWithContent(string $path, int $sizeMB): void
+    {
+        $fh = \fopen($path, 'w');
+        \ftruncate($fh, $sizeMB * 1024 * 1024);
+        \fclose($fh);
+    }
+
+    private static function fixtureRoot(): string
+    {
+        return \sys_get_temp_dir() . '/grumphp-filesize-test';
+    }
+
+    private static function filesystem(): Filesystem
+    {
+        self::$filesystem ??= new Filesystem();
+
+        return self::$filesystem;
     }
 }

--- a/test/fixtures/e2e/tasks/ValidatePathsTask.php
+++ b/test/fixtures/e2e/tasks/ValidatePathsTask.php
@@ -55,9 +55,7 @@ class ValidatePathsTask implements TaskInterface
 
     public function run(ContextInterface $context): TaskResultInterface
     {
-        $contextFiles = $context->getFiles()->map(function(\SplFileInfo $file) {
-            return $file->getPathname();
-        })->toArray();
+        $contextFiles = $context->getFiles()->toArray();
 
         try {
             Assert::assertEquals($this->availableFiles, $contextFiles);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | n/a
| Fixed tickets | #1218 

This PR reduces memory consumption in `FilesCollection`. The key changes:
1. Lower memory in parallel mode. When GrumPHP runs tasks in parallel via `amphp/parallel`, the file collection is serialized and shipped to worker processes. Previously each file was immediately unpacked into a full `SymfonySplFileInfo` object levereging a lot of memory. Now the worker receives plain strings and only builds the objects when something actually iterates over them
2. ensureFiles() - appends one file collection to another without duplicates. It now keeps known paths in a plain hash-map array, so duplicate checks are constant across time.
3. Added printing `Peak memory usage: X.X MB` at the end of commands for easier diagnostic (only in verbose mode)

### Results

Before

```
Running tasks with priority 0!
==============================

Running task 1/12: jsonlint... ✔
Running task 2/12: xmllint... ✔
Running task 3/12: yamllint... ✔
Running task 4/12: openapi... ✔
Running task 5/12: rector... ✔
Running task 6/12: behat... ✔
Running task 7/12: phpmd... ✔
Running task 8/12: phpcs... ✔
Running task 9/12: phpstan... ✔
Running task 10/12: psalm... ✔
Running task 11/12: test-unit... ✔
Running task 12/12: test-integration... ✔

Peak memory usage: 1152.0 MB
```

After

```
Running tasks with priority 0!
==============================

Running task 1/12: jsonlint... ✔
Running task 2/12: xmllint... ✔
Running task 3/12: yamllint... ✔
Running task 4/12: openapi... ✔
Running task 5/12: rector... ✔
Running task 6/12: behat... ✔
Running task 7/12: phpmd... ✔
Running task 8/12: phpcs... ✔
Running task 9/12: phpstan... ✔
Running task 10/12: psalm... ✔
Running task 11/12: test-unit... ✔
Running task 12/12: test-integration... ✔

Peak memory usage: 126.0 MB
```