### PR TITLE
Add cache CLI options for eslint

### DIFF
--- a/doc/tasks/eslint.md
+++ b/doc/tasks/eslint.md
@@ -34,6 +34,8 @@ grumphp:
                 - /^resources\/js\/(.*)/
             config: .eslintrc.json
             ignore_path: .eslintignore
+            cache: ~
+            cache_location: ~
             debug: false
             format: ~
             max_warnings: ~
@@ -78,6 +80,18 @@ The path to your eslint's configuration file. Not necessary if using a standard 
 *Default: null*
 
 The path to your eslint's ignore file ([eslint.org](https://eslint.org/docs/user-guide/configuring/ignoring-code#using-an-alternate-file)). Not necessary if using standard .eslintignore name.
+
+**cache**
+
+*Default: null*
+
+Store the results of processed files so that eslint only operates on the changed ones. By default, the cache is stored in `./.eslintcache ` in `process.cwd()`. ([eslint.org](https://eslint.org/docs/latest/use/command-line-interface#caching)).
+
+**cache_location**
+
+*Default: null*
+
+Path to a file or directory for the cache location. ([eslint.org](https://eslint.org/docs/latest/use/command-line-interface#--cache-location)).
 
 **debug**
 

--- a/src/Task/ESLint.php
+++ b/src/Task/ESLint.php
@@ -34,6 +34,8 @@ class ESLint extends AbstractExternalTask
             // ESLint native config options
             'config' => null,
             'ignore_path' => null,
+            'cache' => null,
+            'cache_location' => null,
             'debug' => false,
             'format' => null,
             'max_warnings' => null,
@@ -49,6 +51,8 @@ class ESLint extends AbstractExternalTask
         // ESLint native config options
         $resolver->addAllowedTypes('config', ['null', 'string']);
         $resolver->addAllowedTypes('ignore_path', ['null', 'string']);
+        $resolver->addAllowedTypes('cache', ['null', 'bool']);
+        $resolver->addAllowedTypes('cache_location', ['null', 'string']);
         $resolver->addAllowedTypes('debug', ['bool']);
         $resolver->addAllowedTypes('format', ['null', 'string']);
         $resolver->addAllowedTypes('max_warnings', ['null', 'integer']);
@@ -82,6 +86,8 @@ class ESLint extends AbstractExternalTask
 
         $arguments->addOptionalArgument('--config=%s', $config['config']);
         $arguments->addOptionalArgument('--ignore-path=%s', $config['ignore_path']);
+        $arguments->addOptionalArgument('--cache', $config['cache']);
+        $arguments->addOptionalArgument('--cache-location=%s', $config['cache_location']);
         $arguments->addOptionalArgument('--debug', $config['debug']);
         $arguments->addOptionalArgument('--format=%s', $config['format']);
         $arguments->addOptionalArgument('--no-eslintrc', $config['no_eslintrc']);

--- a/test/Unit/Task/ESLintTest.php
+++ b/test/Unit/Task/ESLintTest.php
@@ -34,6 +34,8 @@ class ESLintTest extends AbstractExternalTaskTestCase
                 // ESLint native config options
                 'config' => null,
                 'ignore_path' => null,
+                'cache' => null,
+                'cache_location' => null,
                 'debug' => false,
                 'format' => null,
                 'max_warnings' => null,
@@ -142,6 +144,30 @@ class ESLintTest extends AbstractExternalTaskTestCase
             'eslint',
             [
                 '--ignore-path=.eslintignore',
+                'hello.js',
+                'hello2.js',
+            ]
+        ];
+        yield 'cache' => [
+            [
+                'cache' => true,
+            ],
+            self::mockContext(RunContext::class, ['hello.js', 'hello2.js']),
+            'stylelint',
+            [
+                '--cache',
+                'hello.js',
+                'hello2.js',
+            ]
+        ];
+        yield 'cache_location' => [
+            [
+                'cache_location' => 'path/to/cache',
+            ],
+            self::mockContext(RunContext::class, ['hello.js', 'hello2.js']),
+            'stylelint',
+            [
+                '--cache-location=path/to/cache',
                 'hello.js',
                 'hello2.js',
             ]

--- a/test/Unit/Task/ESLintTest.php
+++ b/test/Unit/Task/ESLintTest.php
@@ -153,7 +153,7 @@ class ESLintTest extends AbstractExternalTaskTestCase
                 'cache' => true,
             ],
             self::mockContext(RunContext::class, ['hello.js', 'hello2.js']),
-            'stylelint',
+            'eslint',
             [
                 '--cache',
                 'hello.js',
@@ -165,7 +165,7 @@ class ESLintTest extends AbstractExternalTaskTestCase
                 'cache_location' => 'path/to/cache',
             ],
             self::mockContext(RunContext::class, ['hello.js', 'hello2.js']),
-            'stylelint',
+            'eslint',
             [
                 '--cache-location=path/to/cache',
                 'hello.js',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 2.x
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | no

Add the cache options for eslint, same as stylelint