### PR TITLE
Support git autosquash `amend!` prefix in commit message task

### DIFF
--- a/src/Task/Git/CommitMessage.php
+++ b/src/Task/Git/CommitMessage.php
@@ -24,6 +24,12 @@ class CommitMessage implements TaskInterface
         '(Merge branch|tag \'.+\'(?:\s.+)?|Merge remote-tracking branch \'.+\'|Merge pull request #\d+\s.+)';
 
     /**
+     * Subject prefixes added by git's autosquash helpers
+     * (`git commit --fixup`, `--squash`, `--fixup=amend:` and `--fixup=reword:`).
+     */
+    private const AUTOSQUASH_PREFIXES = 'fixup|squash|amend';
+
+    /**
      * @var TaskConfigInterface
      */
     private $config;
@@ -252,7 +258,7 @@ class CommitMessage implements TaskInterface
 
     private function getSpecialPrefixLength(string $string): int
     {
-        if (1 !== preg_match('/^(fixup|squash)! /', $string, $match)) {
+        if (1 !== preg_match('/^(' . self::AUTOSQUASH_PREFIXES . ')! /', $string, $match)) {
             return 0;
         }
 
@@ -312,7 +318,11 @@ class CommitMessage implements TaskInterface
 
         $firstLetter = $match[1] ?? '';
 
-        return !(1 !== preg_match('/^(fixup|squash)!/u', $subject) && 1 !== preg_match('/[[:upper:]]/u', $firstLetter));
+        if (1 === preg_match('/^(' . self::AUTOSQUASH_PREFIXES . ')!/u', $subject)) {
+            return true;
+        }
+
+        return 1 === preg_match('/[[:upper:]]/u', $firstLetter);
     }
 
     private function subjectIsSingleLined(GitCommitMsgContext $context): bool
@@ -375,7 +385,7 @@ class CommitMessage implements TaskInterface
 
         $scopes = $config['type_scope_conventions']['scopes'] ?? [];
 
-        $specialPrefix = '(?:(?:fixup|squash)! )?';
+        $specialPrefix = '(?:(?:' . self::AUTOSQUASH_PREFIXES . ')! )?';
         $typesPattern = '([a-zA-Z0-9]+)';
         $scopesPattern = '(:\s|(\(.+\)?:\s))';
 

--- a/test/Unit/Task/Git/CommitMessageTest.php
+++ b/test/Unit/Task/Git/CommitMessageTest.php
@@ -488,6 +488,14 @@ class CommitMessageTest extends AbstractTaskTestCase
             function () {
             }
         ];
+        yield 'dont-enforce_capitalized_subject_amend' => [
+            [
+                'enforce_capitalized_subject' => true,
+            ],
+            self::mockCommitMsgContext(self::amend('no capital subject')),
+            function () {
+            }
+        ];
         yield 'enforce_capitalized_subject_special_utf8_char' => [
             [
                 'enforce_capitalized_subject' => true,
@@ -557,6 +565,14 @@ class CommitMessageTest extends AbstractTaskTestCase
                 'max_subject_width' => 10,
             ],
             self::mockCommitMsgContext(self::squash('123456789')),
+            function () {
+            }
+        ];
+        yield 'enforce_text_with_special_prefix_amend' => [
+            [
+                'max_subject_width' => 10,
+            ],
+            self::mockCommitMsgContext(self::amend('123456789')),
             function () {
             }
         ];
@@ -685,6 +701,38 @@ class CommitMessageTest extends AbstractTaskTestCase
                 ],
             ],
             self::mockCommitMsgContext(self::squash('fix(app): match type scope convention')),
+            function () {
+            },
+        ];
+        yield 'amend_type_scope_conventions_match_type_without_scope' => [
+            [
+                'enforce_capitalized_subject' => false,
+                'type_scope_conventions' => [
+                    'types' => [
+                        'fix'
+                    ],
+                    'scopes' => [
+                        'app'
+                    ]
+                ],
+            ],
+            self::mockCommitMsgContext(self::amend('fix: match type scope convention')),
+            function () {
+            },
+        ];
+        yield 'amend_type_scope_conventions_match_type_with_scope' => [
+            [
+                'enforce_capitalized_subject' => false,
+                'type_scope_conventions' => [
+                    'types' => [
+                        'fix'
+                    ],
+                    'scopes' => [
+                        'app'
+                    ]
+                ],
+            ],
+            self::mockCommitMsgContext(self::amend('fix(app): match type scope convention')),
             function () {
             },
         ];
@@ -944,6 +992,17 @@ class CommitMessageTest extends AbstractTaskTestCase
         return self::buildMessage(
             'squash! '.$subject,
             '# This was created by running git commit --squash=...',
+            ...$messages
+        );
+    }
+
+    private static function amend(string ... $messages): string
+    {
+        $subject = array_shift($messages);
+
+        return self::buildMessage(
+            'amend! '.$subject,
+            '# This was created by running git commit --fixup=amend:...',
             ...$messages
         );
     }


### PR DESCRIPTION
  | Q             | A
  | ------------- | ---
  | Branch        | v2.x
  | Bug fix?      | no
  | New feature?  | yes
  | BC breaks?    | no
  | Deprecations? | no
  | Documented?   | no
  | Fixed tickets | no

`git commit --fixup=amend:` / `--fixup=reword:` produce an `amend! …` subject (sibling of `fixup!`/`squash!`), but `amend!` was missing from the three spots those prefixes are special-cased, so amend commits were rejected. Adds `amend` - centralized into one constant - with unit tests mirroring the existing `fixup`/`squash` cases.