### PR TITLE
Fix raw Console markup rendered by ConsoleSectionOutput::overwrite()

### DIFF
--- a/src/Runner/Reporting/TaskResultsReporter.php
+++ b/src/Runner/Reporting/TaskResultsReporter.php
@@ -84,7 +84,11 @@ class TaskResultsReporter
             return;
         }
 
-        $this->outputSection->overwrite(implode(PHP_EOL, $message));
+        $formatter = $this->outputSection->getFormatter();
+        $this->outputSection->overwrite(implode(PHP_EOL, array_map(
+            static fn(string $line): string => $formatter->format($line),
+            $message
+        )));
     }
 
     private function parseTasksDisplayMap(TaskRunnerContext $context): array

--- a/src/Runner/Reporting/TaskResultsReporter.php
+++ b/src/Runner/Reporting/TaskResultsReporter.php
@@ -86,7 +86,7 @@ class TaskResultsReporter
 
         $formatter = $this->outputSection->getFormatter();
         $this->outputSection->overwrite(implode(PHP_EOL, array_map(
-            static fn(string $line): string => $formatter->format($line),
+            static fn(string $line): string => (string) $formatter->format($line),
             $message
         )));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes (documentation already exists)
| Fixed tickets | Did not create a separate bug report for this

While updating recent Drupal core security fix (Symfony were updated to 7.4.12) noticed that markup in the console did not render correctly in a decorated (ANSI) terminal:

Before:
```
GrumPHP is sniffing your code!

Running tasks with priority 0!
==============================

Running task 1/6: composer... ✔
Running task 2/6: phplint... ✔
Running task 3/6: yamllint... ✔
Running task 4/6: phpcs... ✔
```
After:
```
GrumPHP is sniffing your code!

Running tasks with priority 0!
==============================

Running task 1/6: composer... <fg=green>✔</fg=green>
Running task 2/6: phplint... <fg=green>✔</fg=green>
Running task 3/6: yamllint... <fg=green>✔</fg=green>
Running task 4/6: phpcs... <fg=green>✔</fg=green>
```

Symfony's ConsoleSectionOutput::overwrite() does not pass content through the output formatter. When `report()` calls `overwrite()` with raw markup strings like `<fg=green>✔</fg=green>`, they render as literal text instead of ANSI colour codes.

It seems that the bug was already present but hidden — `report()` only calls `overwrite()` when `$this->content` is non-empty (i.e. after the first task result). The first call always falls back to `writeln()`, which formats correctly. With 2 or more tasks in a decorated terminal, subsequent calls hit the `overwrite()` path with unformatted markup.
