### PR TITLE
Read files from the worktree git dir instead of the shared repository

### DIFF
--- a/doc/installation/exotic.md
+++ b/doc/installation/exotic.md
@@ -94,6 +94,8 @@ The path to the root directory of your git project.
 The path to the directory in which git stores it objects etc.
 Most of the time this is the .git folder.
 When using GIT submodules, this is the location of the submodule .git folder.
+Inside a linked git worktree, this points at the shared repository root, since worktrees run the hooks
+of the main repository. File listing and diffs still use the worktree's own branch.
 
 **GRUMPHP_COMPOSER_DIR**
 

--- a/src/Configuration/GuessedPaths.php
+++ b/src/Configuration/GuessedPaths.php
@@ -43,6 +43,11 @@ class GuessedPaths
      */
     private $configFile;
 
+    /**
+     * @var string
+     */
+    private $gitWorktreeDir;
+
     public function __construct(
         string $gitWorkingDir,
         string $gitRepositoryDir,
@@ -50,7 +55,8 @@ class GuessedPaths
         string $projectDir,
         string $binDir,
         ComposerFile $composerFile,
-        string $configFile
+        string $configFile,
+        ?string $gitWorktreeDir = null
     ) {
         $this->gitWorkingDir = $gitWorkingDir;
         $this->gitRepositoryDir = $gitRepositoryDir;
@@ -59,6 +65,7 @@ class GuessedPaths
         $this->binDir = $binDir;
         $this->composerFile = $composerFile;
         $this->configFile = $configFile;
+        $this->gitWorktreeDir = $gitWorktreeDir ?? $gitRepositoryDir;
     }
 
     public function getGitWorkingDir(): string
@@ -69,6 +76,11 @@ class GuessedPaths
     public function getGitRepositoryDir(): string
     {
         return $this->gitRepositoryDir;
+    }
+
+    public function getGitWorktreeDir(): string
+    {
+        return $this->gitWorktreeDir;
     }
 
     public function getWorkingDir(): string

--- a/src/Locator/EnrichedGuessedPathsFromDotEnvLocator.php
+++ b/src/Locator/EnrichedGuessedPathsFromDotEnvLocator.php
@@ -37,6 +37,10 @@ class EnrichedGuessedPathsFromDotEnvLocator
             (string) ($_SERVER['GRUMPHP_GIT_REPOSITORY_DIR'] ?? $guessedPaths->getGitRepositoryDir()),
             $workingDir
         );
+        $gitWorktreeDir = $this->filesystem->makePathAbsolute(
+            (string) ($_SERVER['GRUMPHP_GIT_REPOSITORY_DIR'] ?? $guessedPaths->getGitWorktreeDir()),
+            $workingDir
+        );
         $binDir = $this->filesystem->makePathAbsolute(
             (string) ($_SERVER['GRUMPHP_BIN_DIR'] ?? $guessedPaths->getBinDir()),
             $workingDir
@@ -49,7 +53,8 @@ class EnrichedGuessedPathsFromDotEnvLocator
             $projectDir,
             $binDir,
             $guessedPaths->getComposerFile(),
-            $guessedPaths->getConfigFile()
+            $guessedPaths->getConfigFile(),
+            $gitWorktreeDir
         );
     }
 }

--- a/src/Locator/GitRepositoryDirLocator.php
+++ b/src/Locator/GitRepositoryDirLocator.php
@@ -20,9 +20,27 @@ class GitRepositoryDirLocator
 
     /**
      * Resolves the path to the git repository directory (aka as .git).
-     * For submodules, it parses the .git file and resolves to the .git/modules/[submodules] directory
+     * For submodules, it parses the .git file and resolves to the .git/modules/[submodules] directory.
+     * For worktrees, it resolves to the common repository root, since worktrees share the main
+     * repository's hooks. Use locateWorktreeGitDir() when the worktree's own git dir is required.
      */
     public function locate(string $gitDir): string
