### PR TITLE
feat(phpmd): PHPMD report format allowed values matches renderers

### DIFF
--- a/doc/tasks/phpmd.md
+++ b/doc/tasks/phpmd.md
@@ -47,7 +47,7 @@ This is a list of patterns that will be ignored by phpmd. With this option you c
 *Default: text*
 
 This sets the output [renderer](https://phpmd.org/documentation/#renderers) of phpmd.
-Available formats: ansi, text.
+Available formats: text, ansi, xml, html, json, gitlab, github.
 
 **ruleset**
 

--- a/src/Task/PhpMd.php
+++ b/src/Task/PhpMd.php
@@ -32,7 +32,7 @@ class PhpMd extends AbstractExternalTask
         $resolver->addAllowedTypes('whitelist_patterns', ['array']);
         $resolver->addAllowedTypes('exclude', ['array']);
         $resolver->addAllowedTypes('report_format', ['string']);
-        $resolver->addAllowedValues('report_format', ['text', 'ansi']);
+        $resolver->addAllowedValues('report_format', ['text', 'ansi', 'xml', 'html', 'json', 'gitlab', 'github']);
         $resolver->addAllowedTypes('ruleset', ['array']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | v2.x
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | yes
| Fixed tickets | -

PHPMD task report format allowed values now matches PHPMD renderers https://phpmd.org/documentation/index.html#renderers