+    {
+        return $this->resolveGitDir($gitDir, true);
+    }
+
+    /**
+     * Resolves the git directory used to read files and diffs.
+     * For worktrees this returns the worktree's own git dir (.git/worktrees/[id]) instead of collapsing
+     * to the common repository root, so file listing and diffs reflect the worktree's branch.
+     * For submodules and normal checkouts this is identical to locate().
+     */
+    public function locateWorktreeGitDir(string $gitDir): string
+    {
+        return $this->resolveGitDir($gitDir, false);
+    }
+
+    private function resolveGitDir(string $gitDir, bool $collapseWorktreeToRoot): string
     {
         if (!$this->filesystem->isFile($gitDir)) {
             return $gitDir;
@@ -36,7 +54,9 @@ class GitRepositoryDirLocator
         $gitRepositoryDir = $matches[1];
 
         if ($this->isWorktree($gitRepositoryDir)) {
-            return $this->locateWorktreeRoot($gitRepositoryDir);
+            return $collapseWorktreeToRoot
+                ? $this->locateWorktreeRoot($gitRepositoryDir)
+                : $gitRepositoryDir;
         }
 
         return $this->filesystem->buildPath(

--- a/src/Locator/GitRepositoryLocator.php
+++ b/src/Locator/GitRepositoryLocator.php
@@ -22,7 +22,7 @@ class GitRepositoryLocator
     public function locate(array $options): Repository
     {
         return new Repository(
-            $this->paths->getGitRepositoryDir(),
+            $this->paths->getGitWorktreeDir(),
             array_merge(
                 [
                     'working_dir' => $this->paths->getGitWorkingDir(),

--- a/src/Locator/GuessedPathsLocator.php
+++ b/src/Locator/GuessedPathsLocator.php
@@ -56,6 +56,12 @@ class GuessedPathsLocator
             )),
             $workingDir
         );
+        $gitWorktreeDir = $this->filesystem->makePathAbsolute(
+            (string) ($_SERVER['GRUMPHP_GIT_REPOSITORY_DIR'] ?? $this->gitRepositoryDirLocator->locateWorktreeGitDir(
+                $this->filesystem->buildPath($gitWorkingDir, '.git')
+            )),
+            $workingDir
+        );
 
         $composerFilePathname = $this->filesystem->guessFile(
             [
@@ -125,7 +131,8 @@ class GuessedPathsLocator
             $projectDir,
             $binDir,
             $composerFile,
-            $defaultConfigFile
+            $defaultConfigFile,
+            $gitWorktreeDir
         );
     }
 

--- a/src/Util/Paths.php
+++ b/src/Util/Paths.php
@@ -69,6 +69,15 @@ class Paths
         return $this->guessedPaths->getGitRepositoryDir();
     }
 
+    /**
+     * The git dir to read files and diffs from. Inside a linked worktree this is the worktree's own
+     * git dir; for normal checkouts and submodules it equals getGitRepositoryDir().
+     */
+    public function getGitWorktreeDir(): string
+    {
+        return $this->guessedPaths->getGitWorktreeDir();
+    }
+
     public function getBinDir(): string
     {
         return $this->guessedPaths->getBinDir();

--- a/test/E2E/AbstractE2ETestCase.php
+++ b/test/E2E/AbstractE2ETestCase.php
@@ -87,6 +87,25 @@ abstract class AbstractE2ETestCase extends TestCase
         return $this->filesystem->buildPath($gitPath, basename($submodulePath));
     }
 
+    protected function addGitWorktree(string $fromGitPath, string $worktreeName, string $branch): string
+    {
+        $this->changeGitPermissions();
+        $worktreePath = $this->relativeRootPath($worktreeName);
+        $this->runCommand('add git worktree', new Process(
+            [$this->executableFinder->find('git'), 'worktree', 'add', '-b', $branch, $worktreePath],
+            $fromGitPath
+        ));
+
+        return $worktreePath;
+    }
+
+    protected function commitAllWithoutHook(string $gitPath)
+    {
+        $git = $this->executableFinder->find('git');
+        $this->gitAddPath($gitPath);
+        $this->runCommand('commit without hook', new Process([$git, 'commit', '--no-verify', '-mtest'], $gitPath));
+    }
+
     protected function appendToGitignore(string $gitPath, array $paths = ['vendor'])
     {
         $gitignore = $this->filesystem->buildPath($gitPath, '.gitignore');

--- a/test/E2E/SpecialGitStructuresTest.php
+++ b/test/E2E/SpecialGitStructuresTest.php
@@ -30,6 +30,36 @@ class SpecialGitStructuresTest extends AbstractE2ETestCase
     }
 
     #[Test]
+    function it_runs_inside_a_worktree()
+    {
+        $main = $this->mkdir('main');
+
+        $this->initializeGit($main);
+        $this->appendToGitignore($main);
+        $this->initializeComposer($main);
+        $grumphpFile = $this->initializeGrumphpConfig($main);
+        $this->installComposer($main);
+        $this->ensureHooksExist($main);
+
+        // A file that lives on the main branch but not on the worktree's branch:
+        $this->dumpFile($this->filesystem->buildPath($main, 'only-on-main.txt'), 'main');
+        $this->enableValidatePathsTask($grumphpFile, $main);
+        $this->commitAll($main);
+
+        // A linked worktree on a diverging branch that drops the main-only file:
+        $worktree = $this->addGitWorktree($main, 'worktree', 'feature');
+        $this->filesystem->remove($this->filesystem->buildPath($worktree, 'only-on-main.txt'));
+        $this->commitAllWithoutHook($worktree);
+
+        $this->installComposer($worktree);
+        $worktreeGrumphpFile = $this->initializeGrumphpConfig($worktree);
+        $this->enableValidatePathsTask($worktreeGrumphpFile, $worktree);
+
+        // GrumPHP must list the worktree's branch, so only-on-main.txt stays out of the file list:
+        $this->runGrumphp($worktree);
+    }
+
+    #[Test]
     function it_handles_partial_commits()
     {
         $this->initializeGitInRootDir();

--- a/test/Unit/Locator/EnrichedGuessedPathsFromDotEnvLocatorTest.php
+++ b/test/Unit/Locator/EnrichedGuessedPathsFromDotEnvLocatorTest.php
@@ -83,6 +83,26 @@ class EnrichedGuessedPathsFromDotEnvLocatorTest extends FilesystemTestCase
         ];
 
 
+        yield 'keep-distinct-worktree-dir' => [
+            function (Filesystem $filesystem, string $workspace) use ($configure) {
+                \Closure::bind($configure, $this)($workspace);
+            },
+            $inputWithWorktree = function (string $workspace) {
+                return new GuessedPaths(
+                    $workspace,
+                    $this->path('.git'),
+                    $workspace,
+                    $workspace,
+                    $this->path('vendor/bin'),
+                    new ComposerFile($this->path('composer.json'), []),
+                    $this->path('grumphp.yml'),
+                    $this->path('.git/worktrees/wt1')
+                );
+            },
+            $inputWithWorktree
+        ];
+
+
         yield 'overwritten-config' => [
             function (Filesystem $filesystem, string $workspace) use ($configure) {
                 \Closure::bind($configure, $this)($workspace);

--- a/test/Unit/Locator/GitRepositoryDirLocatorTest.php
+++ b/test/Unit/Locator/GitRepositoryDirLocatorTest.php
@@ -69,4 +69,54 @@ class GitRepositoryDirLocatorTest extends FilesystemTestCase
         $this->filesystem->dumpFile($ourWorktreeProject.'/.git', 'gitdir: '.$this->gitDir.'/worktrees/worktree1');
         $this->assertEquals($this->gitDir, $this->locator->locate($this->gitDir));
     }
+
+    #[Test]
+    public function it_collapses_a_worktree_to_the_common_root_for_hooks(): void
+    {
+        [$worktreeGitFile, ] = $this->setupWorktree();
+
+        $this->assertEquals($this->gitDir, $this->locator->locate($worktreeGitFile));
+    }
+
+    #[Test]
+    public function it_locates_the_worktree_own_git_dir_for_file_listing(): void
+    {
+        [$worktreeGitFile, $worktreeGitDir] = $this->setupWorktree();
+
+        $this->assertEquals($worktreeGitDir, $this->locator->locateWorktreeGitDir($worktreeGitFile));
+    }
+
+    #[Test]
+    public function it_locates_worktree_git_dir_identically_to_locate_for_normal_checkout(): void
+    {
+        $this->filesystem->mkdir($this->gitDir);
+        $this->assertEquals($this->gitDir, $this->locator->locateWorktreeGitDir($this->gitDir));
+    }
+
+    #[Test]
+    public function it_locates_worktree_git_dir_identically_to_locate_for_submodule(): void
+    {
+        $this->filesystem->dumpFile($this->gitDir, 'gitdir: ../dev/null');
+        $this->assertEquals(
+            $this->workspace . DIRECTORY_SEPARATOR . '../dev/null',
+            $this->locator->locateWorktreeGitDir($this->gitDir)
+        );
+    }
+
+    /**
+     * @return array{0: string, 1: string}  [worktree .git file, worktree own git dir]
+     */
+    private function setupWorktree(): array
+    {
+        $worktreeGitDir = $this->gitDir.DIRECTORY_SEPARATOR.'worktrees'.DIRECTORY_SEPARATOR.'worktree1';
+        $this->filesystem->mkdir($worktreeGitDir);
+        $this->filesystem->dumpFile($worktreeGitDir.DIRECTORY_SEPARATOR.'commondir', '../..');
+
+        $worktreeProject = $this->workspace.DIRECTORY_SEPARATOR.'worktree-project';
+        $this->filesystem->mkdir($worktreeProject);
+        $worktreeGitFile = $worktreeProject.DIRECTORY_SEPARATOR.'.git';
+        $this->filesystem->dumpFile($worktreeGitFile, 'gitdir: '.$worktreeGitDir);
+
+        return [$worktreeGitFile, $worktreeGitDir];
+    }
 }

--- a/test/Unit/Locator/GuessedPathsLocatorTest.php
+++ b/test/Unit/Locator/GuessedPathsLocatorTest.php
@@ -60,6 +60,9 @@ namespace GrumPHPTest\Unit\Locator {
             $this->gitRepositoryDirLocator->locate(Argument::any())->will(function (array $arguments) {
                 return $arguments[0];
             });
+            $this->gitRepositoryDirLocator->locateWorktreeGitDir(Argument::any())->will(function (array $arguments) {
+                return $arguments[0];
+            });
 
             $this->guesser = new GuessedPathsLocator(
                 $this->filesystem,

--- a/test/Unit/Util/PathsTest.php
+++ b/test/Unit/Util/PathsTest.php
@@ -120,6 +120,35 @@ class PathsTest extends FilesystemTestCase
     }
 
     #[Test]
+    public function it_knows_the_git_worktree_directory(): void
+    {
+        $this->assertSame(
+            $this->guessedPaths->getGitWorktreeDir(),
+            $this->paths->getGitWorktreeDir()
+        );
+    }
+
+    #[Test]
+    public function it_separates_the_worktree_dir_from_the_hooks_dir_inside_a_worktree(): void
+    {
+        $guessedPaths = new GuessedPaths(
+            $this->workspace,
+            $common = $this->buildPath($this->workspace, '.git'),
+            $this->workspace,
+            $this->workspace,
+            $this->buildPath($this->workspace, 'vendor/bin'),
+            new ComposerFile($this->buildPath($this->workspace, 'composer.json'), []),
+            $this->buildPath($this->workspace, 'grumphp.json'),
+            $worktree = $this->buildPath($this->workspace, '.git/worktrees/wt1')
+        );
+        $paths = new Paths($this->filesystem, $guessedPaths);
+
+        $this->assertSame($worktree, $paths->getGitWorktreeDir());
+        $this->assertSame($common, $paths->getGitRepositoryDir());
+        $this->assertSame($this->buildPath($common, 'hooks'), $paths->getGitHooksDir());
+    }
+
+    #[Test]
     public function it_knows_the_project_directory(): void
     {
         $this->assertSame(


### PR DESCRIPTION
## What is wrong

Inside a linked git worktree, GrumPHP lists and diffs files against the main repository's branch instead of the worktree's own. A task then fails on a file that exists on main but not in the worktree:

```
yamllint: SplFileInfo::openFile(config/services/commands.yaml):
          Failed to open stream: No such file or directory
```

The git CLI in the same directory is right. `git ls-files` there returns the worktree's branch and never mentions `commands.yaml`. Only GrumPHP sees main's files.

## Why it happens

A worktree's `.git` is a file that points at `<main>/.git/worktrees/<id>`, and that directory's `commondir` points back to the shared `<main>/.git`. GrumPHP collapsed a worktree straight to that shared directory and used it for everything, including the git client that lists files. So the client ran `git --git-dir=<main>/.git ls-files` and read main's index.

Because gitonomy passes `--git-dir` on the command line, it overrides `GIT_DIR`. A container that exports the correct `GIT_DIR` and `GIT_WORK_TREE` fixes the bare git CLI but cannot reach GrumPHP, so the fix has to live here.

Collapsing to the shared directory is not wrong on its own. It is correct for hooks, because a worktree runs the main repository's hooks. The mistake was reusing that same directory to list files.

## The fix

Separate the two concerns.

```mermaid
flowchart TD
    W["worktree .git file"] --> R{resolve}
    R -->|hooks| C["shared main/.git"]
    R -->|files and diffs| O["main/.git/worktrees/id"]
    C --> H["install and run hooks"]
    O --> L["ls-files and diff read the worktree branch"]
```

Hooks still resolve to the shared `.git`, so hook install, deinit, and execution are unchanged. The git client that lists files and reads diffs now points at the worktree's own git dir, so `ls-files` and staged diffs follow the worktree's branch. A normal checkout and a submodule resolve exactly as before, so this is a no-op outside worktrees.

`GRUMPHP_GIT_REPOSITORY_DIR` still overrides the resolved directory. It now drives both the hooks dir and the file-listing dir, which is how it behaved before the split, so anyone already setting it keeps the same result.
